### PR TITLE
Specify mariadb-operator chart version to deploy

### DIFF
--- a/kustomize/mariadb-operator/kustomization.yaml
+++ b/kustomize/mariadb-operator/kustomization.yaml
@@ -12,4 +12,5 @@ helmCharts:
           certManager:
             enabled: true
     includeCRDs: true
+    version: 0.24.0
     namespace: mariadb-system


### PR DESCRIPTION
The API group has been renamed in the latest version of mariadb-operator(0.26.0) which breaks the deployment of mariadb cluster installation. https://github.com/mariadb-operator/mariadb-operator/pull/418