### PR TITLE
fix: add charts to our git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ kubernetes_sigs-kubespray*tar.gz
 ansible_collections
 
 kustomize/**/all.yaml
+kustomize/**/charts
 
 # mkdocs
 site/


### PR DESCRIPTION
within kustomize, the charts directory is auto-generated when a chart is created. this change ignores charts from the dir so that we're not attempting to track the generated charts from within a deployment.