### PR TITLE
fix: limit ingress worker processes

### DIFF
--- a/docs/infrastructure-ingress.md
+++ b/docs/infrastructure-ingress.md
@@ -19,3 +19,17 @@ kubectl kustomize --enable-helm /opt/genestack/kustomize/ingress/internal | kube
 ```
 
 The openstack ingress controller uses the class name `nginx-openstack`.
+
+#### Patching the ingress ConfigMap
+
+Sometimes you may need to make an update to your ingress setup which is managed in the ConfigMaps.
+
+!!! example "Patching the worker processes"
+
+    ``` shell
+    kubectl -n ${NAMESPACE} patch configmaps ingress-conf -p '{"data": {"worker-processes": "8"}}'
+    ```
+
+!!! note
+
+    If you make a system level change in the ConfigMap you will need to recreate the pods.

--- a/kustomize/ingress/external/helm/ingress-helm-overrides.yaml
+++ b/kustomize/ingress/external/helm/ingress-helm-overrides.yaml
@@ -306,6 +306,7 @@ conf:
     enable-vts-status: "true"
     server-tokens: "false"
     ssl-dh-param: openstack/secret-dhparam
+    worker-processes: "4"
   # This block sets the --default-ssl-certificate option
   # https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-ssl-certificate
   default_ssl_certificate:

--- a/kustomize/ingress/grafana/helm/ingress-helm-overrides.yaml
+++ b/kustomize/ingress/grafana/helm/ingress-helm-overrides.yaml
@@ -306,6 +306,7 @@ conf:
     enable-vts-status: "true"
     server-tokens: "false"
     ssl-dh-param: openstack/secret-dhparam
+    worker-processes: "4"
   # This block sets the --default-ssl-certificate option
   # https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-ssl-certificate
   default_ssl_certificate:

--- a/kustomize/ingress/internal/helm/ingress-helm-overrides.yaml
+++ b/kustomize/ingress/internal/helm/ingress-helm-overrides.yaml
@@ -306,6 +306,7 @@ conf:
     enable-vts-status: "true"
     server-tokens: "false"
     ssl-dh-param: openstack/secret-dhparam
+    worker-processes: "4"
   # This block sets the --default-ssl-certificate option
   # https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-ssl-certificate
   default_ssl_certificate:


### PR DESCRIPTION
This change updates our worker process so that it has a base value of 4. The worker processes used to be "auto" which would create 1 process per core on the node. On production hardware this would result in at least 64 process and 32 threads per porc, totally 2048 threads. This change is simply enforcing a sane limit, and documenting how we can patch a new value into our environment when it's required.