### PR TITLE
fix: simplify mariadb secret usage in helm charts

### DIFF
--- a/docs/Deploy-Openstack.md
+++ b/docs/Deploy-Openstack.md
@@ -59,7 +59,6 @@ helm upgrade --install keystone ./keystone \
     --timeout 120m \
     -f /opt/genestack/helm-configs/keystone/keystone-helm-overrides.yaml \
     --set endpoints.identity.auth.admin.password="$(kubectl --namespace openstack get secret keystone-admin -o jsonpath='{.data.password}' | base64 -d)" \
-    --set endpoints.oslo_db.auth.admin.password="$(kubectl --namespace openstack get secret mariadb -o jsonpath='{.data.root-password}' | base64 -d)" \
     --set endpoints.oslo_db.auth.keystone.password="$(kubectl --namespace openstack get secret keystone-db-password -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.oslo_messaging.auth.admin.password="$(kubectl --namespace openstack get secret rabbitmq-default-user -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.oslo_messaging.auth.keystone.password="$(kubectl --namespace openstack get secret keystone-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)" \
@@ -124,7 +123,6 @@ helm upgrade --install glance ./glance \
     -f /opt/genestack/helm-configs/glance/glance-helm-overrides.yaml \
     --set endpoints.identity.auth.admin.password="$(kubectl --namespace openstack get secret keystone-admin -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.identity.auth.glance.password="$(kubectl --namespace openstack get secret glance-admin -o jsonpath='{.data.password}' | base64 -d)" \
-    --set endpoints.oslo_db.auth.admin.password="$(kubectl --namespace openstack get secret mariadb -o jsonpath='{.data.root-password}' | base64 -d)" \
     --set endpoints.oslo_db.auth.glance.password="$(kubectl --namespace openstack get secret glance-db-password -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.oslo_messaging.auth.admin.password="$(kubectl --namespace openstack get secret rabbitmq-default-user -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.oslo_messaging.auth.glance.password="$(kubectl --namespace openstack get secret glance-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)" \
@@ -187,7 +185,6 @@ helm upgrade --install heat ./heat \
     --set endpoints.identity.auth.heat.password="$(kubectl --namespace openstack get secret heat-admin -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.identity.auth.heat_trustee.password="$(kubectl --namespace openstack get secret heat-trustee -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.identity.auth.heat_stack_user.password="$(kubectl --namespace openstack get secret heat-stack-user -o jsonpath='{.data.password}' | base64 -d)" \
-    --set endpoints.oslo_db.auth.admin.password="$(kubectl --namespace openstack get secret mariadb -o jsonpath='{.data.root-password}' | base64 -d)" \
     --set endpoints.oslo_db.auth.heat.password="$(kubectl --namespace openstack get secret heat-db-password -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.oslo_messaging.auth.admin.password="$(kubectl --namespace openstack get secret rabbitmq-default-user -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.oslo_messaging.auth.heat.password="$(kubectl --namespace openstack get secret heat-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)" \
@@ -238,7 +235,6 @@ helm upgrade --install cinder ./cinder \
     -f /opt/genestack/helm-configs/cinder/cinder-helm-overrides.yaml \
     --set endpoints.identity.auth.admin.password="$(kubectl --namespace openstack get secret keystone-admin -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.identity.auth.cinder.password="$(kubectl --namespace openstack get secret cinder-admin -o jsonpath='{.data.password}' | base64 -d)" \
-    --set endpoints.oslo_db.auth.admin.password="$(kubectl --namespace openstack get secret mariadb -o jsonpath='{.data.root-password}' | base64 -d)" \
     --set endpoints.oslo_db.auth.cinder.password="$(kubectl --namespace openstack get secret cinder-db-password -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.oslo_messaging.auth.admin.password="$(kubectl --namespace openstack get secret rabbitmq-default-user -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.oslo_messaging.auth.cinder.password="$(kubectl --namespace openstack get secret cinder-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)" \
@@ -484,7 +480,6 @@ helm upgrade --install placement ./placement --namespace=openstack \
     -f /opt/genestack/helm-configs/placement/placement-helm-overrides.yaml \
     --set endpoints.identity.auth.admin.password="$(kubectl --namespace openstack get secret keystone-admin -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.identity.auth.placement.password="$(kubectl --namespace openstack get secret placement-admin -o jsonpath='{.data.password}' | base64 -d)" \
-    --set endpoints.oslo_db.auth.admin.password="$(kubectl --namespace openstack get secret mariadb -o jsonpath='{.data.root-password}' | base64 -d)" \
     --set endpoints.oslo_db.auth.placement.password="$(kubectl --namespace openstack get secret placement-db-password -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.oslo_db.auth.nova_api.password="$(kubectl --namespace openstack get secret nova-db-password -o jsonpath='{.data.password}' | base64 -d)" \
     --post-renderer /opt/genestack/kustomize/kustomize.sh \
@@ -506,11 +501,8 @@ helm upgrade --install nova ./nova \
     --set endpoints.identity.auth.ironic.password="$(kubectl --namespace openstack get secret ironic-admin -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.identity.auth.placement.password="$(kubectl --namespace openstack get secret placement-admin -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.identity.auth.cinder.password="$(kubectl --namespace openstack get secret cinder-admin -o jsonpath='{.data.password}' | base64 -d)" \
-    --set endpoints.oslo_db.auth.admin.password="$(kubectl --namespace openstack get secret mariadb -o jsonpath='{.data.root-password}' | base64 -d)" \
     --set endpoints.oslo_db.auth.nova.password="$(kubectl --namespace openstack get secret nova-db-password -o jsonpath='{.data.password}' | base64 -d)" \
-    --set endpoints.oslo_db_api.auth.admin.password="$(kubectl --namespace openstack get secret mariadb -o jsonpath='{.data.root-password}' | base64 -d)" \
     --set endpoints.oslo_db_api.auth.nova.password="$(kubectl --namespace openstack get secret nova-db-password -o jsonpath='{.data.password}' | base64 -d)" \
-    --set endpoints.oslo_db_cell0.auth.admin.password="$(kubectl --namespace openstack get secret mariadb -o jsonpath='{.data.root-password}' | base64 -d)" \
     --set endpoints.oslo_db_cell0.auth.nova.password="$(kubectl --namespace openstack get secret nova-db-password -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.oslo_messaging.auth.admin.password="$(kubectl --namespace openstack get secret rabbitmq-default-user -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.oslo_messaging.auth.nova.password="$(kubectl --namespace openstack get secret nova-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)" \
@@ -548,7 +540,6 @@ helm upgrade --install neutron ./neutron \
     --set endpoints.identity.auth.placement.password="$(kubectl --namespace openstack get secret placement-admin -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.identity.auth.designate.password="$(kubectl --namespace openstack get secret designate-admin -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.identity.auth.ironic.password="$(kubectl --namespace openstack get secret ironic-admin -o jsonpath='{.data.password}' | base64 -d)" \
-    --set endpoints.oslo_db.auth.admin.password="$(kubectl --namespace openstack get secret mariadb -o jsonpath='{.data.root-password}' | base64 -d)" \
     --set endpoints.oslo_db.auth.neutron.password="$(kubectl --namespace openstack get secret neutron-db-password -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.oslo_messaging.auth.admin.password="$(kubectl --namespace openstack get secret rabbitmq-default-user -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.oslo_messaging.auth.neutron.password="$(kubectl --namespace openstack get secret neutron-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)" \
@@ -603,7 +594,6 @@ helm upgrade --install octavia ./octavia \
     -f /opt/genestack/helm-configs/octavia/octavia-helm-overrides.yaml \
     --set endpoints.identity.auth.admin.password="$(kubectl --namespace openstack get secret keystone-admin -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.identity.auth.octavia.password="$(kubectl --namespace openstack get secret octavia-admin -o jsonpath='{.data.password}' | base64 -d)" \
-    --set endpoints.oslo_db.auth.admin.password="$(kubectl --namespace openstack get secret mariadb -o jsonpath='{.data.root-password}' | base64 -d)" \
     --set endpoints.oslo_db.auth.octavia.password="$(kubectl --namespace openstack get secret octavia-db-password -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.oslo_messaging.auth.admin.password="$(kubectl --namespace openstack get secret rabbitmq-default-user -o jsonpath='{.data.password}' | base64 -d)" \
     --set endpoints.oslo_messaging.auth.octavia.password="$(kubectl --namespace openstack get secret octavia-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)" \
@@ -653,7 +643,6 @@ helm upgrade --install horizon ./horizon \
     -f /opt/genestack/helm-configs/horizon/horizon-helm-overrides.yaml \
     --set endpoints.identity.auth.admin.password="$(kubectl --namespace openstack get secret keystone-admin -o jsonpath='{.data.password}' | base64 -d)" \
     --set conf.horizon.local_settings.config.horizon_secret_key="$(kubectl --namespace openstack get secret horizon-secrete-key -o jsonpath='{.data.root-password}' | base64 -d)" \
-    --set endpoints.oslo_db.auth.admin.password="$(kubectl --namespace openstack get secret mariadb -o jsonpath='{.data.root-password}' | base64 -d)" \
     --set endpoints.oslo_db.auth.horizon.password="$(kubectl --namespace openstack get secret horizon-db-password -o jsonpath='{.data.password}' | base64 -d)" \
     --post-renderer /opt/genestack/kustomize/kustomize.sh \
     --post-renderer-args horizon/base

--- a/docs/deploy-required-infrastructure.md
+++ b/docs/deploy-required-infrastructure.md
@@ -22,8 +22,7 @@ kubectl apply -k /opt/genestack/kustomize/openstack
 kubectl --namespace openstack \
         create secret generic mariadb \
         --type Opaque \
-        --from-literal=root-password="$(< /dev/urandom tr -dc _A-Za-z0-9 | head -c${1:-32};echo;)" \
-        --from-literal=password="$(< /dev/urandom tr -dc _A-Za-z0-9 | head -c${1:-32};echo;)"
+        --from-literal=root-password="$(< /dev/urandom tr -dc _A-Za-z0-9 | head -c${1:-32};echo;)"
 ```
 
 ### Deploy the mariadb operator

--- a/helm-configs/glance/glance-helm-overrides.yaml
+++ b/helm-configs/glance/glance-helm-overrides.yaml
@@ -977,7 +977,7 @@ manifests:
   pod_rally_test: false
   pvc_images: true
   network_policy: false
-  secret_db: true
+  secret_db: false
   secret_ingress_tls: true
   secret_keystone: true
   secret_rabbitmq: true

--- a/helm-configs/heat/heat-helm-overrides.yaml
+++ b/helm-configs/heat/heat-helm-overrides.yaml
@@ -1234,7 +1234,7 @@ manifests:
   pdb_cloudwatch: false
   pod_rally_test: false
   network_policy: false
-  secret_db: true
+  secret_db: false
   secret_ingress_tls: true
   secret_keystone: true
   secret_rabbitmq: true

--- a/helm-configs/horizon/horizon-helm-overrides.yaml
+++ b/helm-configs/horizon/horizon-helm-overrides.yaml
@@ -7300,7 +7300,7 @@ manifests:
   pdb: true
   pod_helm_test: false
   network_policy: false
-  secret_db: true
+  secret_db: false
   secret_ingress_tls: true
   secret_keystone: true
   secret_registry: true

--- a/helm-configs/keystone/keystone-helm-overrides.yaml
+++ b/helm-configs/keystone/keystone-helm-overrides.yaml
@@ -1095,7 +1095,7 @@ manifests:
   pod_rally_test: false
   network_policy: false
   secret_credential_keys: true
-  secret_db: true
+  secret_db: false
   secret_fernet_keys: true
   secret_ingress_tls: true
   secret_keystone: true

--- a/helm-configs/nova/nova-helm-overrides.yaml
+++ b/helm-configs/nova/nova-helm-overrides.yaml
@@ -2556,7 +2556,7 @@ manifests:
   network_policy: false
   secret_db_api: true
   secret_db_cell0: true
-  secret_db: true
+  secret_db: false
   secret_ingress_tls: true
   secret_keystone: true
   secret_rabbitmq: true

--- a/helm-configs/octavia/octavia-helm-overrides.yaml
+++ b/helm-configs/octavia/octavia-helm-overrides.yaml
@@ -736,7 +736,7 @@ manifests:
   pod_rally_test: false
   network_policy: false
   secret_credential_keys: true
-  secret_db: true
+  secret_db: false
   secret_ingress_tls: true
   secret_keystone: true
   secret_rabbitmq: true

--- a/helm-configs/placement/placement-helm-overrides.yaml
+++ b/helm-configs/placement/placement-helm-overrides.yaml
@@ -458,7 +458,7 @@ manifests:
   job_ks_service: true
   job_ks_user: true
   network_policy: false
-  secret_db: true
+  secret_db: false
   secret_ingress_tls: true
   secret_registry: true
   pdb: true

--- a/kustomize/mariadb-cluster/base/mariadb-galera.yaml
+++ b/kustomize/mariadb-cluster/base/mariadb-galera.yaml
@@ -8,12 +8,6 @@ spec:
     name: mariadb
     key: root-password
 
-  database: mariadb
-  username: mariadb
-  passwordSecretKeyRef:
-    name: mariadb
-    key: password
-
   image: mariadb:11.0.3
 
   port: 3306


### PR DESCRIPTION
Removed the unnecessary creation of the 'mariadb' database and associated user. Removed the need for passing around the MariaDB root user's password by simplifying the invocation of helm and removing the creation of the unused secret that needed it.

A little bit further write up at https://rackerlabs.github.io/understack/openstack-helm/ and https://rackerlabs.github.io/understack/secrets/