### PR TITLE
add pygobject

### DIFF
--- a/Containerfiles/NovaEFI-Containerfile
+++ b/Containerfiles/NovaEFI-Containerfile
@@ -3,7 +3,10 @@ FROM openstackhelm/nova:$VERSION
 # Packages for the following features:
 # - Nova: EFI
 # - Nova: iSCSI
-RUN apt update && apt install -y ovmf open-iscsi multipath-tools libgirepository-1.0-1; rm -rf /var/cache/apt/archives /var/lib/apt/lists; apt clean
+RUN apt update && apt install -y ovmf open-iscsi multipath-tools libgirepository-1.0-1 libgirepository1.0-dev \
+                                 libcairo2-dev python3-dev gcc libosinfo-bin gir1.2-libosinfo-1.0; \
+    rm -rf /var/cache/apt/archives /var/lib/apt/lists; \
+    apt clean
 # Packages for the following features:
 # - Nova: Libosinfo
-RUN /var/lib/openstack/bin/pip install pgi
+RUN /var/lib/openstack/bin/pip install pygobject


### PR DESCRIPTION
This will resolve the libosdetect issues in nova. While gi isn't a critical issue, having it will ensure we're running a functionally complete environment.