### PR TITLE
Introduce Gnocchi helm chart to Genestack

### DIFF
--- a/docs/deploy-required-infrastructure.md
+++ b/docs/deploy-required-infrastructure.md
@@ -332,6 +332,95 @@ helm upgrade --install postgresql ./postgresql \
 > In a production like environment you may need to include production specific files like the example variable file found in
   `helm-configs/prod-example-openstack-overrides.yaml`.
 
+## Deploy Gnocchi
+
+### Create Secrets
+
+```shell
+kubectl --namespace openstack create secret generic gnocchi-admin \
+        --type Opaque \
+        --from-literal=password="$(< /dev/urandom tr -dc _A-Za-z0-9 | head -c${1:-32};echo;)"
+kubectl --namespace openstack create secret generic gnocchi-db-password \
+        --type Opaque \
+        --from-literal=password="$(< /dev/urandom tr -dc _A-Za-z0-9 | head -c${1:-32};echo;)"
+kubectl --namespace openstack create secret generic gnocchi-pgsql-password \
+        --type Opaque \
+        --from-literal=password="$(< /dev/urandom tr -dc _A-Za-z0-9 | head -c${1:-32};echo;)"
+```
+
+### Create ceph-etc configmap
+
+While the below example should work fine for most environments, depending
+on the use case it may be necessary to provide additional client configuration
+options for ceph. The below simply creates the expected `ceph-etc`
+ConfigMap with the ceph.conf needed by Gnocchi to establish a connection
+to the mon host(s) via the rados client.
+
+```shell
+kubectl apply -n openstack -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ceph-etc
+  namespace: openstack
+data:
+  ceph.conf: |
+    [global]
+    mon_host = $(for pod in $(kubectl get pods -n rook-ceph | grep rook-ceph-mon | awk '{print $1}'); do \
+    	echo -n "$(kubectl get pod $pod -n rook-ceph -o go-template --template='{{.status.podIP}}'):6789,"; done \
+    	| sed 's/,$//')
+EOF
+```
+
+### Verify the ceph-etc configmap is sane
+
+Below is an example of what you're looking for to verify the configmap was
+created as expected - a CSV of the mon hosts, colon seperated with default
+mon port, 6789.
+
+```shell
+(genestack) root@openstack-flex-launcher:/opt/genestack# kubectl get configmap -n openstack ceph-etc -o "jsonpath={.data['ceph\.conf']}"
+[global]
+mon_host = 172.31.3.7:6789,172.31.1.112:6789,172.31.0.46:6789
+```
+
+### Run the package deployment
+
+```shell
+cd /opt/genestack/submodules/openstack-helm-infra
+helm upgrade --install gnocchi ./gnocchi \
+    --namespace=openstack \
+    --wait \
+    --timeout 10m \
+    -f /opt/genestack/helm-configs/gnocchi/gnocchi-helm-overrides.yaml \
+    --set conf.ceph.admin_keyring="$(kubectl get secret --namespace rook-ceph rook-ceph-admin-keyring -o jsonpath='{.data.keyring}' | base64 -d)" \
+    --set endpoints.identity.auth.admin.password="$(kubectl --namespace openstack get secret keystone-admin -o jsonpath='{.data.password}' | base64 -d)" \
+    --set endpoints.identity.auth.gnocchi.password="$(kubectl --namespace openstack get secret gnocchi-admin -o jsonpath='{.data.password}' | base64 -d)" \
+    --set endpoints.oslo_db.auth.admin.password="$(kubectl --namespace openstack get secret mariadb -o jsonpath='{.data.root-password}' | base64 -d)" \
+    --set endpoints.oslo_db.auth.gnocchi.password="$(kubectl --namespace openstack get secret gnocchi-db-password -o jsonpath='{.data.password}' | base64 -d)" \
+    --set endpoints.oslo_db_postgresql.auth.admin.password="$(kubectl --namespace openstack get secret postgresql-db-admin -o jsonpath='{.data.password}' | base64 -d)" \
+    --set endpoints.oslo_db_postgresql.auth.gnocchi.password="$(kubectl --namespace openstack get secret gnocchi-pgsql-password -o jsonpath='{.data.password}' | base64 -d)" \
+    --post-renderer /opt/genestack/kustomize/kustomize.sh \
+    --post-renderer-args gnocchi/base
+```
+
+> In a production like environment you may need to include production specific files like the example variable file found in
+  `helm-configs/prod-example-openstack-overrides.yaml`.
+
+### Validate the metric endpoint
+
+#### Pip install gnocchiclient and python-ceilometerclient
+
+```shell
+kubectl exec -it openstack-admin-client -n openstack -- /var/lib/openstack/bin/pip install python-ceilometerclient gnocchiclient
+```
+
+#### Verify metric list functionality
+
+```shell
+kubectl exec -it openstack-admin-client -n openstack -- openstack metric list
+```
+
 ## Validation our infrastructure is operational
 
 Before going any further make sure you validate that the backends are operational.

--- a/docs/deploy-required-infrastructure.md
+++ b/docs/deploy-required-infrastructure.md
@@ -315,6 +315,10 @@ kubectl --namespace openstack create secret generic postgresql-db-audit \
 
 ### Run the package deployment
 
+> Consider the PVC size you will need for the environment you're deploying in.
+  Make adjustments as needed near `storage.[pvc|archive_pvc].size` and
+  `volume.backup.size` to your helm overrides.
+
 ```shell
 cd /opt/genestack/submodules/openstack-helm-infra
 helm upgrade --install postgresql ./postgresql \

--- a/docs/deploy-required-infrastructure.md
+++ b/docs/deploy-required-infrastructure.md
@@ -294,6 +294,44 @@ kubectl apply -k /opt/genestack/kustomize/ovn
 After running the setup, nodes will have the label `ovn.openstack.org/configured` with a date stamp when it was configured.
 If there's ever a need to reconfigure a node, simply remove the label and the DaemonSet will take care of it automatically.
 
+## Deploy PostgreSQL
+
+### Create Secrets
+
+```shell
+kubectl --namespace openstack create secret generic postgresql-identity-admin \
+        --type Opaque \
+        --from-literal=password="$(< /dev/urandom tr -dc _A-Za-z0-9 | head -c${1:-32};echo;)"
+kubectl --namespace openstack create secret generic postgresql-db-admin \
+        --type Opaque \
+        --from-literal=password="$(< /dev/urandom tr -dc _A-Za-z0-9 | head -c${1:-32};echo;)"
+kubectl --namespace openstack create secret generic postgresql-db-exporter \
+        --type Opaque \
+        --from-literal=password="$(< /dev/urandom tr -dc _A-Za-z0-9 | head -c${1:-32};echo;)"
+kubectl --namespace openstack create secret generic postgresql-db-audit \
+        --type Opaque \
+        --from-literal=password="$(< /dev/urandom tr -dc _A-Za-z0-9 | head -c${1:-32};echo;)"
+```
+
+### Run the package deployment
+
+```shell
+cd /opt/genestack/submodules/openstack-helm-infra
+helm upgrade --install postgresql ./postgresql \
+    --namespace=openstack \
+    --wait \
+    --timeout 10m \
+    -f /opt/genestack/helm-configs/postgresql/postgresql-helm-overrides.yaml \
+    --set endpoints.identity.auth.admin.password="$(kubectl --namespace openstack get secret keystone-admin -o jsonpath='{.data.password}' | base64 -d)" \
+    --set endpoints.identity.auth.postgresql.password="$(kubectl --namespace openstack get secret postgresql-identity-admin -o jsonpath='{.data.password}' | base64 -d)" \
+    --set endpoints.postgresql.auth.admin.password="$(kubectl --namespace openstack get secret postgresql-db-admin -o jsonpath='{.data.password}' | base64 -d)" \
+    --set endpoints.postgresql.auth.exporter.password="$(kubectl --namespace openstack get secret postgresql-db-exporter -o jsonpath='{.data.password}' | base64 -d)" \
+    --set endpoints.postgresql.auth.audit.password="$(kubectl --namespace openstack get secret postgresql-db-audit -o jsonpath='{.data.password}' | base64 -d)"
+```
+
+> In a production like environment you may need to include production specific files like the example variable file found in
+  `helm-configs/prod-example-openstack-overrides.yaml`.
+
 ## Validation our infrastructure is operational
 
 Before going any further make sure you validate that the backends are operational.

--- a/helm-configs/gnocchi/gnocchi-helm-overrides.yaml
+++ b/helm-configs/gnocchi/gnocchi-helm-overrides.yaml
@@ -376,29 +376,41 @@ conf:
     override:
     append:
   paste:
-    pipeline:main:
-      pipeline: gnocchi+auth
-    composite:gnocchi+noauth:
-      use: egg:Paste#urlmap
-      /: gnocchiversions
-      /v1: gnocchiv1+noauth
-    composite:gnocchi+auth:
-      use: egg:Paste#urlmap
-      /: gnocchiversions
-      /v1: gnocchiv1+auth
-    pipeline:gnocchiv1+noauth:
-      pipeline: gnocchiv1
-    pipeline:gnocchiv1+auth:
-      pipeline: keystone_authtoken gnocchiv1
-    app:gnocchiversions:
-      paste.app_factory: gnocchi.rest.app:app_factory
-      root: gnocchi.rest.VersionsController
     app:gnocchiv1:
       paste.app_factory: gnocchi.rest.app:app_factory
-      root: gnocchi.rest.V1Controller
-    filter:keystone_authtoken:
-      paste.filter_factory: keystonemiddleware.auth_token:filter_factory
+      root: gnocchi.rest.api.V1Controller
+    app:gnocchiversions:
+      paste.app_factory: gnocchi.rest.app:app_factory
+      root: gnocchi.rest.api.VersionsController
+    app:healthcheck:
       oslo_config_project: gnocchi
+      use: egg:oslo.middleware#healthcheck
+    composite:gnocchi+basic:
+      /: gnocchiversions_pipeline
+      /healthcheck: healthcheck
+      /v1: gnocchiv1+noauth
+      use: egg:Paste#urlmap
+    composite:gnocchi+keystone:
+      /: gnocchiversions_pipeline
+      /healthcheck: healthcheck
+      /v1: gnocchiv1+keystone
+      use: egg:Paste#urlmap
+    composite:gnocchi+remoteuser:
+      /: gnocchiversions_pipeline
+      /healthcheck: healthcheck
+      /v1: gnocchiv1+noauth
+      use: egg:Paste#urlmap
+    filter:keystone_authtoken:
+      oslo_config_project: gnocchi
+      use: egg:keystonemiddleware#auth_token
+    pipeline:gnocchiv1+keystone:
+      pipeline: keystone_authtoken gnocchiv1
+    pipeline:gnocchiv1+noauth:
+      pipeline: gnocchiv1
+    pipeline:gnocchiversions_pipeline:
+      pipeline: gnocchiversions
+    pipeline:main:
+      pipeline: gnocchi+keystone
   policy:
     admin_or_creator: 'role:admin or project_id:%(created_by_project_id)s'
     resource_owner: 'project_id:%(project_id)s'

--- a/helm-configs/gnocchi/gnocchi-helm-overrides.yaml
+++ b/helm-configs/gnocchi/gnocchi-helm-overrides.yaml
@@ -358,7 +358,7 @@ conf:
     <VirtualHost *:{{ tuple "metric" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}>
         WSGIDaemonProcess gnocchi processes=1 threads=2 user=gnocchi group=gnocchi display-name=%{GROUP}
         WSGIProcessGroup gnocchi
-        WSGIScriptAlias / "/var/lib/kolla/venv/lib/python2.7/site-packages/gnocchi/rest/app.wsgi"
+        WSGIScriptAlias / "/var/lib/kolla/venv/lib/python3.8/site-packages/gnocchi/rest/wsgi.py"
         WSGIApplicationGroup %{GLOBAL}
 
         ErrorLog /dev/stderr
@@ -366,7 +366,7 @@ conf:
         CustomLog /dev/stdout combined env=!forwarded
         CustomLog /dev/stdout proxy env=forwarded
 
-        <Directory "/var/lib/kolla/venv/lib/python2.7/site-packages/gnocchi/rest">
+        <Directory "/var/lib/kolla/venv/lib/python3.8/site-packages/gnocchi/rest">
               Require all granted
         </Directory>
     </VirtualHost>

--- a/helm-configs/gnocchi/gnocchi-helm-overrides.yaml
+++ b/helm-configs/gnocchi/gnocchi-helm-overrides.yaml
@@ -38,18 +38,18 @@ images:
   tags:
     dep_check: quay.io/airshipit/kubernetes-entrypoint:v1.0.0
     gnocchi_storage_init: docker.io/openstackhelm/ceph-config-helper:ubuntu_focal_18.2.0-1-20231013
-    db_init_indexer: docker.io/library/postgres:9.5
+    db_init_indexer: docker.io/library/postgres:14.5
     # using non-kolla images until kolla supports postgres as
     # an indexer
-    db_init: quay.io/attcomdev/ubuntu-source-gnocchi-api:3.0.3
-    db_sync: quay.io/attcomdev/ubuntu-source-gnocchi-api:3.0.3
-    ks_user: docker.io/openstackhelm/heat:newton-ubuntu_xenial
-    ks_service: docker.io/openstackhelm/heat:newton-ubuntu_xenial
-    ks_endpoints: docker.io/openstackhelm/heat:newton-ubuntu_xenial
-    gnocchi_api: quay.io/attcomdev/ubuntu-source-gnocchi-api:3.0.3
-    gnocchi_statsd: quay.io/attcomdev/ubuntu-source-gnocchi-statsd:3.0.3
-    gnocchi_metricd: quay.io/attcomdev/ubuntu-source-gnocchi-metricd:3.0.3
-    gnocchi_resources_cleaner: quay.io/attcomdev/ubuntu-source-gnocchi-base:3.0.3
+    db_init: quay.io/openstack.kolla/ubuntu-source-gnocchi-api:yoga
+    db_sync: quay.io/openstack.kolla/ubuntu-source-gnocchi-api:yoga
+    ks_user: docker.io/openstackhelm/heat:wallaby-ubuntu_focal
+    ks_service: docker.io/openstackhelm/heat:wallaby-ubuntu_focal
+    ks_endpoints: docker.io/openstackhelm/heat:wallaby-ubuntu_focal
+    gnocchi_api: quay.io/openstack.kolla/ubuntu-source-gnocchi-api:yoga
+    gnocchi_statsd: quay.io/openstack.kolla/ubuntu-source-gnocchi-statsd:yoga
+    gnocchi_metricd: quay.io/openstack.kolla/ubuntu-source-gnocchi-metricd:yoga
+    gnocchi_resources_cleaner: quay.io/openstack.kolla/ubuntu-source-gnocchi-base:yoga
     image_repo_sync: docker.io/library/docker:17.07.0
   pull_policy: "IfNotPresent"
   local_registry:

--- a/helm-configs/gnocchi/gnocchi-helm-overrides.yaml
+++ b/helm-configs/gnocchi/gnocchi-helm-overrides.yaml
@@ -1,0 +1,665 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default values for gnocchi.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+---
+labels:
+  api:
+    node_selector_key: openstack-control-plane
+    node_selector_value: enabled
+  job:
+    node_selector_key: openstack-control-plane
+    node_selector_value: enabled
+  metricd:
+    node_selector_key: openstack-control-plane
+    node_selector_value: enabled
+  statsd:
+    node_selector_key: openstack-control-plane
+    node_selector_value: enabled
+  test:
+    node_selector_key: openstack-control-plane
+    node_selector_value: enabled
+
+release_group: null
+
+images:
+  tags:
+    dep_check: quay.io/airshipit/kubernetes-entrypoint:v1.0.0
+    gnocchi_storage_init: docker.io/openstackhelm/ceph-config-helper:ubuntu_focal_18.2.0-1-20231013
+    db_init_indexer: docker.io/library/postgres:9.5
+    # using non-kolla images until kolla supports postgres as
+    # an indexer
+    db_init: quay.io/attcomdev/ubuntu-source-gnocchi-api:3.0.3
+    db_sync: quay.io/attcomdev/ubuntu-source-gnocchi-api:3.0.3
+    ks_user: docker.io/openstackhelm/heat:newton-ubuntu_xenial
+    ks_service: docker.io/openstackhelm/heat:newton-ubuntu_xenial
+    ks_endpoints: docker.io/openstackhelm/heat:newton-ubuntu_xenial
+    gnocchi_api: quay.io/attcomdev/ubuntu-source-gnocchi-api:3.0.3
+    gnocchi_statsd: quay.io/attcomdev/ubuntu-source-gnocchi-statsd:3.0.3
+    gnocchi_metricd: quay.io/attcomdev/ubuntu-source-gnocchi-metricd:3.0.3
+    gnocchi_resources_cleaner: quay.io/attcomdev/ubuntu-source-gnocchi-base:3.0.3
+    image_repo_sync: docker.io/library/docker:17.07.0
+  pull_policy: "IfNotPresent"
+  local_registry:
+    active: false
+    exclude:
+      - dep_check
+      - image_repo_sync
+
+jobs:
+  resources_cleaner:
+    # daily
+    cron: "0 */24 * * *"
+    deleted_resources_ttl: '1day'
+    history:
+      success: 3
+      failed: 1
+
+network:
+  api:
+    ingress:
+      public: true
+      classes:
+        namespace: "nginx"
+        cluster: "nginx-openstack"
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /
+    external_policy_local: false
+    node_port:
+      enabled: false
+      port: 8041
+  statsd:
+    node_port:
+      enabled: false
+      port: 8125
+
+dependencies:
+  dynamic:
+    common:
+      local_image_registry:
+        jobs:
+          - gnocchi-image-repo-sync
+        services:
+          - endpoint: node
+            service: local_image_registry
+  static:
+    api:
+      jobs:
+        - gnocchi-storage-init
+        - gnocchi-db-sync
+        - gnocchi-ks-endpoints
+        - gnocchi-ks-service
+        - gnocchi-ks-user
+      services:
+        - endpoint: internal
+          service: identity
+        - endpoint: internal
+          service: oslo_db
+    clean:
+      services: null
+    db_init:
+      services:
+        - endpoint: internal
+          service: oslo_db
+    db_init_postgresql:
+      jobs: null
+      services:
+        - endpoint: internal
+          service: oslo_db_postgresql
+    db_sync:
+      jobs:
+        - gnocchi-storage-init
+        - gnocchi-db-init
+        - gnocchi-db-init-indexer
+      services:
+        - endpoint: internal
+          service: oslo_db_postgresql
+    ks_endpoints:
+      jobs:
+        - gnocchi-ks-service
+      services:
+        - endpoint: internal
+          service: identity
+    ks_service:
+      services:
+        - endpoint: internal
+          service: identity
+    ks_user:
+      services:
+        - endpoint: internal
+          service: identity
+    metricd:
+      jobs:
+        - gnocchi-storage-init
+        - gnocchi-db-sync
+        - gnocchi-ks-user
+        - gnocchi-ks-service
+        - gnocchi-ks-endpoints
+      services:
+        - endpoint: internal
+          service: oslo_db_postgresql
+        - endpoint: internal
+          service: metric
+    statsd:
+      jobs:
+        - gnocchi-storage-init
+        - gnocchi-db-sync
+        - gnocchi-ks-user
+        - gnocchi-ks-service
+        - gnocchi-ks-endpoints
+      services:
+        - endpoint: internal
+          service: oslo_db_postgresql
+        - endpoint: internal
+          service: metric
+    resources_cleaner:
+      jobs:
+        - gnocchi-storage-init
+        - gnocchi-db-sync
+        - gnocchi-ks-user
+        - gnocchi-ks-endpoints
+      services:
+        - endpoint: internal
+          service: oslo_db
+        - endpoint: internal
+          service: identity
+        - endpoint: internal
+          service: metric
+    storage_init:
+      services: null
+    tests:
+      jobs:
+        - gnocchi-storage-init
+        - gnocchi-db-sync
+      services:
+        - endpoint: internal
+          service: identity
+        - endpoint: internal
+          service: oslo_db_postgresql
+        - endpoint: internal
+          service: metric
+    image_repo_sync:
+      services:
+        - endpoint: internal
+          service: local_image_registry
+
+pod:
+  user:
+    gnocchi:
+      uid: 1000
+  affinity:
+    anti:
+      type:
+        default: preferredDuringSchedulingIgnoredDuringExecution
+      topologyKey:
+        default: kubernetes.io/hostname
+      weight:
+        default: 10
+  tolerations:
+    gnocchi:
+      enabled: false
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+  mounts:
+    gnocchi_api:
+      init_container: null
+      gnocchi_api:
+    gnocchi_statsd:
+      init_container: null
+      gnocchi_statsd:
+    gnocchi_metricd:
+      init_container: null
+      gnocchi_metricd:
+    gnocchi_resources_cleaner:
+      init_container: null
+      gnocchi_resources_cleaner:
+    gnocchi_tests:
+      init_container: null
+      gnocchi_tests:
+  replicas:
+    api: 1
+  lifecycle:
+    upgrades:
+      deployments:
+        revision_history: 3
+        pod_replacement_strategy: RollingUpdate
+        rolling_update:
+          max_unavailable: 1
+          max_surge: 3
+      daemonsets:
+        pod_replacement_strategy: RollingUpdate
+        metricd:
+          enabled: false
+          min_ready_seconds: 0
+          max_unavailable: 1
+        statsd:
+          enabled: false
+          min_ready_seconds: 0
+          max_unavailable: 1
+    disruption_budget:
+      api:
+        min_available: 0
+    termination_grace_period:
+      api:
+        timeout: 30
+  resources:
+    enabled: false
+    api:
+      requests:
+        memory: "124Mi"
+        cpu: "100m"
+      limits:
+        memory: "4096Mi"
+        cpu: "2000m"
+    statsd:
+      requests:
+        memory: "124Mi"
+        cpu: "100m"
+      limits:
+        memory: "1024Mi"
+        cpu: "2000m"
+    metricd:
+      requests:
+        memory: "124Mi"
+        cpu: "100m"
+      limits:
+        memory: "1024Mi"
+        cpu: "2000m"
+    jobs:
+      clean:
+        requests:
+          memory: "124Mi"
+          cpu: "100m"
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+      db_init:
+        requests:
+          memory: "124Mi"
+          cpu: "100m"
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+      db_sync:
+        requests:
+          memory: "124Mi"
+          cpu: "100m"
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+      ks_endpoints:
+        requests:
+          memory: "124Mi"
+          cpu: "100m"
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+      ks_service:
+        requests:
+          memory: "124Mi"
+          cpu: "100m"
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+      ks_user:
+        requests:
+          memory: "124Mi"
+          cpu: "100m"
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+      resources_cleaner:
+        requests:
+          memory: "128Mi"
+          cpu: "100m"
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+      tests:
+        requests:
+          memory: "124Mi"
+          cpu: "100m"
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+      image_repo_sync:
+        requests:
+          memory: "128Mi"
+          cpu: "100m"
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+
+conf:
+  apache: |
+    Listen 0.0.0.0:{{ tuple "metric" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}
+
+    SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+    CustomLog /dev/stdout combined env=!forwarded
+    CustomLog /dev/stdout proxy env=forwarded
+
+    <VirtualHost *:{{ tuple "metric" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}>
+        WSGIDaemonProcess gnocchi processes=1 threads=2 user=gnocchi group=gnocchi display-name=%{GROUP}
+        WSGIProcessGroup gnocchi
+        WSGIScriptAlias / "/var/lib/kolla/venv/lib/python2.7/site-packages/gnocchi/rest/app.wsgi"
+        WSGIApplicationGroup %{GLOBAL}
+
+        ErrorLog /dev/stderr
+        SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+        CustomLog /dev/stdout combined env=!forwarded
+        CustomLog /dev/stdout proxy env=forwarded
+
+        <Directory "/var/lib/kolla/venv/lib/python2.7/site-packages/gnocchi/rest">
+              Require all granted
+        </Directory>
+    </VirtualHost>
+  ceph:
+    monitors: []
+    admin_keyring: null
+    override:
+    append:
+  paste:
+    pipeline:main:
+      pipeline: gnocchi+auth
+    composite:gnocchi+noauth:
+      use: egg:Paste#urlmap
+      /: gnocchiversions
+      /v1: gnocchiv1+noauth
+    composite:gnocchi+auth:
+      use: egg:Paste#urlmap
+      /: gnocchiversions
+      /v1: gnocchiv1+auth
+    pipeline:gnocchiv1+noauth:
+      pipeline: gnocchiv1
+    pipeline:gnocchiv1+auth:
+      pipeline: keystone_authtoken gnocchiv1
+    app:gnocchiversions:
+      paste.app_factory: gnocchi.rest.app:app_factory
+      root: gnocchi.rest.VersionsController
+    app:gnocchiv1:
+      paste.app_factory: gnocchi.rest.app:app_factory
+      root: gnocchi.rest.V1Controller
+    filter:keystone_authtoken:
+      paste.filter_factory: keystonemiddleware.auth_token:filter_factory
+      oslo_config_project: gnocchi
+  policy:
+    admin_or_creator: 'role:admin or project_id:%(created_by_project_id)s'
+    resource_owner: 'project_id:%(project_id)s'
+    metric_owner: 'project_id:%(resource.project_id)s'
+    get status: 'role:admin'
+    create resource: ''
+    get resource: 'rule:admin_or_creator or rule:resource_owner'
+    update resource: 'rule:admin_or_creator'
+    delete resource: 'rule:admin_or_creator'
+    delete resources: 'rule:admin_or_creator'
+    list resource: 'rule:admin_or_creator or rule:resource_owner'
+    search resource: 'rule:admin_or_creator or rule:resource_owner'
+    create resource type: 'role:admin'
+    delete resource type: 'role:admin'
+    update resource type: 'role:admin'
+    list resource type: ''
+    get resource type: ''
+    get archive policy: ''
+    list archive policy: ''
+    create archive policy: 'role:admin'
+    update archive policy: 'role:admin'
+    delete archive policy: 'role:admin'
+    create archive policy rule: 'role:admin'
+    get archive policy rule: ''
+    list archive policy rule: ''
+    delete archive policy rule: 'role:admin'
+    create metric: ''
+    delete metric: 'rule:admin_or_creator'
+    get metric: 'rule:admin_or_creator or rule:metric_owner'
+    search metric: 'rule:admin_or_creator or rule:metric_owner'
+    list metric: ''
+    list all metric: 'role:admin'
+    get measures: 'rule:admin_or_creator or rule:metric_owner'
+    post measures: 'rule:admin_or_creator'
+  gnocchi:
+    DEFAULT:
+      debug: false
+    token:
+      provider: uuid
+    api:
+      auth_mode: keystone
+      # NOTE(portdirect): the bind port should not be defined, and is manipulated
+      # via the endpoints section.
+      port: null
+    statsd:
+      # NOTE(portdirect): the bind port should not be defined, and is manipulated
+      # via the endpoints section.
+      port: null
+    # Increase worker count for production
+    metricd:
+      workers: 1
+    database:
+      max_retries: -1
+    storage:
+      driver: ceph
+      ceph_pool: gnocchi.metrics
+      ceph_username: gnocchi
+      ceph_keyring: /etc/ceph/ceph.client.gnocchi.keyring
+      ceph_conffile: /etc/ceph/ceph.conf
+      file_basepath: /var/lib/gnocchi
+      provided_keyring: null
+    indexer:
+      driver: postgresql
+    keystone_authtoken:
+      auth_type: password
+      auth_version: v3
+      memcache_security_strategy: ENCRYPT
+
+ceph_client:
+  configmap: ceph-etc
+  user_secret_name: pvc-ceph-client-key
+
+secrets:
+  identity:
+    admin: gnocchi-keystone-admin
+    gnocchi: gnocchi-keystone-user
+  oslo_db:
+    admin: gnocchi-db-admin
+    gnocchi: gnocchi-db-user
+  oslo_db_indexer:
+    admin: gnocchi-db-indexer-admin
+    gnocchi: gnocchi-db-indexer-user
+  rbd: gnocchi-rbd-keyring
+  tls:
+    metric:
+      api:
+        public: gnocchi-tls-public
+
+bootstrap:
+  enabled: false
+  ks_user: gnocchi
+  script: |
+    openstack token issue
+
+# typically overridden by environmental
+# values, but should include all endpoints
+# required by this chart
+endpoints:
+  cluster_domain_suffix: cluster.local
+  local_image_registry:
+    name: docker-registry
+    namespace: docker-registry
+    hosts:
+      default: localhost
+      internal: docker-registry
+      node: localhost
+    host_fqdn_override:
+      default: null
+    port:
+      registry:
+        node: 5000
+  identity:
+    name: keystone
+    auth:
+      admin:
+        username: "admin"
+        user_domain_name: "default"
+        password: "password"
+        project_name: "admin"
+        project_domain_name: "default"
+        region_name: "RegionOne"
+        os_auth_type: "password"
+        os_tenant_name: "admin"
+      gnocchi:
+        username: "gnocchi"
+        role: "admin"
+        password: "password"
+        project_name: "service"
+        region_name: "RegionOne"
+        os_auth_type: "password"
+        os_tenant_name: "service"
+        user_domain_name: service
+        project_domain_name: service
+    hosts:
+      default: keystone
+      internal: keystone-api
+    host_fqdn_override:
+      default: null
+    path:
+      default: /v3
+    scheme:
+      default: 'http'
+    port:
+      api:
+        default: 5000
+        public: 80
+        internal: 5000
+        service: 5000
+  metric:
+    name: gnocchi
+    hosts:
+      default: gnocchi-api
+      public: gnocchi
+    host_fqdn_override:
+      default: null
+      # NOTE: this chart supports TLS for fqdn over-ridden public
+      # endpoints using the following format:
+      # public:
+      #   host: null
+      #   tls:
+      #     crt: null
+      #     key: null
+    path:
+      default: null
+    scheme:
+      default: 'http'
+    port:
+      api:
+        default: 8041
+        public: 80
+        internal: 8041
+        service: 8041
+  metric_statsd:
+    name: gnocchi-statsd
+    hosts:
+      default: gnocchi-statsd
+    host_fqdn_override:
+      default: null
+    path:
+      default: null
+    scheme:
+      default: null
+    port:
+      statsd:
+        default: 8125
+  oslo_db_postgresql:
+    auth:
+      admin:
+        username: postgres
+        password: password
+      gnocchi:
+        username: gnocchi
+        password: password
+    hosts:
+      default: postgresql
+    host_fqdn_override:
+      default: null
+    path: /gnocchi
+    scheme: postgresql
+    port:
+      postgresql:
+        default: 5432
+  oslo_db:
+    auth:
+      admin:
+        username: root
+        password: password
+      gnocchi:
+        username: gnocchi
+        password: password
+    hosts:
+      default: mariadb-galera-primary
+    host_fqdn_override:
+      default: null
+    path: /gnocchi
+    scheme: mysql+pymysql
+    port:
+      mysql:
+        default: 3306
+  oslo_cache:
+    auth:
+      # NOTE(portdirect): this is used to define the value for keystone
+      # authtoken cache encryption key, if not set it will be populated
+      # automatically with a random value, but to take advantage of
+      # this feature all services should be set to use the same key,
+      # and memcache service.
+      memcache_secret_key: null
+    hosts:
+      default: memcached
+    host_fqdn_override:
+      default: null
+    port:
+      memcache:
+        default: 11211
+
+manifests:
+  configmap_bin: true
+  configmap_etc: true
+  cron_job_resources_cleaner: true
+  daemonset_metricd: true
+  daemonset_statsd: true
+  deployment_api: true
+  ingress_api: true
+  job_bootstrap: true
+  job_clean: true
+  job_db_drop: false
+  job_db_init_indexer: true
+  job_db_init: true
+  job_image_repo_sync: true
+  secret_db_indexer: true
+  job_db_sync: true
+  job_ks_endpoints: true
+  job_ks_service: true
+  job_ks_user: true
+  job_storage_init: true
+  pdb_api: true
+  pod_gnocchi_test: false
+  secret_db: true
+  secret_keystone: true
+  secret_ingress_tls: true
+  service_api: true
+  service_ingress_api: true
+  service_statsd: true
+...

--- a/helm-configs/gnocchi/gnocchi-helm-overrides.yaml
+++ b/helm-configs/gnocchi/gnocchi-helm-overrides.yaml
@@ -469,7 +469,7 @@ conf:
 
 ceph_client:
   configmap: ceph-etc
-  user_secret_name: pvc-ceph-client-key
+  user_secret_name: gnocchi-temp-keyring
 
 secrets:
   identity:

--- a/helm-configs/postgresql/postgresql-helm-overrides.yaml
+++ b/helm-configs/postgresql/postgresql-helm-overrides.yaml
@@ -154,6 +154,7 @@ images:
       - image_repo_sync
 
 storage:
+  # Ensure PVC sizes are appropriate for the given environment
   pvc:
     enabled: true
     size: 5Gi

--- a/helm-configs/postgresql/postgresql-helm-overrides.yaml
+++ b/helm-configs/postgresql/postgresql-helm-overrides.yaml
@@ -1,0 +1,486 @@
+---
+release_group: null
+
+pod:
+  security_context:
+    prometheus_postgresql_exporter:
+      pod:
+        runAsUser: 65534
+      container:
+        postgresql_exporter:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+    server:
+      pod:
+        runAsUser: 999
+        # fsGroup used to allows cert file be witten to file.
+        fsGroup: 999
+      container:
+        set_volume_perms:
+          runAsUser: 0
+          readOnlyRootFilesystem: true
+        postgresql:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+    postgresql_backup:
+      pod:
+        runAsUser: 65534
+      container:
+        backup_perms:
+          runAsUser: 0
+          readOnlyRootFilesystem: true
+        postgresql_backup:
+          runAsUser: 65534
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+    create_user:
+      pod:
+        runAsUser: 65534
+      container:
+        prometheus_postgresql_exporter_create_user:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+  affinity:
+    anti:
+      type:
+        default: preferredDuringSchedulingIgnoredDuringExecution
+      topologyKey:
+        default: kubernetes.io/hostname
+      weight:
+        default: 10
+  replicas:
+    # only 1 replica currently supported
+    server: 1
+    prometheus_postgresql_exporter: 1
+  lifecycle:
+    upgrades:
+      statefulsets:
+        pod_replacement_strategy: OnDelete
+        partition: 0
+      deployments:
+        revision_history: 3
+        pod_replacement_strategy: RollingUpdate
+        rolling_update:
+          max_unavailable: 1
+          max_surge: 3
+    termination_grace_period:
+      prometheus_postgresql_exporter:
+        timeout: 30
+      server:
+        timeout: 180
+  probes:
+    server:
+      postgresql:
+        liveness:
+          enabled: true
+          params:
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 10
+        readiness:
+          enabled: false
+          params:
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 10
+  resources:
+    enabled: false
+    server:
+      requests:
+        memory: "2048Mi"
+        cpu: "100m"
+      limits:
+        memory: "1024Mi"
+        cpu: "2000m"
+    test:
+      requests:
+        memory: "128Mi"
+        cpu: "100m"
+      limits:
+        memory: "1024Mi"
+        cpu: "2000m"
+    prometheus_postgresql_exporter:
+      limits:
+        memory: "1024Mi"
+        cpu: "2000m"
+      requests:
+        memory: "128Mi"
+        cpu: "500m"
+    jobs:
+      image_repo_sync:
+        requests:
+          memory: "128Mi"
+          cpu: "100m"
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+      prometheus_postgresql_exporter_create_user:
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+        requests:
+          memory: "128Mi"
+          cpu: "100m"
+      postgresql_backup:
+        requests:
+          memory: "128Mi"
+          cpu: "100m"
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+      ks_user:
+        requests:
+          memory: "128Mi"
+          cpu: "100m"
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+
+# using dockerhub postgresql: https://hub.docker.com/r/library/postgres/tags/
+images:
+  tags:
+    postgresql: "docker.io/library/postgres:14.5"
+    dep_check: quay.io/airshipit/kubernetes-entrypoint:v1.0.0
+    image_repo_sync: docker.io/library/docker:17.07.0
+    ks_user: docker.io/openstackhelm/heat:stein-ubuntu_bionic
+    prometheus_postgresql_exporter: docker.io/wrouesnel/postgres_exporter:v0.4.6
+    prometheus_postgresql_exporter_create_user: "docker.io/library/postgres:14.5"
+    postgresql_backup: "quay.io/airshipit/porthole-postgresql-utility:latest-ubuntu_bionic"
+  pull_policy: "IfNotPresent"
+  local_registry:
+    active: false
+    exclude:
+      - dep_check
+      - image_repo_sync
+
+storage:
+  pvc:
+    enabled: true
+    size: 5Gi
+    class_name: general
+    class_path: volume.beta.kubernetes.io/storage-class
+  archive_pvc:
+    size: 5Gi
+    class_name: general
+    class_path: volume.beta.kubernetes.io/storage-class
+  host:
+    host_path: /data/openstack-helm/postgresql
+  mount:
+    path: /var/lib/postgresql
+    subpath: .
+  archive:
+    mount_path: /var/lib/archive
+    archive_limit: 60
+
+labels:
+  server:
+    node_selector_key: openstack-control-plane
+    node_selector_value: enabled
+  test:
+    node_selectory_key: openstack-control-plane
+    node_selector_value: enabled
+  prometheus_postgresql_exporter:
+    node_selector_key: openstack-control-plane
+    node_selector_value: enabled
+  job:
+    node_selector_key: openstack-control-plane
+    node_selector_value: enabled
+
+dependencies:
+  dynamic:
+    common:
+      local_image_registry:
+        jobs:
+          - postgresql-image-repo-sync
+        services:
+          - endpoint: node
+            service: local_image_registry
+  static:
+    postgresql_backup:
+      jobs:
+        - postgresql-ks-user
+      services:
+        - endpoint: internal
+          service: postgresql
+    tests:
+      services:
+        - endpoint: internal
+          service: postgresql
+    image_repo_sync:
+      services:
+        - endpoint: internal
+          service: local_image_registry
+    prometheus_postgresql_exporter_create_user:
+      services:
+        - endpoint: internal
+          service: postgresql
+    prometheus_postgresql_exporter:
+      services:
+        - endpoint: internal
+          service: postgresql
+      jobs:
+        - prometheus-postgresql-exporter-create-user
+
+monitoring:
+  prometheus:
+    enabled: true
+    postgresql_exporter:
+      scrape: true
+
+volume:
+  backup:
+    enabled: true
+    class_name: general
+    size: 5Gi
+
+jobs:
+  postgresql_backup:
+    # activeDeadlineSeconds == 0 means no deadline
+    activeDeadlineSeconds: 0
+    backoffLimit: 6
+    cron: "0 0 * * *"
+    history:
+      success: 3
+      failed: 1
+  ks_user:
+    # activeDeadlineSeconds == 0 means no deadline
+    activeDeadlineSeconds: 0
+    backoffLimit: 6
+
+network_policy:
+  postgresql:
+    ingress:
+      - {}
+    egress:
+      - {}
+
+conf:
+  debug: false
+  pg_hba: |
+    host all all 127.0.0.1/32 trust
+    host all all 0.0.0.0/0 md5
+    local all all trust
+
+  postgresql:
+    archive_mode: 'on'
+    archive_command: 'test ! -f /var/lib/archive/%f && gzip < %p > /var/lib/archive/%f'
+    cluster_name: 'postgresql'
+    datestyle: 'iso, mdy'
+    external_pid_file: '/tmp/postgres.pid'
+    fsync: 'on'
+    listen_addresses: '0.0.0.0'
+    log_checkpoints: 'on'
+    log_connections: 'on'
+    log_disconnections: 'on'
+    log_line_prefix: 'postgresql: %t [%p]: [%l-1] %c %x %d %u %a %h %m '
+    log_lock_waits: 'on'
+    log_temp_files: '0'
+    log_timezone: 'UTC'
+    max_connections: '1000'
+    max_locks_per_transaction: '64'
+    max_prepared_transactions: '0'
+    max_wal_senders: '16'
+    max_worker_processes: '10'
+    port: '5432'
+    shared_buffers: '2GB'
+    ssl: 'off'
+    ssl_cert_file: '/server_certs/tls.crt'
+    ssl_ca_file: '/server_certs/ca.crt'
+    ssl_key_file: '/server_certs/tls.key'
+    ssl_ciphers: 'TLSv1.2:!aNULL'
+    tcp_keepalives_idle: '900'
+    tcp_keepalives_interval: '100'
+    timezone: 'UTC'
+    track_commit_timestamp: 'on'
+    track_functions: 'all'
+    wal_keep_size: '256'
+    wal_level: 'hot_standby'
+    wal_log_hints: 'on'
+    hba_file: '/tmp/pg_hba.conf'
+    ident_file: '/tmp/pg_ident.conf'
+  backup:
+    enabled: false
+    base_path: /var/backup
+    days_to_keep: 3
+    pg_dumpall_options: '--inserts --clean'
+    remote_backup:
+      enabled: false
+      container_name: postgresql
+      days_to_keep: 14
+      storage_policy: default-placement
+      number_of_retries: 5
+      delay_range:
+        min: 30
+        max: 60
+      throttle_backups:
+        enabled: false
+        sessions_limit: 480
+        lock_expire_after: 7200
+        retry_after: 3600
+        container_name: throttle-backups-manager
+
+  exporter:
+    queries:
+      pg_postmaster:
+        query: "SELECT pg_postmaster_start_time as start_time_seconds from pg_postmaster_start_time()"
+        master: true
+        metrics:
+          - start_time_seconds:
+              usage: "GAUGE"
+              description: "Time at which postmaster started"
+
+secrets:
+  oci_image_registry:
+    postgresql: postgresql-oci-image-registry-key
+  postgresql:
+    admin: postgresql-admin
+    exporter: postgresql-exporter
+    audit: postgresql-audit
+    backup_restore: postgresql-backup-restore
+    tls:
+      server:
+        internal: postgresql-tls-direct
+  identity:
+    admin: keystone-admin-user
+    postgresql: postgresql-backup-user
+
+endpoints:
+  cluster_domain_suffix: cluster.local
+  local_image_registry:
+    name: docker-registry
+    namespace: docker-registry
+    hosts:
+      default: localhost
+      internal: docker-registry
+      node: localhost
+    host_fqdn_override:
+      default: null
+    port:
+      registry:
+        node: 5000
+  oci_image_registry:
+    name: oci-image-registry
+    namespace: oci-image-registry
+    auth:
+      enabled: false
+      postresql:
+        username: postresql
+        password: password
+    hosts:
+      default: localhost
+    host_fqdn_override:
+      default: null
+    port:
+      registry:
+        default: null
+  postgresql:
+    auth:
+      admin:
+        username: postgres
+        password: password
+      exporter:
+        username: psql_exporter
+        password: psql_exp_pass
+      audit:
+        username: audit
+        password: password
+    hosts:
+      default: postgresql
+    host_fqdn_override:
+      default: null
+    path: null
+    scheme: postgresql
+    port:
+      postgresql:
+        default: 5432
+        internal: 5432
+        service: 5432
+  postgresql_restapi:
+    hosts:
+      default: postgresql-restapi
+    host_fqdn_override:
+      default: null
+    path: null
+    scheme: postgresql
+    port:
+      restapi:
+        default: 8008
+        internal: 8008
+        service: 8008
+  prometheus_postgresql_exporter:
+    namespace: null
+    hosts:
+      default: postgresql-exporter
+    host_fqdn_override:
+      default: null
+    path:
+      default: /metrics
+    scheme:
+      default: 'http'
+    port:
+      metrics:
+        default: 9187
+  identity:
+    name: backup-storage-auth
+    namespace: openstack
+    auth:
+      admin:
+        # Auth URL of null indicates local authentication
+        # HTK will form the URL unless specified here
+        auth_url: null
+        region_name: RegionOne
+        username: admin
+        password: password
+        project_name: admin
+        user_domain_name: default
+        project_domain_name: default
+      postgresql:
+        # Auth URL of null indicates local authentication
+        # HTK will form the URL unless specified here
+        auth_url: null
+        role: admin
+        region_name: RegionOne
+        username: postgresql-backup-user
+        password: password
+        project_name: service
+        user_domain_name: service
+        project_domain_name: service
+    hosts:
+      default: keystone
+      internal: keystone-api
+    host_fqdn_override:
+      default: null
+    path:
+      default: /v3
+    scheme:
+      default: 'http'
+    port:
+      api:
+        default: 80
+        internal: 5000
+
+manifests:
+  certificates: false
+  configmap_bin: true
+  configmap_etc: true
+  job_image_repo_sync: true
+  network_policy: false
+  job_ks_user: false
+  secret_admin: true
+  secret_etc: true
+  secret_audit: true
+  secret_backup_restore: false
+  secret_registry: true
+  service: true
+  statefulset: true
+  cron_job_postgresql_backup: false
+  pvc_backup: false
+  monitoring:
+    prometheus:
+      configmap_bin: true
+      configmap_etc: true
+      deployment_exporter: true
+      job_user_create: true
+      secret_etc: true
+      service_exporter: true
+...

--- a/kustomize/gnocchi/base/configmap-bin.yaml
+++ b/kustomize/gnocchi/base/configmap-bin.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gnocchi-bin
+data:
+  storage-init.sh: |
+    #!/bin/bash
+
+    set -x
+    SECRET=$(mktemp --suffix .yaml)
+    KEYRING=$(mktemp --suffix .keyring)
+    function cleanup {
+        rm -f ${SECRET} ${KEYRING}
+    }
+    trap cleanup EXIT
+
+    set -ex
+    ceph -s
+    function ensure_pool () {
+      ceph osd pool stats $1 || ceph osd pool create $1 $2
+      local test_version=$(ceph tell osd.* version | egrep -c "nautilus|mimic|luminous" | xargs echo)
+      if [[ ${test_version} -gt 0 ]]; then
+        ceph osd pool application enable $1 $3
+      fi
+    }
+    ensure_pool ${RBD_POOL_NAME} ${RBD_POOL_CHUNK_SIZE} "gnocchi-metrics"
+
+    if USERINFO=$(ceph auth get client.${RBD_POOL_USER}); then
+      echo "Cephx user client.${RBD_POOL_USER} already exist."
+      echo "Update its cephx caps"
+      ceph auth caps client.${RBD_POOL_USER} \
+        mon "allow r" \
+        osd "allow rwx pool=${RBD_POOL_NAME}" \
+        mgr "allow r"
+      ceph auth get client.${RBD_POOL_USER} -o ${KEYRING}
+    else
+      ceph auth get-or-create client.${RBD_POOL_USER} \
+        mon "allow r" \
+        osd "allow rwx pool=${RBD_POOL_NAME}" \
+        mgr "allow r" \
+        -o ${KEYRING}
+    fi
+
+    ENCODED_KEYRING=$(sed -n 's/^[[:blank:]]*key[[:blank:]]\+=[[:blank:]]\(.*\)/\1/p' ${KEYRING} | base64 -w0)
+    cat > ${SECRET} <<EOF
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: "${RBD_POOL_SECRET}"
+    type: kubernetes.io/rbd
+    data:
+      key: $( echo ${ENCODED_KEYRING} )
+    EOF
+    kubectl apply --namespace ${NAMESPACE} -f ${SECRET}

--- a/kustomize/gnocchi/base/configmap-bin.yaml
+++ b/kustomize/gnocchi/base/configmap-bin.yaml
@@ -1,3 +1,6 @@
+# A patch to supplant the `storage-init.sh` script containing an updated
+# ceph command that does not use `profile` when setting auth capabilities.
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/kustomize/gnocchi/base/gnocchi-temp-keyring.yaml
+++ b/kustomize/gnocchi/base/gnocchi-temp-keyring.yaml
@@ -1,0 +1,20 @@
+# Creates a named temp secret with a non-sensitve value.
+# It would be used during keyring placement if the admin or client keyrings
+# are not available, see: _ceph-keyring.sh.tpl -> /tmp/client-keyring
+# The `admin_keyring` should be provided as an override to the helm-chart
+# so that the RBD pool and user can be created automatically. The resulting
+# keyring from user creation will be stored in `gnocchi-rbd-keyring`.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gnocchi-temp-keyring
+type: Opaque
+stringData:
+  key: |
+    # This file should not be used under normal circumstances.
+    # If the admin_keyring is not defined in the helm chart then this file
+    # would be used. Similarly, if the gnocchi.storage.provided_keyring is
+    # not provided, this file would be used.
+    # Refer to _ceph-keyring.sh.tpl -> /tmp/client-keyring for a better
+    # understanding of why you're here.

--- a/kustomize/gnocchi/base/kustomization.yaml
+++ b/kustomize/gnocchi/base/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+  - all.yaml
+
+patches:
+  # A patch to supplant the `storage-init.sh` script containing an updated
+  # ceph command that does not use `profile` when setting auth capabilities.
+  - path: configmap-bin.yaml
+    target:
+      kind: ConfigMap
+      name: gnocchi-bin

--- a/kustomize/gnocchi/base/kustomization.yaml
+++ b/kustomize/gnocchi/base/kustomization.yaml
@@ -1,9 +1,8 @@
 resources:
+  - gnocchi-temp-keyring.yaml
   - all.yaml
 
 patches:
-  # A patch to supplant the `storage-init.sh` script containing an updated
-  # ceph command that does not use `profile` when setting auth capabilities.
   - path: configmap-bin.yaml
     target:
       kind: ConfigMap


### PR DESCRIPTION
This PR introduces helm configs for Gnocchi (OpenStack Metrics API) and its dependency, PostgreSQL. Gnocchi is a dependency of Ceilometer, which we will be adding to Genestack soon.

Note that PostgreSQL is being used as the indexer storage back-end in favor of our existing MariaDB operator implementation for several reasons.

1. Gnocchi [cites PostgreSQL as the preferred driver](https://gnocchi.osci.io/intro.html#indexer-driver) (though they don't state _why_ exactly).
2. I could not get the MySQL driver working with the helm chart, despite several attempts. It seems like it may be possible, but instructions are unclear, and there may be a bit of overhaul with the chart required to get it to work as expected. MySQL is supported by Gnocchi though, so it's within the realm of possibility.

Iff we go with PostgreSQL long term, we will want to investigate the upstream operator. The existing chart works and is being maintained to some extent, but the operator no doubt has more active contributors and will likely suit Genestack better.