### PR TITLE
Upstream disabled DVR with OVN. This commit re-enables it.

### DIFF
--- a/helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/helm-configs/neutron/neutron-helm-overrides.yaml
@@ -1793,6 +1793,7 @@ conf:
     oslo_policy:
       policy_file: /etc/neutron/policy.yaml
     ovn:
+      enable_distributed_floating_ip: true
       ovn_l3_scheduler: leastloaded
       dns_servers: 8.8.8.8,1.1.1.1
       neutron_sync_mode: 'off'  # This needs to be set to OFF for OVN in a hybrid deployment.


### PR DESCRIPTION
Upstream disabled DVR as they found it unstable. I think @busterswt said we want to re-enable this.

Marking as draft, making PR for comments/review. Feel free to close this PR if we don't want to re-enable this.

Upstream disabling:

https://github.com/openstack/openstack-helm/commit/6ae4b98eec6bd5ccd564b24a4b2f0f1f54822df5