### PR TITLE
feat: introduce maxscale

### DIFF
--- a/docs/infrastructure-mariadb-connect.md
+++ b/docs/infrastructure-mariadb-connect.md
@@ -3,9 +3,9 @@
 Sometimes an operator may need to connect to the database to troubleshoot things or otherwise make modifications to the databases in place. The following command can be used to connect to the database from a node within the cluster.
 
 ``` shell
-mysql -h $(kubectl -n openstack get service mariadb-galera-primary -o jsonpath='{.spec.clusterIP}') \
-      -p$(kubectl --namespace openstack get secret mariadb -o jsonpath='{.data.root-password}' | base64 -d) \
-      -u root
+mysql -h $(kubectl -n openstack get service maxscale-galera -o jsonpath='{.spec.clusterIP}') \
+      -p$(kubectl --namespace openstack get secret maxscale -o jsonpath='{.data.password}' | base64 -d) \
+      -u maxscale-galera-client
 ```
 
 !!! info

--- a/docs/infrastructure-mariadb.md
+++ b/docs/infrastructure-mariadb.md
@@ -42,3 +42,19 @@ kubectl --namespace openstack apply -k /opt/genestack/kustomize/mariadb-cluster/
 ``` shell
 kubectl --namespace openstack get mariadbs -w
 ```
+
+## MaxScale
+
+Within the deployment the OpenStack services use MaxScale for loadlancing and greater reliability. While the MaxScale ecosystem is a good one, there are some limitations that you should be aware of. It is recommended that you review the [MaxScale reference documentation](https://mariadb.com/kb/en/mariadb-maxscale-2302-limitations-and-known-issues-within-mariadb-maxscale) for more about all of the known limitations and potential workarounds available.
+
+``` mermaid
+flowchart TD
+    A[Connection] ---B{MaxScale}
+    B ---|ro| C[ES-0]
+    B ---|rw| D[ES-1] ---|sync| E & C
+    B ---|ro| E[ES-2]
+```
+
+### MaxScale GUI
+
+The MaxScale deployment has access to a built in GUI that can be exposed for further debuging and visibility into the performance of the MariDB backend. For more information on accessing the GUI please refer to the MaxScale documentation that can be found [here](https://mariadb.com/resources/blog/getting-started-with-the-mariadb-maxscale-gui).

--- a/docs/openstack-skyline.md
+++ b/docs/openstack-skyline.md
@@ -17,7 +17,7 @@ kubectl --namespace openstack \
         --from-literal=service-domain="service" \
         --from-literal=service-project="service" \
         --from-literal=service-project-domain="service" \
-        --from-literal=db-endpoint="mariadb-galera-primary.openstack.svc.cluster.local" \
+        --from-literal=db-endpoint="maxscale-galera.openstack.svc.cluster.local" \
         --from-literal=db-name="skyline" \
         --from-literal=db-username="skyline" \
         --from-literal=db-password="$(< /dev/urandom tr -dc _A-Za-z0-9 | head -c${1:-32};echo;)" \

--- a/helm-configs/cinder/cinder-helm-overrides.yaml
+++ b/helm-configs/cinder/cinder-helm-overrides.yaml
@@ -1320,7 +1320,7 @@ endpoints:
         username: cinder
         password: password
     hosts:
-      default: mariadb-galera-primary
+      default: maxscale-galera
     host_fqdn_override:
       default: null
     path: /cinder

--- a/helm-configs/glance/glance-helm-overrides.yaml
+++ b/helm-configs/glance/glance-helm-overrides.yaml
@@ -589,7 +589,7 @@ endpoints:
         username: glance
         password: password
     hosts:
-      default: mariadb-galera-primary
+      default: maxscale-galera
     host_fqdn_override:
       default: null
     path: /glance

--- a/helm-configs/gnocchi/gnocchi-helm-overrides.yaml
+++ b/helm-configs/gnocchi/gnocchi-helm-overrides.yaml
@@ -622,7 +622,7 @@ endpoints:
         username: gnocchi
         password: password
     hosts:
-      default: mariadb-galera-primary
+      default: maxscale-galera
     host_fqdn_override:
       default: null
     path: /gnocchi

--- a/helm-configs/heat/heat-helm-overrides.yaml
+++ b/helm-configs/heat/heat-helm-overrides.yaml
@@ -859,7 +859,7 @@ endpoints:
         username: heat
         password: password
     hosts:
-      default: mariadb-galera-primary
+      default: maxscale-galera
     host_fqdn_override:
       default: null
     path: /heat

--- a/helm-configs/horizon/horizon-helm-overrides.yaml
+++ b/helm-configs/horizon/horizon-helm-overrides.yaml
@@ -7242,7 +7242,7 @@ endpoints:
         username: horizon
         password: password
     hosts:
-      default: mariadb-galera-primary
+      default: maxscale-galera
     host_fqdn_override:
       default: null
     path: /horizon

--- a/helm-configs/keystone/keystone-helm-overrides.yaml
+++ b/helm-configs/keystone/keystone-helm-overrides.yaml
@@ -972,7 +972,7 @@ endpoints:
         username: keystone
         password: password
     hosts:
-      default: mariadb-galera-primary
+      default: maxscale-galera
     host_fqdn_override:
       default: null
     path: /keystone

--- a/helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/helm-configs/neutron/neutron-helm-overrides.yaml
@@ -2199,7 +2199,7 @@ endpoints:
         username: neutron
         password: password
     hosts:
-      default: mariadb-galera-primary
+      default: maxscale-galera
     host_fqdn_override:
       default: null
     path: /neutron

--- a/helm-configs/nova/nova-helm-overrides.yaml
+++ b/helm-configs/nova/nova-helm-overrides.yaml
@@ -1640,7 +1640,7 @@ endpoints:
         username: nova
         password: password
     hosts:
-      default: mariadb-galera-primary
+      default: maxscale-galera
     host_fqdn_override:
       default: null
     path: /nova
@@ -1657,7 +1657,7 @@ endpoints:
         username: nova
         password: password
     hosts:
-      default: mariadb-galera-primary
+      default: maxscale-galera
     host_fqdn_override:
       default: null
     path: /nova_api
@@ -1674,7 +1674,7 @@ endpoints:
         username: nova
         password: password
     hosts:
-      default: mariadb-galera-primary
+      default: maxscale-galera
     host_fqdn_override:
       default: null
     path: /nova_cell0

--- a/helm-configs/octavia/octavia-helm-overrides.yaml
+++ b/helm-configs/octavia/octavia-helm-overrides.yaml
@@ -466,7 +466,7 @@ endpoints:
         username: octavia
         password: password
     hosts:
-      default: mariadb-galera-primary
+      default: maxscale-galera
     host_fqdn_override:
       default: null
     path: /octavia

--- a/helm-configs/placement/placement-helm-overrides.yaml
+++ b/helm-configs/placement/placement-helm-overrides.yaml
@@ -206,7 +206,7 @@ endpoints:
         username: nova
         password: password
     hosts:
-      default: mariadb-galera-primary
+      default: maxscale-galera
     host_fqdn_override:
       default: null
     path: /placement

--- a/kustomize/cinder/base/cinder-mariadb-database.yaml
+++ b/kustomize/cinder/base/cinder-mariadb-database.yaml
@@ -4,6 +4,8 @@ kind: Database
 metadata:
   name: cinder
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -18,6 +20,8 @@ kind: User
 metadata:
   name: cinder
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -36,6 +40,8 @@ kind: Grant
 metadata:
   name: cinder-grant
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   mariaDbRef:
     name: mariadb-galera

--- a/kustomize/cinder/base/cinder-rabbitmq-queue.yaml
+++ b/kustomize/cinder/base/cinder-rabbitmq-queue.yaml
@@ -4,6 +4,8 @@ kind: User
 metadata:
   name: cinder
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   tags:
   - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
@@ -19,6 +21,8 @@ kind: Vhost
 metadata:
   name: cinder-vhost
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   name: "cinder" # vhost name; required and cannot be updated
   defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
@@ -38,6 +42,8 @@ kind: Queue
 metadata:
   name: cinder-queue
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   name: cinder-qq # name of the queue
   vhost: "cinder" # default to '/' if not provided
@@ -53,6 +59,8 @@ kind: Permission
 metadata:
   name: cinder-permission
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   vhost: "cinder" # name of a vhost
   userReference:

--- a/kustomize/glance/base/glance-mariadb-database.yaml
+++ b/kustomize/glance/base/glance-mariadb-database.yaml
@@ -4,6 +4,8 @@ kind: Database
 metadata:
   name: glance
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -18,6 +20,8 @@ kind: User
 metadata:
   name: glance
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -36,6 +40,8 @@ kind: Grant
 metadata:
   name: glance-grant
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   mariaDbRef:
     name: mariadb-galera

--- a/kustomize/glance/base/glance-rabbitmq-queue.yaml
+++ b/kustomize/glance/base/glance-rabbitmq-queue.yaml
@@ -4,6 +4,8 @@ kind: User
 metadata:
   name: glance
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   tags:
   - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
@@ -19,6 +21,8 @@ kind: Vhost
 metadata:
   name: glance-vhost
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   name: "glance" # vhost name; required and cannot be updated
   defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
@@ -38,6 +42,8 @@ kind: Queue
 metadata:
   name: glance-queue
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   name: glance-qq # name of the queue
   vhost: "glance" # default to '/' if not provided
@@ -53,6 +59,8 @@ kind: Permission
 metadata:
   name: glance-permission
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   vhost: "glance" # name of a vhost
   userReference:

--- a/kustomize/grafana/base/grafana-database.yaml
+++ b/kustomize/grafana/base/grafana-database.yaml
@@ -1,4 +1,4 @@
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: grafana
@@ -13,7 +13,7 @@ spec:
   requeueInterval: 30s
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
   name: grafana
@@ -32,7 +32,7 @@ spec:
   requeueInterval: 30s
   retryInterval: 5s
 ---
-apiVersion: mariadb.mmontes.io/v1alpha1
+apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: grant

--- a/kustomize/grafana/base/grafana-database.yaml
+++ b/kustomize/grafana/base/grafana-database.yaml
@@ -3,6 +3,10 @@ kind: Database
 metadata:
   name: grafana
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/managed-by: Helm
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -18,6 +22,8 @@ kind: User
 metadata:
   name: grafana
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -37,6 +43,8 @@ kind: Grant
 metadata:
   name: grant
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   mariaDbRef:
     name: mariadb-galera

--- a/kustomize/heat/base/heat-mariadb-database.yaml
+++ b/kustomize/heat/base/heat-mariadb-database.yaml
@@ -4,6 +4,8 @@ kind: Database
 metadata:
   name: heat
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -18,6 +20,8 @@ kind: User
 metadata:
   name: heat
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -36,6 +40,8 @@ kind: Grant
 metadata:
   name: heat-grant
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   mariaDbRef:
     name: mariadb-galera

--- a/kustomize/horizon/base/horizon-mariadb-database.yaml
+++ b/kustomize/horizon/base/horizon-mariadb-database.yaml
@@ -4,6 +4,8 @@ kind: Database
 metadata:
   name: horizon
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -18,6 +20,8 @@ kind: User
 metadata:
   name: horizon
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -36,6 +40,8 @@ kind: Grant
 metadata:
   name: horizon-grant
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   mariaDbRef:
     name: mariadb-galera

--- a/kustomize/keystone/base/keystone-mariadb-database.yaml
+++ b/kustomize/keystone/base/keystone-mariadb-database.yaml
@@ -4,6 +4,8 @@ kind: Database
 metadata:
   name: keystone
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -18,6 +20,8 @@ kind: User
 metadata:
   name: keystone
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -36,6 +40,8 @@ kind: Grant
 metadata:
   name: keystone-grant
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   mariaDbRef:
     name: mariadb-galera

--- a/kustomize/keystone/base/keystone-rabbitmq-queue.yaml
+++ b/kustomize/keystone/base/keystone-rabbitmq-queue.yaml
@@ -4,6 +4,8 @@ kind: User
 metadata:
   name: keystone
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   tags:
   - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
@@ -19,6 +21,8 @@ kind: Vhost
 metadata:
   name: keystone-vhost
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   name: "keystone" # vhost name; required and cannot be updated
   defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
@@ -38,6 +42,8 @@ kind: Queue
 metadata:
   name: keystone-queue
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   name: keystone-qq # name of the queue
   vhost: "keystone" # default to '/' if not provided
@@ -53,6 +59,8 @@ kind: Permission
 metadata:
   name: keystone-permission
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   vhost: "keystone" # name of a vhost
   userReference:

--- a/kustomize/mariadb-cluster/aio/kustomization.yaml
+++ b/kustomize/mariadb-cluster/aio/kustomization.yaml
@@ -12,3 +12,10 @@ patches:
       - op: replace
         path: /spec/galera/enabled
         value: false
+  - target:
+      kind: MaxScale
+      name: maxscale-galera
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1

--- a/kustomize/mariadb-cluster/base/kustomization.yaml
+++ b/kustomize/mariadb-cluster/base/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
   - mariadb-configmap.yaml
+  - mariadb-maxscale.yaml
   - mariadb-galera.yaml
   - mariadb-backup.yaml

--- a/kustomize/mariadb-cluster/base/mariadb-galera.yaml
+++ b/kustomize/mariadb-cluster/base/mariadb-galera.yaml
@@ -28,21 +28,8 @@ spec:
     runAsUser: 0
 
   # point to an existing MaxScale instance. Doing this will delegate tasks such as primary failover to MaxScale.
-  # maxScaleRef:
-  #   name: maxscale
-
-  # provision a MaxScale instance and set 'spec.maxScaleRef' automatically.
-  maxScale:
-    enabled: false
-
-    kubernetesService:
-      type: LoadBalancer
-      annotations:
-        metallb.universe.tf/address-pool: primary
-
-    connection:
-      secretName: mxs-galera-conn
-      port: 3306
+  maxScaleRef:
+    name: maxscale-galera
 
   galera:
     enabled: true
@@ -132,8 +119,6 @@ spec:
   resources:
     requests:
       memory: 256Mi
-    limits:
-      memory: 16Gi
 
   metrics:
     enabled: true

--- a/kustomize/mariadb-cluster/base/mariadb-maxscale.yaml
+++ b/kustomize/mariadb-cluster/base/mariadb-maxscale.yaml
@@ -1,0 +1,132 @@
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: MaxScale
+metadata:
+  name: maxscale-galera
+spec:
+  replicas: 3
+
+  mariaDbRef:
+    name: mariadb-galera
+    namespace: openstack
+
+  services:
+    - name: rw-router
+      router: readwritesplit
+      params:
+        transaction_replay: "true"
+        transaction_replay_attempts: "10"
+        transaction_replay_timeout: "5s"
+        max_slave_connections: "255"
+        max_replication_lag: "3s"
+        master_accept_reads: "true"
+      listener:
+        name: rw-listener
+        port: 3306
+        protocol: MariaDBProtocol
+        params:
+          connection_metadata: "tx_isolation=auto"
+        suspend: false
+      suspend: false
+    - name: rconn-master-router
+      router: readconnroute
+      params:
+        router_options: "master"
+        max_replication_lag: "3s"
+        master_accept_reads: "true"
+      listener:
+        port: 3307
+    - name: rconn-slave-router
+      router: readconnroute
+      params:
+        router_options: "slave"
+        max_replication_lag: "3s"
+      listener:
+        port: 3308
+
+  monitor:
+    name: mariadb-monitor
+    module: galeramon
+    interval: 2s
+    cooperativeMonitoring: majority_of_all
+    params:
+      disable_master_failback: "false"
+      available_when_donor: "false"
+      disable_master_role_setting: "false"
+    suspend: false
+
+  admin:
+    port: 8989
+    guiEnabled: true
+
+  config:
+    params:
+      log_info: "true"
+    volumeClaimTemplate:
+      resources:
+        requests:
+          storage: 100Mi
+      accessModes:
+        - ReadWriteOnce
+      storageClassName: general
+    sync:
+      database: mysql
+      interval: 5s
+      timeout: 10s
+
+  auth:
+    generate: true
+    adminUsername: mariadb-operator
+    adminPasswordSecretKeyRef:
+      name: maxscale
+      key: password
+    deleteDefaultAdmin: true
+    clientUsername: maxscale-galera-client
+    clientPasswordSecretKeyRef:
+      name: maxscale
+      key: password
+    clientMaxConnections: 1024
+    serverUsername: maxscale-galera-server
+    serverPasswordSecretKeyRef:
+      name: maxscale
+      key: password
+    serverMaxConnections: 1024
+    monitorUsername: maxscale-galera-monitor
+    monitorPasswordSecretKeyRef:
+      name: maxscale
+      key: password
+    monitorMaxConnections: 128
+    syncUsername: maxscale-galera-sync
+    syncPasswordSecretKeyRef:
+      name: maxscale
+      key: password
+    syncMaxConnections: 128
+
+  securityContext:
+    allowPrivilegeEscalation: false
+
+  updateStrategy:
+    type: RollingUpdate
+
+  kubernetesService:
+    type: LoadBalancer
+    annotations:
+      metallb.universe.tf/address-pool: primary
+
+  connection:
+    secretName: mxs-galera-conn
+    port: 3306
+
+  resources:
+    requests:
+      memory: 128Mi
+
+  affinity:
+    enableAntiAffinity: true
+
+  tolerations:
+    - key: "k8s.mariadb.com/ha"
+      operator: "Exists"
+      effect: "NoSchedule"
+
+  podDisruptionBudget:
+    maxUnavailable: 33%

--- a/kustomize/neutron/base/neutron-mariadb-database.yaml
+++ b/kustomize/neutron/base/neutron-mariadb-database.yaml
@@ -4,6 +4,8 @@ kind: Database
 metadata:
   name: neutron
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -18,6 +20,8 @@ kind: User
 metadata:
   name: neutron
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -36,6 +40,8 @@ kind: Grant
 metadata:
   name: neutron-grant
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   mariaDbRef:
     name: mariadb-galera

--- a/kustomize/neutron/base/neutron-rabbitmq-queue.yaml
+++ b/kustomize/neutron/base/neutron-rabbitmq-queue.yaml
@@ -4,6 +4,8 @@ kind: User
 metadata:
   name: neutron
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   tags:
   - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
@@ -19,6 +21,8 @@ kind: Vhost
 metadata:
   name: neutron-vhost
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   name: "neutron" # vhost name; required and cannot be updated
   defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
@@ -38,6 +42,8 @@ kind: Queue
 metadata:
   name: neutron-queue
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   name: neutron-qq # name of the queue
   vhost: "neutron" # default to '/' if not provided
@@ -53,6 +59,8 @@ kind: Permission
 metadata:
   name: neutron-permission
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   vhost: "neutron" # name of a vhost
   userReference:

--- a/kustomize/nova/base/nova-mariadb-database.yaml
+++ b/kustomize/nova/base/nova-mariadb-database.yaml
@@ -4,6 +4,8 @@ kind: Database
 metadata:
   name: nova
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -18,6 +20,8 @@ kind: Database
 metadata:
   name: nova-api
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -33,6 +37,8 @@ kind: Database
 metadata:
   name: nova-cell0
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -48,6 +54,8 @@ kind: User
 metadata:
   name: nova
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -66,6 +74,8 @@ kind: Grant
 metadata:
   name: nova-grant
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   mariaDbRef:
     name: mariadb-galera
@@ -83,6 +93,8 @@ kind: Grant
 metadata:
   name: nova-api-grant
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   mariaDbRef:
     name: mariadb-galera
@@ -100,6 +112,8 @@ kind: Grant
 metadata:
   name: nova-cell0-grant
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   mariaDbRef:
     name: mariadb-galera

--- a/kustomize/nova/base/nova-rabbitmq-queue.yaml
+++ b/kustomize/nova/base/nova-rabbitmq-queue.yaml
@@ -4,6 +4,8 @@ kind: User
 metadata:
   name: nova
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   tags:
   - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
@@ -19,6 +21,8 @@ kind: Vhost
 metadata:
   name: nova-vhost
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   name: "nova" # vhost name; required and cannot be updated
   defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
@@ -38,6 +42,8 @@ kind: Queue
 metadata:
   name: nova-queue
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   name: nova-qq # name of the queue
   vhost: "nova" # default to '/' if not provided
@@ -53,6 +59,8 @@ kind: Permission
 metadata:
   name: nova-permission
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   vhost: "nova" # name of a vhost
   userReference:

--- a/kustomize/octavia/base/octavia-agent.yaml
+++ b/kustomize/octavia/base/octavia-agent.yaml
@@ -81,7 +81,7 @@ spec:
             - name: PATH
               value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/
             - name: DEPENDENCY_SERVICE
-              value: "openstack:mariadb-galera-primary,openstack:keystone-api,openstack:rabbitmq-nodes,openstack:memcached,openstack:neutron-server"
+              value: "openstack:maxscale-galera,openstack:keystone-api,openstack:rabbitmq-nodes,openstack:memcached,openstack:neutron-server"
             - name: DEPENDENCY_JOBS
               value: "octavia-db-sync,octavia-ks-user,octavia-ks-endpoints"
             - name: DEPENDENCY_DAEMONSET

--- a/kustomize/octavia/base/octavia-mariadb-database.yaml
+++ b/kustomize/octavia/base/octavia-mariadb-database.yaml
@@ -4,6 +4,8 @@ kind: Database
 metadata:
   name: octavia
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -18,6 +20,8 @@ kind: User
 metadata:
   name: octavia
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -36,6 +40,8 @@ kind: Grant
 metadata:
   name: octavia-grant
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   mariaDbRef:
     name: mariadb-galera

--- a/kustomize/octavia/base/octavia-rabbitmq-queue.yaml
+++ b/kustomize/octavia/base/octavia-rabbitmq-queue.yaml
@@ -4,6 +4,8 @@ kind: User
 metadata:
   name: octavia
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   tags:
   - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
@@ -19,6 +21,8 @@ kind: Vhost
 metadata:
   name: octavia-vhost
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   name: "octavia" # vhost name; required and cannot be updated
   defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
@@ -38,6 +42,8 @@ kind: Queue
 metadata:
   name: octavia-queue
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   name: octavia-qq # name of the queue
   vhost: "octavia" # default to '/' if not provided
@@ -53,6 +59,8 @@ kind: Permission
 metadata:
   name: octavia-permission
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   vhost: "octavia" # name of a vhost
   userReference:

--- a/kustomize/placement/base/placement-mariadb-database.yaml
+++ b/kustomize/placement/base/placement-mariadb-database.yaml
@@ -4,6 +4,8 @@ kind: Database
 metadata:
   name: placement
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -18,6 +20,8 @@ kind: User
 metadata:
   name: placement
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -36,6 +40,8 @@ kind: Grant
 metadata:
   name: placement-grant
   namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   mariaDbRef:
     name: mariadb-galera


### PR DESCRIPTION
With the release of the mariadb operator v0.25.0 maxscale was introduced to resolve issues with multi-master deployments, enhance scale, and make better use of nodes in the environment. This change creates the maxscale resources and converts our standard deployment systems to use maxscale as the point of ingress.

Specific feature we're interested in

> point to an existing MaxScale instance. Doing this will delegate tasks
  such as primary failover to MaxScale.

Docs: https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/MAXSCALE.md
Related: https://github.com/mariadb-operator/mariadb-operator/releases/tag/v0.0.26