### PR TITLE
Use default ssh config when connecting to bastion

### DIFF
--- a/ansible/playbooks/infra-deploy.yaml
+++ b/ansible/playbooks/infra-deploy.yaml
@@ -191,7 +191,7 @@
         network_name: "{{ os_network_name }}-internal"
         name: "{{ os_network_name }}-subnet-internal"
         cidr: 192.168.0.0/22
-    # The disable_gateway_ip setting only works 
+    # The disable_gateway_ip setting only works
     # on an update and not a create
     - name: Update subnet internal
       openstack.cloud.subnet:
@@ -367,12 +367,13 @@
                 ServerAliveCountMax 30
             dest: "{{ lookup('env', 'HOME') }}/.ssh/{{ os_keypair_name }}.config"
             mode: "0640"
-        - name: Wait 300 seconds for port 22 to become open and contain "OpenSSH"
-          ansible.builtin.wait_for:
-            port: 22
-            host: "{{ bastion_ip }}"
-            search_regex: OpenSSH
-            delay: 10
+        - name: Check SSH connection to bastion
+          ansible.builtin.ping:
+          delegate_to: "{{ bastion_ip }}"
+          register: ping_result
+          until: ping_result is succeeded
+          retries: 60
+          delay: 5
     - name: Get server info from the cluster
       openstack.cloud.server_info:
         cloud: "{{ os_cloud_name }}"
@@ -502,7 +503,7 @@
     os_bastion_user: ubuntu
     os_network_name: openstack-flex
     os_keypair_name: "{{ os_network_name }}-keypair"
-    ansible_ssh_common_args: "-F {{ lookup('env', 'HOME') }}/.ssh/{{ os_keypair_name }}.config"
+    # ansible_ssh_common_args: "-F {{ lookup('env', 'HOME') }}/.ssh/{{ os_keypair_name }}.config"
     ansible_ssh_private_key_file: "{{ lookup('env', 'HOME') }}/.ssh/{{ os_keypair_name }}.key"
   tasks:
     - name: Create ssh directory on jump host


### PR DESCRIPTION
During the infra-deploy playbook, ansible connects to the bastion or launcher node. It's best that this be done with the user's default ssh configuration in lieu of the generated one, otherwise connections to the bastion could fail.

Use ansible.builtin.ping to check liveness which is more thorough of a test. It will use the default ssh config, whereas wait_for ill only attempt a tcp connection, which may fail if a user has a default proxy configured as required in their environment.