### PR TITLE
Change Rabbitmq storage to 20g

### DIFF
--- a/kustomize/rabbitmq-cluster/base/rabbitmq-cluster.yaml
+++ b/kustomize/rabbitmq-cluster/base/rabbitmq-cluster.yaml
@@ -27,8 +27,8 @@ spec:
       - rabbitmq_web_mqtt
       - rabbitmq_web_stomp
   persistence:
-    storageClassName: general  # This should be changed to an ssd for production
-    storage: "5Gi"  # This should be changed to 500Gi for production
+    storageClassName: general
+    storage: "20Gi"
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Since we are using persistent messages, we need bigger storage to ensure that in times of high volume messages we have enough storage to handle it.