### PR TITLE
fix: update skyline to 2023.2 and ensure consistent images

### DIFF
--- a/kustomize/skyline/base/deployment-apiserver.yaml
+++ b/kustomize/skyline/base/deployment-apiserver.yaml
@@ -293,7 +293,7 @@ spec:
                 name: skyline-apiserver-secrets
                 key: default-region
         - name: skyline-apiserver-db-migrate
-          image: "docker.io/99cloud/skyline:2023.1"
+          image: "docker.io/99cloud/skyline:2023.2"
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -316,11 +316,9 @@ spec:
               readOnly: true
       containers:
         - name: skyline-apiserver
-          image: "docker.io/99cloud/skyline:latest"
+          image: "docker.io/99cloud/skyline:2023.2"
           imagePullPolicy: IfNotPresent
           resources:
-            limits:
-              memory: "1Gi"
             requests:
               cpu: "0.25"
               memory: "64Mi"


### PR DESCRIPTION
This change updates our use of skyline to use 2023.2 which has several fixes that improve qol. We've made the  init and api servers use the same image which is better for consistency and removes potential issues between the versions. This change removes the limits, which should let the service perform better for longer.