### PR TITLE
Remove `dns_domain_ports`

### DIFF
--- a/helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/helm-configs/neutron/neutron-helm-overrides.yaml
@@ -1765,7 +1765,7 @@ conf:
       # service_plugin can be: router, odl-router, empty for calico,
       # networking_ovn.l3.l3_ovn.OVNL3RouterPlugin for OVN
       # NOTE(cloudnull): This is a bug, doc needs to be updated for ovn-router, instead of OVNL3RouterPlugin
-      service_plugins: ovn-router,qos,metering,trunk,segments,dns_domain_ports
+      service_plugins: ovn-router,qos,metering,trunk,segments
       allow_automatic_l3agent_failover: True
       l3_ha: False
       max_l3_agents_per_router: 1


### PR DESCRIPTION
This change updates our neutron config to remove `dns_domain_ports`. While this is a valid plugin the capability won't be functional until we're ready to deploy designate.

Docs: https://docs.openstack.org/designate/latest/user/neutron-integration.html