### PR TITLE
Specify version of loki helm chart

### DIFF
--- a/docs/infrastructure-loki.md
+++ b/docs/infrastructure-loki.md
@@ -16,7 +16,8 @@ helm upgrade --install \
              --values my-loki-helm-overrides.yaml \
              loki grafana/loki \
              --create-namespace \
-             --namespace grafana
+             --namespace grafana \
+             --version 5.47.2
 ```
 
 !!! example


### PR DESCRIPTION
Grafana has updated loki software and helm charts and is incompatible with current configuration examples.  Documenting the version of the loki helm chart to install.