### PR TITLE
Resolve cinder iscsi incompatibilities

### DIFF
--- a/Containerfiles/NovaEFI-Containerfile
+++ b/Containerfiles/NovaEFI-Containerfile
@@ -1,3 +1,9 @@
 ARG VERSION=master-ubuntu_jammy
 FROM openstackhelm/nova:$VERSION
-RUN apt update && apt install -y ovmf; rm -rf /var/cache/apt/archives /var/lib/apt/lists; apt clean
+# Packages for the following features:
+# - Nova: EFI
+# - Nova: iSCSI
+RUN apt update && apt install -y ovmf open-iscsi multipath-tools; rm -rf /var/cache/apt/archives /var/lib/apt/lists; apt clean
+# Packages for the following features:
+# - Nova: osdetect
+RUN /var/lib/openstack/bin/pip install pgi

--- a/helm-configs/cinder/cinder-helm-overrides.yaml
+++ b/helm-configs/cinder/cinder-helm-overrides.yaml
@@ -25,7 +25,6 @@ release_group: null
 
 images:
   tags:
-
     db_init: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
     cinder_db_sync: "docker.io/openstackhelm/cinder:2023.1-ubuntu_jammy"
     db_drop: "docker.io/openstackhelm/heat:2023.1-ubuntu_jammy"
@@ -75,7 +74,8 @@ jobs:
           readOnlyRootFilesystem: true
         cinder_api:
           readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
+          allowPrivilegeEscalation: true
+          privileged: true
     cinder_backup:
       pod:
         runAsUser: 42424
@@ -790,6 +790,7 @@ conf:
       # Internal tenant id
       internal_project_name: internal_cinder
       internal_user_name: internal_cinder
+      rootwrap_config: /etc/cinder/rootwrap.conf
     database:
       max_retries: -1
     keystone_authtoken:
@@ -897,12 +898,15 @@ conf:
     lvmdriver-1:
       volume_group: cinder-volumes-1
       volume_driver: cinder.volume.drivers.lvm.LVMVolumeDriver
-      volume_backend_name: LVM
+      volume_backend_name: LVM_iSCSI
       volume_clear: zero
       lvm_type: default
-      target_protocol: iscsi
       image_volume_cache_enabled: True
+      iscsi_iotype: fileio
+      iscsi_num_targets: 100
+      target_protocol: iscsi
       target_helper: tgtadm
+      target_port: 3260
   rally_tests:
     run_tempest: false
     clean_up: |

--- a/helm-configs/nova/nova-helm-overrides.yaml
+++ b/helm-configs/nova/nova-helm-overrides.yaml
@@ -1434,6 +1434,7 @@ conf:
       disk_cachemodes: "network=writeback"
       hw_disk_discard: unmap
       cpu_mode: host-passthrough
+      iscsi_use_multipath: false  # Disabled because multipathd is not configured or running
     upgrade_levels:
       compute: auto
     cache:
@@ -2112,7 +2113,7 @@ pod:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
         nova_compute:
-          readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: false
           privileged: true
         nova_compute_ssh:
           privileged: true

--- a/playbooks/deploy-cinder-volumes-reference.yaml
+++ b/playbooks/deploy-cinder-volumes-reference.yaml
@@ -6,21 +6,25 @@
   vars:
     cinder_release: "2023.1"
     cinder_storage_network_interface: br-storage
+    cinder_backend_name: "lvmdriver-1"
   handlers:
     - name: Restart cinder-volume systemd services
       ansible.builtin.systemd:
         name: "{{ item }}"
         state: restarted
         daemon_reload: true
+        enabled: true
       loop:
         - cinder-volume
         - cinder-volume-usage-audit
+        - iscsid.service
+        - tgt.service
   tasks:
     - name: K8S Facts block
       delegate_to: "{{ groups['kube_control_plane'][0] }}"
       block:
         - name: Ensure python3-kubernetes is available
-          ansible.builtin.apt:
+          ansible.builtin.package:
             name: python3-kubernetes
             state: present
             update_cache: true
@@ -33,11 +37,16 @@
           register: _kubernetes_cinder_etc_secret
 
     - name: Install required packages
-      ansible.builtin.apt:
+      ansible.builtin.package:
         name:
           - build-essential
+          - git
+          - open-iscsi
           - python3-venv
           - python3-dev
+          - qemu-block-extra
+          - qemu-utils
+          - tgt
         state: present
         update_cache: true
 
@@ -99,7 +108,7 @@
         - src: "{{ playbook_dir }}/templates/cinder-volume.service"
           dest: /etc/systemd/system/cinder-volume.service
         - src: "{{ playbook_dir }}/templates/sudoers"
-          dest: /etc/sudoers.d//cinder-volume
+          dest: /etc/sudoers.d/cinder-volume
           mode: "0440"
       notify:
         - Restart cinder-volume systemd services
@@ -140,5 +149,30 @@
         option: "my_ip"
         value: "{{ hostvars[inventory_hostname]['ansible_facts'][cinder_storage_network_interface]['ipv4']['address'] | default(ansible_default_ipv4.address) }}"
         create: true
+      notify:
+        - Restart cinder-volume systemd services
+
+    - name: Replace the target_ip_address in the backends.conf with the current Ansible FQDN
+      community.general.ini_file:
+        path: /etc/cinder/backends.conf
+        section: "{{ cinder_backend_name }}"
+        option: "target_ip_address"
+        value: "{{ hostvars[inventory_hostname]['ansible_facts'][cinder_storage_network_interface]['ipv4']['address'] | default(ansible_default_ipv4.address) }}"
+        create: true
+      notify:
+        - Restart cinder-volume systemd services
+
+    - name: Replace exec path in rootwrap
+      community.general.ini_file:
+        path: /etc/cinder/rootwrap.conf
+        section: DEFAULT
+        option: "{{ item.key }}"
+        value: "{{ item.value }}"
+        create: true
+      loop:
+        - key: "exec_dirs"
+          value: "/opt/cinder/bin,/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin,/usr/lpp/mmfs/bin"
+        - key: "filters_path"
+          value: "/etc/cinder/rootwrap.d"
       notify:
         - Restart cinder-volume systemd services

--- a/playbooks/templates/sudoers
+++ b/playbooks/templates/sudoers
@@ -1,3 +1,4 @@
 Defaults:cinder !requiretty
 Defaults:cinder secure_path="/opt/cinder/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 cinder ALL = (root) NOPASSWD: /opt/cinder/bin/cinder-rootwrap
+cinder ALL = (root) NOPASSWD: /opt/cinder/bin/privsep-helper


### PR DESCRIPTION
This change adds some missing config for cinder compatibility and a couple extra tasks needed in the deployment example playbook which wire the cinder rootwrap conf to cinder itself.

The nova container has been further extended to support the cinder workload as well as resolve missing functionality in the nova python enviroment.