### PR TITLE
fix: Remove product assumption when running the deployment

### DIFF
--- a/scripts/genestack.rc
+++ b/scripts/genestack.rc
@@ -13,8 +13,15 @@ export USER_COLLECTION_FILE=${USER_COLLECTION_FILE:-"$(readlink -f ${BASEDIR}/us
 test -f "${GENESTACK_CONFIG}/provider" 2>/dev/null && export K8S_PROVIDER=$(head -n1 ${GENESTACK_CONFIG}/provider)
 export K8S_PROVIDER="${K8S_PROVIDER:-kubespray}"
 
-test -f "${GENESTACK_CONFIG}/product" 2>/dev/null && export GENESTACK_PRODUCT=$(head -n1 ${GENESTACK_CONFIG}/product)
-export GENESTACK_PRODUCT=${GENESTACK_PRODUCT:-openstack-enterprise}
+if [[ -f "${GENESTACK_CONFIG}/product" ]]; then
+  export GENESTACK_PRODUCT=$(head -n1 ${GENESTACK_CONFIG}/product) 
+elif [[ -z "${GENESTACK_PRODUCT}" ]]; then
+  export GENESTACK_PRODUCT="${GENESTACK_PRODUCT}"
+else 
+  echo -e "No GENESTACK_PRODUCT defined"
+  echo -e "Define the environment variable GENESTACK_PRODUCT to continue."
+  exit 99
+fi
 
 # Export OSH variables
 export CONTAINER_DISTRO_NAME=ubuntu

--- a/scripts/genestack.rc
+++ b/scripts/genestack.rc
@@ -17,7 +17,7 @@ if [[ -f "${GENESTACK_CONFIG}/product" ]]; then
   export GENESTACK_PRODUCT=$(head -n1 ${GENESTACK_CONFIG}/product) 
 elif [[ -z "${GENESTACK_PRODUCT}" ]]; then
   export GENESTACK_PRODUCT="${GENESTACK_PRODUCT}"
-else 
+else
   echo -e "No GENESTACK_PRODUCT defined"
   echo -e "Define the environment variable GENESTACK_PRODUCT to continue."
   exit 99

--- a/scripts/genestack.rc
+++ b/scripts/genestack.rc
@@ -14,7 +14,7 @@ test -f "${GENESTACK_CONFIG}/provider" 2>/dev/null && export K8S_PROVIDER=$(head
 export K8S_PROVIDER="${K8S_PROVIDER:-kubespray}"
 
 if [[ -f "${GENESTACK_CONFIG}/product" ]]; then
-  export GENESTACK_PRODUCT=$(head -n1 ${GENESTACK_CONFIG}/product) 
+  export GENESTACK_PRODUCT=$(head -n1 ${GENESTACK_CONFIG}/product)
 elif [[ -z "${GENESTACK_PRODUCT}" ]]; then
   export GENESTACK_PRODUCT="${GENESTACK_PRODUCT}"
 else


### PR DESCRIPTION
This change will assert that the product is defined and in the event that the product is missing the RC file will raise an error instead of allowing the process to continue with an assumed product option.