### PR TITLE
Create the horizon rxt image

### DIFF
--- a/.github/workflows/release-horizon-rxt.yml
+++ b/.github/workflows/release-horizon-rxt.yml
@@ -1,0 +1,60 @@
+#
+name: Create and publish a the Horizon RXT compatible image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: 'Set release used for the build'
+        required: true
+        default: 'master'
+        type: choice
+        options:
+        - "master"
+        - "2023.1"
+        - "2023.2"
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          file: Containerfiles/KeystoneRXT-Containerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/keystone-rxt:${{ github.event.inputs.release }}-ubuntu_jammy
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            RELEASE=${{ github.event.inputs.release }}

--- a/Containerfiles/HorizonRXT-Containerfile
+++ b/Containerfiles/HorizonRXT-Containerfile
@@ -1,0 +1,6 @@
+ARG RELEASE=master
+ARG VERSION=${RELEASE}-ubuntu_jammy
+FROM openstackhelm/horizon:$VERSION
+RUN /var/lib/openstack/bin/pip install --constraint=https://releases.openstack.org/constraints/upper/${RELEASE} \
+                               heat-dashboard \
+                               octavia-dashboard

--- a/helm-configs/horizon/horizon-helm-overrides.yaml
+++ b/helm-configs/horizon/horizon-helm-overrides.yaml
@@ -6953,7 +6953,7 @@ conf:
     # for example heat_dashboard, cloudkittydashboard or neutron_taas_dashboard
     extra_panels:
       - heat_dashboard
-      - neutron_taas_dashboard
+      - octavia_dashboard
 
 dependencies:
   dynamic:


### PR DESCRIPTION
This change adds horizon panels to the system. By default the stock horizon image does not contain panels an operator may want to leverage. To ensure we're able to offer a better horizon experience we're creating a new image which has some additional panels.

A change has been made to include the new panels in horizon's configuration.