### PR TITLE
Upgrade to the latest stable k8s

### DIFF
--- a/ansible/inventory/openstack-enterprise/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/ansible/inventory/openstack-enterprise/group_vars/k8s_cluster/k8s-cluster.yml
@@ -17,7 +17,7 @@ kube_token_dir: "{{ kube_config_dir }}/tokens"
 kube_api_anonymous_auth: true
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
-kube_version: v1.26.10
+kube_version: v1.28.6
 
 # Where the binaries will be downloaded.
 # Note: ensure that you've enough disk space (about 1G)

--- a/ansible/inventory/openstack-flex/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/ansible/inventory/openstack-flex/group_vars/k8s_cluster/k8s-cluster.yml
@@ -17,7 +17,7 @@ kube_token_dir: "{{ kube_config_dir }}/tokens"
 kube_api_anonymous_auth: true
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
-kube_version: v1.26.10
+kube_version: v1.28.6
 
 # Where the binaries will be downloaded.
 # Note: ensure that you've enough disk space (about 1G)


### PR DESCRIPTION
This change updates flex and ent to use the latest stable k8s release from kubespray. The change has been lab and hardware tested and shown to work well.

``` shell
ubuntu@openstack-flex-launcher:/opt/genestack/submodules/openstack-helm$ kubectl version
Client Version: v1.29.1
Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
Server Version: v1.28.6
```

Openstack endpoint confirmation

``` shell
ubuntu@openstack-flex-launcher:/opt/genestack/submodules/openstack-helm$ kubectl --namespace openstack exec -ti openstack-admin-client -- openstack endpoint list
+----------------------------------+-----------+--------------+----------------+---------+-----------+---------------------------------------------------------------------+
| ID                               | Region    | Service Name | Service Type   | Enabled | Interface | URL                                                                 |
+----------------------------------+-----------+--------------+----------------+---------+-----------+---------------------------------------------------------------------+
| 0fd83a3960ab457b9fbacb5db14d844d | RegionOne | heat         | orchestration  | True    | admin     | http://heat-api.openstack.svc.cluster.local:8004/v1/%(project_id)s  |
| 150fa686fb9644ed9847c27a6d529316 | RegionOne | nova         | compute        | True    | public    | http://nova.openstack.svc.cluster.local/v2.1/%(tenant_id)s          |
| 1fb2db2a46f14620b38735e3613391f1 | RegionOne | placement    | placement      | True    | admin     | http://placement-api.openstack.svc.cluster.local:8778/              |
| 299ab70e75324723ab15171c5a310f86 | RegionOne | cinderv3     | volumev3       | True    | public    | http://cinder.openstack.svc.cluster.local/v3/%(tenant_id)s          |
| 2bcb84d125bd481a82c2092832f72804 | RegionOne | heat         | orchestration  | True    | public    | http://heat.openstack.svc.cluster.local/v1/%(project_id)s           |
| 2c2da2109c4e4ca8b096eb7ca61702e9 | RegionOne | heat-cfn     | cloudformation | True    | internal  | http://heat-cfn.openstack.svc.cluster.local:8000/v1                 |
| 373b36de9c904bc9b71175da4865a008 | RegionOne | keystone     | identity       | True    | admin     | http://keystone.openstack.svc.cluster.local:5000/v3                 |
| 422247581a384f9aa0338573cce23564 | RegionOne | neutron      | network        | True    | admin     | http://neutron-server.openstack.svc.cluster.local:9696/             |
| 490f89eab2ec4b8e990f4186be933e96 | RegionOne | heat-cfn     | cloudformation | True    | admin     | http://heat-cfn.openstack.svc.cluster.local:8000/v1                 |
| 5e7ba2536f6d4beebe949d7b22234755 | RegionOne | cinderv3     | volumev3       | True    | admin     | http://cinder-api.openstack.svc.cluster.local:8776/v3/%(tenant_id)s |
| 60c2121cf99647a7b5042b695aad5f15 | RegionOne | placement    | placement      | True    | public    | http://placement.openstack.svc.cluster.local/                       |
| 61f00e537b69434793806ca3cbd7235b | RegionOne | heat         | orchestration  | True    | internal  | http://heat-api.openstack.svc.cluster.local:8004/v1/%(project_id)s  |
| 7f2e46f38d8a4a81b8aee8c895082bb1 | RegionOne | glance       | image          | True    | internal  | http://glance-api.openstack.svc.cluster.local:9292/                 |
| 82eac6cf6500475f9cfe6d3b3eca133a | RegionOne | neutron      | network        | True    | public    | http://neutron.openstack.svc.cluster.local/                         |
| 9248f1d88c71409a8ff0416bca9848fd | RegionOne | glance       | image          | True    | public    | http://glance.openstack.svc.cluster.local/                          |
| a95b2f21c05642a1bb0364358f4f31b9 | RegionOne | neutron      | network        | True    | internal  | http://neutron-server.openstack.svc.cluster.local:9696/             |
| a9c1d5d4cfe54378bc3bacd70fa5bb5f | RegionOne | keystone     | identity       | True    | internal  | http://keystone-api.openstack.svc.cluster.local:5000/v3             |
| afc5a5cc165f47168fc938f33b857443 | RegionOne | placement    | placement      | True    | internal  | http://placement-api.openstack.svc.cluster.local:8778/              |
| b521ff59bc714266b43a34e9eaa41932 | RegionOne | keystone     | identity       | True    | public    | http://keystone.openstack.svc.cluster.local/v3                      |
| c673fa7461044948bb08260804fcd684 | RegionOne | nova         | compute        | True    | admin     | http://nova-api.openstack.svc.cluster.local:8774/v2.1/%(tenant_id)s |
| cf48e13905d2434b95ebdbbe4907a885 | RegionOne | cinderv3     | volumev3       | True    | internal  | http://cinder-api.openstack.svc.cluster.local:8776/v3/%(tenant_id)s |
| e730713641604aa2a5984b4bce6280f8 | RegionOne | heat-cfn     | cloudformation | True    | public    | http://cloudformation.openstack.svc.cluster.local/v1                |
| fb2966186dc54be3a22236da6bb3325d | RegionOne | nova         | compute        | True    | internal  | http://nova-api.openstack.svc.cluster.local:8774/v2.1/%(tenant_id)s |
| ff27ecfcdbcb42899ea37276e4bc6f9f | RegionOne | glance       | image          | True    | admin     | http://glance-api.openstack.svc.cluster.local:9292/                 |
+----------------------------------+-----------+--------------+----------------+---------+-----------+---------------------------------------------------------------------+
```

This change will ensure we have a fairly long runway on our platform without being forced into an upgrade.