### PR TITLE
Add ArgoCD installation chart

### DIFF
--- a/.github/workflows/kustomize-argocd.yaml
+++ b/.github/workflows/kustomize-argocd.yaml
@@ -1,0 +1,37 @@
+name: Kustomize GitHub Actions for argocd
+
+on:
+  pull_request:
+    paths:
+      - kustomize/argocd/**
+      - .github/workflows/kustomize-argocd.yaml
+jobs:
+  kustomize:
+    strategy:
+      matrix:
+        overlays:
+          - base
+    name: Kustomize
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: azure/setup-helm@v3
+        with:
+          version: latest
+          token: "${{ secrets.GITHUB_TOKEN }}"
+        id: helm
+      - name: Kustomize Install
+        working-directory: /usr/local/bin/
+        run: |
+          if [ ! -f /usr/local/bin/kustomize ]; then
+            curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | sudo bash
+          fi
+      - name: Run Kustomize Build
+        run: |
+          kustomize build kustomize/argocd/${{ matrix.overlays }} --enable-helm --helm-command ${{ steps.helm.outputs.helm-path }} > /tmp/rendered.yaml
+      - name: Return Kustomize Build
+        uses: actions/upload-artifact@v2
+        with:
+          name: kustomize-argocd-artifact-${{ matrix.overlays }}
+          path: /tmp/rendered.yaml

--- a/kustomize/argocd/base/kustomization.yaml
+++ b/kustomize/argocd/base/kustomization.yaml
@@ -1,0 +1,22 @@
+resources:
+  - namespace.yaml
+
+namespace: argocd1
+helmGlobals:
+  chartHome: ../charts/
+helmCharts:
+- name: argo-cd
+  includeCRDs: true
+  valuesFile: values.yaml
+  releaseName: argocd
+  version: 5.51.5
+  repo: https://argoproj.github.io/argo-helm
+patches:
+- target:
+    kind: Pod
+  patch: |-
+    $patch: delete
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: argocd-redis-ha-service-test

--- a/kustomize/argocd/base/namespace.yaml
+++ b/kustomize/argocd/base/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubernetes.io/metadata.name: argocd
+    name: argocd
+  name: argocd

--- a/kustomize/argocd/base/values.yaml
+++ b/kustomize/argocd/base/values.yaml
@@ -1,0 +1,39 @@
+global:
+  nodeSelector:
+    openstack-control-plane: enabled
+
+redis-ha:
+  enabled: true
+  nodeSelector:
+    openstack-control-plane: enabled
+
+controller:
+  replicas: 1
+
+configs:
+  cm:
+    kustomize.buildOptions: --enable-helm
+
+server:
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+  ingress:
+    annotations:
+      nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    enabled: true
+    ingressClassName: "nginx-cluster"
+    hosts: ["argocd.dfw-ospcv2-staging.ohthree.com"]
+    tls:
+      - hosts:
+          - argocd.dfw-ospcv2-staging.ohthree.com
+        secretName: argocd-tls-public
+    https: true
+
+repoServer:
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+
+applicationSet:
+  replicas: 2

--- a/kustomize/ingress/internal/helm/ingress-helm-overrides.yaml
+++ b/kustomize/ingress/internal/helm/ingress-helm-overrides.yaml
@@ -1,5 +1,5 @@
 deployment:
-  mode: namespace
+  mode: cluster
   type: Deployment
   cluster:
     class: "nginx-openstack"


### PR DESCRIPTION
Uses kustomize to deploy argoCD helm chart. 

It expects `argocd-tls-public` Kubernetes secret containing FQDN ssl cert/key. The method of deploying the secret in argocd namespace will vary depending on tool we select(sealed-secret/vault).