### PR TITLE
Put clusterName in kustomize.yaml for the mariadb-operator.

### DIFF
--- a/kustomize/mariadb-operator/kustomization.yaml
+++ b/kustomize/mariadb-operator/kustomization.yaml
@@ -6,6 +6,7 @@ helmCharts:
     repo: https://mariadb-operator.github.io/mariadb-operator
     releaseName: mariadb-operator
     valuesInline:
+      clusterName: cluster.local
       webhook:
         cert:
           certManager:


### PR DESCRIPTION
The documentation currently has you ensure your servers have an FQDN, which might lead some people to to give their cluster a name besides the default cluster.local. If you don't put your actual cluster name here, you can't get the MariaDB stuff deployed, so I put in 'cluster.local' to suggest that it should get edited.