### PR TITLE
Specify the skyline image for the installation

### DIFF
--- a/kustomize/skyline/base/deployment-apiserver.yaml
+++ b/kustomize/skyline/base/deployment-apiserver.yaml
@@ -293,7 +293,7 @@ spec:
                 name: skyline-apiserver-secrets
                 key: default-region
         - name: skyline-apiserver-db-migrate
-          image: "docker.io/99cloud/skyline:latest"
+          image: "docker.io/99cloud/skyline::2023.1"
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -316,7 +316,7 @@ spec:
               readOnly: true
       containers:
         - name: skyline-apiserver
-          image: "docker.io/99cloud/skyline:latest"
+          image: "docker.io/99cloud/skyline:2023.1"
           imagePullPolicy: IfNotPresent
           resources:
             limits:


### PR DESCRIPTION
Skyline fails with latest image[1]. This commit specifies the image to use for the installation

closes #OSPC-363


[1]

```
(genestack) root@openstack-flex-prat4036-launcher:~# kubectl logs skyline-846c7448b-mntwj -n openstack  -c skyline-apiserver-db-migrate
+ alembic -c /skyline-apiserver/skyline_apiserver/db/alembic/alembic.ini upgrade head
FAILED: No config file '/skyline-apiserver/skyline_apiserver/db/alembic/alembic.ini' found, or file has no '[alembic]' section
```