### PR TITLE
SET fs.inotify.max_user_instances=8192 instead of default 128

### DIFF
--- a/ansible/roles/host_setup/defaults/main.yml
+++ b/ansible/roles/host_setup/defaults/main.yml
@@ -50,6 +50,7 @@ host_nf_conntrack_max: 262144
 
 # System control kernel tuning
 kernel_options:
+  - { key: 'fs.inotify.max_user_instances', value: 8192 }
   - { key: 'fs.inotify.max_user_watches', value: 1048576 }
   - { key: 'net.ipv4.conf.all.rp_filter', value: "{{ host_rp_filter_all }}" }
   - { key: 'net.ipv4.conf.default.rp_filter', value: "{{ host_rp_filter_default }}" }


### PR DESCRIPTION
This alleviates the inotify errors seen on many nodes in a K8s cluster when there are too many open files.
fs.inotify.max_user_instances works in conjunction with fs.inotify.max_user_watches. We have already updated the default for fs.inotify.max_user_watches

Example error without updating fs.inotify.max_user_instances:

systemctl restart systemd-resolved.service 
Failed to allocate directory watch: Too many open files