### PR TITLE
Ensures memory request and limit is same for rabbitmq

### DIFF
--- a/kustomize/rabbitmq-cluster/aio/kustomization.yaml
+++ b/kustomize/rabbitmq-cluster/aio/kustomization.yaml
@@ -9,3 +9,13 @@ patches:
       - op: replace
         path: /spec/replicas
         value: 1
+  - target:
+      kind: RabbitmqCluster
+      name: rabbitmq
+    patch: |-
+      - op: replace
+        path: /spec/resources/requests/memory
+        value: 2Gi
+      - op: replace
+        path: /spec/resources/limits/memory
+        value: 2Gi

--- a/kustomize/rabbitmq-cluster/base/rabbitmq-cluster.yaml
+++ b/kustomize/rabbitmq-cluster/base/rabbitmq-cluster.yaml
@@ -11,9 +11,9 @@ spec:
   resources:
     requests:
       cpu: 500m
-      memory: 1Gi
+      memory: 32Gi
     limits:
-      memory: 16Gi  # This should be changed to 10Gi for production
+      memory: 32Gi
   rabbitmq:
     additionalConfig: |
       cluster_partition_handling = pause_minority


### PR DESCRIPTION
The rabbitmq operator has recommendation that the memory request and limit be the same. This patch ensures that we request 10G memory and also have a 10G limit.