### PR TITLE
Update kustomize.sh

### DIFF
--- a/kustomize/kustomize.sh
+++ b/kustomize/kustomize.sh
@@ -3,4 +3,4 @@ set -e
 pushd $(dirname "${BASH_SOURCE[0]}") &>/dev/null
     cat <&0 > ${1}/../base/all.yaml
     kubectl kustomize --reorder='none' ${1}
-popd &>/dev/nulls
+popd &>/dev/null


### PR DESCRIPTION
Fix typo in the kustomize script. While this works in 1.26 later versions of kustomize and kubernetes sees this an an error.