### PR TITLE
Add additional config to ensure ovn+octavia is working

### DIFF
--- a/helm-configs/octavia/octavia-helm-overrides.yaml
+++ b/helm-configs/octavia/octavia-helm-overrides.yaml
@@ -213,10 +213,13 @@ conf:
       ca_certificate: /etc/octavia/certs/ca_01.pem
     cinder:
       endpoint_type: internalURL
+      valid_interfaces: internal
     glance:
       endpoint_type: internalURL
+      valid_interfaces: internal
     neutron:
       endpoint_type: internalURL
+      valid_interfaces: internal
     haproxy_amphora:
       server_ca: /etc/octavia/certs/ca_01.pem
       client_cert: /etc/octavia/certs/client.pem
@@ -249,6 +252,7 @@ conf:
       cafile: ""
       auth_version: v3
       memcache_security_strategy: ENCRYPT
+      insecure: true
     ovn:
       ovn_sb_connection: tcp:127.0.0.1:6642
       ovn_nb_connection: tcp:127.0.0.1:6641


### PR DESCRIPTION
This change adds some additional config to handle octavia's use of the public URL when creating loadbalancer. While most of the calls are done over the internalURL it seems octavia defaults to the publicURL in some cases. This update ensures that we have a functional octavia environment in all cases.