### PR TITLE
Enables rabbitmq anti affinity rule

### DIFF
--- a/kustomize/rabbitmq-cluster/base/rabbitmq-cluster.yaml
+++ b/kustomize/rabbitmq-cluster/base/rabbitmq-cluster.yaml
@@ -38,15 +38,15 @@ spec:
                 operator: In
                 values:
                   - worker
-    # podAntiAffinity:
-    #   requiredDuringSchedulingIgnoredDuringExecution:
-    #   - labelSelector:
-    #       matchExpressions:
-    #         - key: app.kubernetes.io/name
-    #           operator: In
-    #           values:
-    #           - rabbitmq
-    #     topologyKey: kubernetes.io/hostname
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - rabbitmq
+        topologyKey: kubernetes.io/hostname
   override:
     service:
       spec:


### PR DESCRIPTION
We need the pods to not land on the same host
during scheduling. This enables the antiaffinity
rule to make sure that pods always land on different hosts.

JIRA: OSPC-389