### PR TITLE
Moving the components list into a separate document for easier reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,67 +5,36 @@
 Genestack — where Kubernetes and OpenStack tango in the cloud. Imagine a waltz between systems that deploy
 what you need.
 
-
 ## Included/Required Components
 
-The following components are part of the initial product release
-and largely deployed with Helm+Kustomize against the K8s API (v1.28 and up):
+* Kubernetes:
+    * etd: noSQL Store
+    * Kube-OVN: OVN based CNI plugin
+    * Dashboard: Always there to take the lead
+    * MetalLB: L2/L3 (BGP) Load Balancer
+    * CoreDNS: DNS Server
+    * Ingress-NGINX: Network Proxy
+    * Cert-Manager: X509-TLS Certificate Manager
 
-| Group      | Component            | OpenStack Flex | OpenStack Enterprise |
-|------------|----------------------|----------------|----------------------|
-| Kubernetes | Kubernetes           | Required       | Required             |
-| Kubernetes | Kubernetes Dashboard | Required       | Required             |
-| Kubernetes | Cert-Manager         | Required       | Required             |
-| Kubernetes | MetaLB (L2/L3)       | Required       | Required             |
-| Kubernetes | Core DNS             | Required       | Required             |
-| Kubernetes | Ingress Controller (Nginx) | Required       | Required             |
-| Kubernetes | Kube-Proxy (IPVS)    | Required       | Required             |
-| Kubernetes | Calico               | Optional       | Required             |
-| Kubernetes | Kube-OVN             | Required       | Optional             |
-| Kubernetes | Helm                 | Required       | Required             |
-| Kubernetes | Kustomize            | Required       | Required             |
-| OpenStack  | openVswitch (Helm)   | Optional       | Required             |
-| OpenStack  | Galera (Operator)    | Required       | Required             |
-| OpenStack  | rabbitMQ (Operator)  | Required       | Required             |
-| OpenStack  | memcacheD (Operator) | Required       | Required             |
-| OpenStack  | Ceph Rook            | Optional       | Required             |
-| OpenStack  | iscsi/tgtd           | Required       | Optional             |
-| OpenStack  | Keystone (Helm)      | Required       | Required             |
-| OpenStack  | Glance (Helm)        | Required       | Required             |
-| OpenStack  | Cinder (Helm)        | Required       | Required             |
-| OpenStack  | Nova (Helm)          | Required       | Required             |
-| OpenStack  | Neutron (Helm)       | Required       | Required             |
-| OpenStack  | Placement (Helm)     | Required       | Required             |
-| OpenStack  | Horizon (Helm)       | Required       | Required             |
-| OpenStack  | Skyline (Helm)       | Optional       | Optional             |
-| OpenStack  | Heat (Helm)          | Required       | Required             |
-| OpenStack  | Designate (Helm)     | Optional       | Required             |
-| OpenStack  | Barbican (Helm)      | Required       | Required             |
-| OpenStack  | Octavia (Helm)       | Required       | Required             |
-| OpenStack  | Ironic (Helm)        | Optional       | Required             |
-| OpenStack  | metal3.io            | Optional       | Required             |
+* Operators:
+    * MariaDB: SQL Database
+    * RabbitMQ: Message Bus
+    * Rook (Optional): Ceph software defined Storage
+    * Memcached: in-memory cache
 
-Initial monitoring componets consists of the following projects
+* OpenStack:
+    * Cinder: Block Storage Service
+    * Glance: Machine Images Service
+    * Heat: Orchestration Service
+    * Horizon: Dashboard
+    * Keystone: Identity Service
+    * Neutron: Software defined Networking
+    * Nova: Compute Service
+    * Placement: Compute Scheduling
+    * Octavia: Load Balancing Service
+    * openVswitch: Kernel based network switching, alternatively to OVN (OpenStack only)
 
-| Group      | Component            | OpenStack Flex | OpenStack Enterprise |
-|------------|----------------------|----------------|----------------------|
-| Kubernetes | Prometheus           | Required       | Required             |
-| Kubernetes | Thanos               | Required       | Required             |
-| Kubernetes | Alertmanager         | Required       | Required             |
-| Kubernetes | Grafana              | Required       | Required             |
-| Kubernetes | Node Exporter        | Required       | Required             |
-| Kubernetes | redfish Exporter     | Required       | Required             |
-| OpenStack  | OpenStack Exporter   | Required       | Required             |
-
-At a later stage these components will be added
-
-| Group     | Component            | OpenStack Flex | OpenStack Enterprise |
-|-----------|----------------------|----------------|----------------------|
-| OpenStack | MongoDB              | Optional       | Required             |
-| OpenStack | Aodh (Helm)          | Optional       | Required             |
-| OpenStack | Ceilometer (Helm)    | Optional       | Required             |
-| OpenStack | Masakari (Helm)      | Optional       | Required             |
-
+A more complete list is available at [Project Components](docs/components.md)
 
 ### Symphony of Simplicity
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,63 @@
+
+## Included/Required Components
+
+The following components are part of the initial product release
+and largely deployed with Helm+Kustomize against the K8s API (v1.28 and up).
+Some components are intially only installed with the public cloud based,
+OpenStack Flex, service, while OpenStack Enterprise naturally provides a larger
+variety of services:
+
+| Group      | Component            | OpenStack Flex | OpenStack Enterprise |
+|------------|----------------------|----------------|----------------------|
+| Kubernetes | Kubernetes           | Required       | Required             |
+| Kubernetes | Kubernetes Dashboard | Required       | Required             |
+| Kubernetes | Cert-Manager         | Required       | Required             |
+| Kubernetes | MetaLB (L2/L3)       | Required       | Required             |
+| Kubernetes | Core DNS             | Required       | Required             |
+| Kubernetes | Ingress Controller (Nginx) | Required       | Required             |
+| Kubernetes | Kube-Proxy (IPVS)    | Required       | Required             |
+| Kubernetes | Calico               | Optional       | Required             |
+| Kubernetes | Kube-OVN             | Required       | Optional             |
+| Kubernetes | Helm                 | Required       | Required             |
+| Kubernetes | Kustomize            | Required       | Required             |
+| OpenStack  | openVswitch (Helm)   | Optional       | Required             |
+| OpenStack  | Galera (Operator)    | Required       | Required             |
+| OpenStack  | rabbitMQ (Operator)  | Required       | Required             |
+| OpenStack  | memcacheD (Operator) | Required       | Required             |
+| OpenStack  | Ceph Rook            | Optional       | Required             |
+| OpenStack  | iscsi/tgtd           | Required       | Optional             |
+| OpenStack  | Keystone (Helm)      | Required       | Required             |
+| OpenStack  | Glance (Helm)        | Required       | Required             |
+| OpenStack  | Cinder (Helm)        | Required       | Required             |
+| OpenStack  | Nova (Helm)          | Required       | Required             |
+| OpenStack  | Neutron (Helm)       | Required       | Required             |
+| OpenStack  | Placement (Helm)     | Required       | Required             |
+| OpenStack  | Horizon (Helm)       | Required       | Required             |
+| OpenStack  | Skyline (Helm)       | Optional       | Optional             |
+| OpenStack  | Heat (Helm)          | Required       | Required             |
+| OpenStack  | Designate (Helm)     | Optional       | Required             |
+| OpenStack  | Barbican (Helm)      | Required       | Required             |
+| OpenStack  | Octavia (Helm)       | Required       | Required             |
+| OpenStack  | Ironic (Helm)        | Optional       | Required             |
+| OpenStack  | metal3.io            | Optional       | Required             |
+
+Initial monitoring componets consists of the following projects
+
+| Group      | Component            | OpenStack Flex | OpenStack Enterprise |
+|------------|----------------------|----------------|----------------------|
+| Kubernetes | Prometheus           | Required       | Required             |
+| Kubernetes | Thanos               | Required       | Required             |
+| Kubernetes | Alertmanager         | Required       | Required             |
+| Kubernetes | Grafana              | Required       | Required             |
+| Kubernetes | Node Exporter        | Required       | Required             |
+| Kubernetes | redfish Exporter     | Required       | Required             |
+| OpenStack  | OpenStack Exporter   | Required       | Required             |
+
+At a later stage these components will be added
+
+| Group     | Component            | OpenStack Flex | OpenStack Enterprise |
+|-----------|----------------------|----------------|----------------------|
+| OpenStack | MongoDB              | Optional       | Required             |
+| OpenStack | Aodh (Helm)          | Optional       | Required             |
+| OpenStack | Ceilometer (Helm)    | Optional       | Required             |
+| OpenStack | Masakari (Helm)      | Optional       | Required             |


### PR DESCRIPTION
The MVP component list is moved to docs/components.md for easier reading