### PR TITLE
Skyline fix for dbsync

### DIFF
--- a/kustomize/skyline/base/deployment-apiserver.yaml
+++ b/kustomize/skyline/base/deployment-apiserver.yaml
@@ -293,7 +293,7 @@ spec:
                 name: skyline-apiserver-secrets
                 key: default-region
         - name: skyline-apiserver-db-migrate
-          image: "docker.io/99cloud/skyline:latest"
+          image: "docker.io/99cloud/skyline:2023.1"
           imagePullPolicy: IfNotPresent
           resources:
             requests:


### PR DESCRIPTION
They broke something in latest that prevents skyline from doing a db-sync. If you roll back the image to tag 2023.1 it works again.