### PR TITLE
Adds gateway to expose internal services

### DIFF
--- a/.github/workflows/kustomize-gateway-api.yaml
+++ b/.github/workflows/kustomize-gateway-api.yaml
@@ -1,0 +1,33 @@
+name: Kustomize GitHub Actions for Gateway API
+
+on:
+  pull_request:
+    paths:
+      - kustomize/gateway/**
+      - .github/workflows/kustomize-gateway-api.yaml
+jobs:
+  kustomize:
+    name: Kustomize
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: azure/setup-helm@v3
+        with:
+          version: latest
+          token: "${{ secrets.GITHUB_TOKEN }}"
+        id: helm
+      - name: Kustomize Install
+        working-directory: /usr/local/bin/
+        run: |
+          if [ ! -f /usr/local/bin/kustomize ]; then
+            curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | sudo bash
+          fi
+      - name: Run Kustomize Build
+        run: |
+          kustomize build kustomize/gateway/ --enable-helm --helm-command ${{ steps.helm.outputs.helm-path }} > /tmp/rendered.yaml
+      - name: Return Kustomize Build
+        uses: actions/upload-artifact@v2
+        with:
+          name: kustomize-gateway-artifact
+          path: /tmp/rendered.yaml

--- a/kustomize/gateway/alertmanager-routes.yaml
+++ b/kustomize/gateway/alertmanager-routes.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: alertmanger-gateway-route
+  namespace: prometheus
+spec:
+  parentRefs:
+  - name: flex-gateway
+    sectionName: http
+    namespace: nginx-gateway
+  hostnames:
+  - "alertmanager.sjc.ohthree.com"
+  rules:
+    - backendRefs:
+      - name: kube-prometheus-stack-alertmanager
+        port: 9093

--- a/kustomize/gateway/internal-gateway-api.yaml
+++ b/kustomize/gateway/internal-gateway-api.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: flex-gateway
+  namespace: nginx-gateway
+spec:
+  gatewayClassName: nginx
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+    hostname: "*.sjc.ohthree.com"
+    allowedRoutes:
+      namespaces:
+        from: All

--- a/kustomize/gateway/kustomization.yaml
+++ b/kustomize/gateway/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - internal-gateway-api.yaml # namespace: nginx-gateway (common gateway)
+  - alertmanager-routes.yaml  # namespace: prometheus
+  - prometheus-routes.yaml    # namespace: prometheus

--- a/kustomize/gateway/prometheus-routes.yaml
+++ b/kustomize/gateway/prometheus-routes.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: prometheus-gateway-route
+  namespace: prometheus
+spec:
+  parentRefs:
+  - name: flex-gateway
+    sectionName: http
+    namespace: nginx-gateway
+  hostnames:
+  - "prometheus.sjc.ohthree.com"
+  rules:
+    - backendRefs:
+      - name: kube-prometheus-stack-prometheus
+        port: 9090


### PR DESCRIPTION
This patch adds the common gateway (flex-gateway) in nginx-gateway namespace. This gateway will be shared by all other namespaces to expose services internally. To do so the service that is getting exposed internally simply need to follow the fqdn naming of *.sjc.ohthree.com and ref the flex-gateway.

Also, adding the http routes for prometheus and alertmanager that use the above method to expose the two services internally.