### PR TITLE
MariaDB-Operator updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "submodules/rook"]
 	path = submodules/rook
 	url = https://github.com/rook/rook.git
-[submodule "submodules/mariadb-operator"]
-	path = submodules/mariadb-operator
-	url = https://github.com/mariadb-operator/mariadb-operator
 [submodule "submodules/openstack-exporter"]
 	path = submodules/openstack-exporter
 	url = https://github.com/openstack-exporter/helm-charts

--- a/kustomize/cinder/base/cinder-mariadb-database.yaml
+++ b/kustomize/cinder/base/cinder-mariadb-database.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: cinder
@@ -13,7 +13,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
   name: cinder
@@ -31,7 +31,7 @@ spec:
   host: "%"
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: cinder-grant

--- a/kustomize/glance/base/glance-mariadb-database.yaml
+++ b/kustomize/glance/base/glance-mariadb-database.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: glance
@@ -13,7 +13,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
   name: glance
@@ -31,7 +31,7 @@ spec:
   host: "%"
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: glance-grant

--- a/kustomize/heat/base/heat-mariadb-database.yaml
+++ b/kustomize/heat/base/heat-mariadb-database.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: heat
@@ -13,7 +13,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
   name: heat
@@ -31,7 +31,7 @@ spec:
   host: "%"
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: heat-grant

--- a/kustomize/horizon/base/horizon-mariadb-database.yaml
+++ b/kustomize/horizon/base/horizon-mariadb-database.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: horizon
@@ -13,7 +13,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
   name: horizon
@@ -31,7 +31,7 @@ spec:
   host: "%"
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: horizon-grant

--- a/kustomize/keystone/base/keystone-mariadb-database.yaml
+++ b/kustomize/keystone/base/keystone-mariadb-database.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: keystone
@@ -13,7 +13,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
   name: keystone
@@ -31,7 +31,7 @@ spec:
   host: "%"
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: keystone-grant

--- a/kustomize/mariadb-cluster/base/mariadb-backup.yaml
+++ b/kustomize/mariadb-cluster/base/mariadb-backup.yaml
@@ -1,4 +1,4 @@
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Backup
 metadata:
   name: mariadb-backup

--- a/kustomize/mariadb-cluster/base/mariadb-galera.yaml
+++ b/kustomize/mariadb-cluster/base/mariadb-galera.yaml
@@ -1,4 +1,4 @@
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: MariaDB
 metadata:
   name: mariadb-galera
@@ -7,47 +7,75 @@ spec:
   rootPasswordSecretKeyRef:
     name: mariadb
     key: root-password
-
-  database: mariadb
   username: mariadb
-  passwordSecretKeyRef:
-    name: mariadb
-    key: password
+  database: mariadb
 
-  image: mariadb:11.0.3
-
-  port: 3306
+  storage:
+    size: 1Gi
+    storageClassName: general
+    resizeInUseVolumes: true
+    waitForVolumeResize: true
+    volumeClaimTemplate:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+      storageClassName: general
 
   replicas: 3
   podSecurityContext:
     runAsUser: 0
+
+  # point to an existing MaxScale instance. Doing this will delegate tasks such as primary failover to MaxScale.
+  # maxScaleRef:
+  #   name: maxscale
+
+  # provision a MaxScale instance and set 'spec.maxScaleRef' automatically.
+  maxScale:
+    enabled: false
+
+    kubernetesService:
+      type: LoadBalancer
+      annotations:
+        metallb.universe.tf/address-pool: primary
+
+    connection:
+      secretName: mxs-galera-conn
+      port: 3306
+
   galera:
     enabled: true
     primary:
       podIndex: 0
       automaticFailover: true
     sst: mariabackup
-    replicaThreads: 4
+    availableWhenDonor: false
+    galeraLibPath: /usr/lib/galera/libgalera_smm.so
+    replicaThreads: 1
     agent:
-      image: ghcr.io/mariadb-operator/agent:v0.0.3
+      image: ghcr.io/mariadb-operator/mariadb-operator:v0.0.26
       port: 5555
       kubernetesAuth:
         enabled: true
-      gracefulShutdownTimeout: 5s
+      gracefulShutdownTimeout: 1s
     recovery:
       enabled: true
-      clusterHealthyTimeout: 3m
+      minClusterSize: 50%
+      clusterHealthyTimeout: 30s
       clusterBootstrapTimeout: 10m
-      podRecoveryTimeout: 5m
-      podSyncTimeout: 5m
+      podRecoveryTimeout: 3m
+      podSyncTimeout: 3m
     initContainer:
-      image: ghcr.io/mariadb-operator/init:v0.0.6
-    volumeClaimTemplate:
-      resources:
-        requests:
-          storage: 10Gi
-      accessModes:
-        - ReadWriteOnce
+      image: ghcr.io/mariadb-operator/mariadb-operator:v0.0.26
+    config:
+      reuseStorageVolume: false
+      volumeClaimTemplate:
+        resources:
+          requests:
+            storage: 300Mi
+        accessModes:
+          - ReadWriteOnce
 
   service:
     type: LoadBalancer
@@ -77,17 +105,15 @@ spec:
       key: dsn
 
   affinity:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - topologyKey: "kubernetes.io/hostname"
+    enableAntiAffinity: true
 
   tolerations:
-    - key: "mariadb.mmontes.io/ha"
+    - key: "k8s.mariadb.com/ha"
       operator: "Exists"
       effect: "NoSchedule"
 
   podDisruptionBudget:
-    maxUnavailable: 66%
+    maxUnavailable: 33%
 
   updateStrategy:
     type: RollingUpdate
@@ -109,9 +135,5 @@ spec:
     limits:
       memory: 16Gi
 
-  volumeClaimTemplate:
-    resources:
-      requests:
-        storage: 10Gi
-    accessModes:
-      - ReadWriteOnce
+  metrics:
+    enabled: true

--- a/kustomize/mariadb-cluster/base/mariadb-galera.yaml
+++ b/kustomize/mariadb-cluster/base/mariadb-galera.yaml
@@ -11,7 +11,7 @@ spec:
   database: mariadb
 
   storage:
-    size: 1Gi
+    size: 10Gi
     storageClassName: general
     resizeInUseVolumes: true
     waitForVolumeResize: true
@@ -20,7 +20,7 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 1Gi
+          storage: 10Gi
       storageClassName: general
 
   replicas: 3
@@ -73,7 +73,7 @@ spec:
       volumeClaimTemplate:
         resources:
           requests:
-            storage: 300Mi
+            storage: 10Gi
         accessModes:
           - ReadWriteOnce
 

--- a/kustomize/mariadb-operator/kustomization.yaml
+++ b/kustomize/mariadb-operator/kustomization.yaml
@@ -11,6 +11,8 @@ helmCharts:
         cert:
           certManager:
             enabled: true
+      metrics:
+        enabled: true
     includeCRDs: true
-    version: 0.24.0
+    version: 0.26.0
     namespace: mariadb-system

--- a/kustomize/neutron/base/neutron-mariadb-database.yaml
+++ b/kustomize/neutron/base/neutron-mariadb-database.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: neutron
@@ -13,7 +13,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
   name: neutron
@@ -31,7 +31,7 @@ spec:
   host: "%"
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: neutron-grant

--- a/kustomize/nova/base/nova-mariadb-database.yaml
+++ b/kustomize/nova/base/nova-mariadb-database.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: nova
@@ -13,7 +13,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: nova-api
@@ -28,7 +28,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: nova-cell0
@@ -43,7 +43,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
   name: nova
@@ -61,7 +61,7 @@ spec:
   host: "%"
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: nova-grant
@@ -78,7 +78,7 @@ spec:
   host: "%"
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: nova-api-grant
@@ -95,7 +95,7 @@ spec:
   host: "%"
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: nova-cell0-grant

--- a/kustomize/octavia/base/octavia-mariadb-database.yaml
+++ b/kustomize/octavia/base/octavia-mariadb-database.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: octavia
@@ -13,7 +13,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
   name: octavia
@@ -31,7 +31,7 @@ spec:
   host: "%"
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: octavia-grant

--- a/kustomize/placement/base/placement-mariadb-database.yaml
+++ b/kustomize/placement/base/placement-mariadb-database.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: placement
@@ -13,7 +13,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
   name: placement
@@ -31,7 +31,7 @@ spec:
   host: "%"
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: placement-grant

--- a/kustomize/prometheus-mysql-exporter/monitoring_user_create.yaml
+++ b/kustomize/prometheus-mysql-exporter/monitoring_user_create.yaml
@@ -1,4 +1,4 @@
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
   name: monitoring

--- a/kustomize/prometheus-mysql-exporter/monitoring_user_grant.yaml
+++ b/kustomize/prometheus-mysql-exporter/monitoring_user_grant.yaml
@@ -1,4 +1,4 @@
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: monitoring-grant

--- a/kustomize/skyline/base/skyline-mariadb-database.yaml
+++ b/kustomize/skyline/base/skyline-mariadb-database.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: skyline
@@ -13,7 +13,7 @@ spec:
   collate: utf8_general_ci
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
   name: skyline
@@ -31,7 +31,7 @@ spec:
   host: "%"
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: skyline-grant


### PR DESCRIPTION
This change is updating the mariadb-galera manifest to use the latest images
and system config. This is being done to help resolve some of the deadlock
issues being experienced when the cluster is under load.

This change also brings in a LOT of fixes into the operator, which should
help make our platform run better, generally.

All of the CRD references have been updated to use the stable release of the
operator, version 0.26.0.