### PR TITLE
fix: Add podAntiAffinity rule for maria pods

### DIFF
--- a/kustomize/mariadb-cluster/base/mariadb-galera.yaml
+++ b/kustomize/mariadb-cluster/base/mariadb-galera.yaml
@@ -102,6 +102,15 @@ spec:
                 operator: In
                 values:
                   - worker
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+              - key: app.kubernetes.io/instance
+                operator: In
+                values:
+                - mariadb-galera
+        topologyKey: kubernetes.io/hostname
 
   tolerations:
     - key: "k8s.mariadb.com/ha"

--- a/kustomize/mariadb-cluster/base/mariadb-maxscale.yaml
+++ b/kustomize/mariadb-cluster/base/mariadb-maxscale.yaml
@@ -148,6 +148,15 @@ spec:
                 operator: In
                 values:
                   - worker
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+              - key: app.kubernetes.io/instance
+                operator: In
+                values:
+                - maxscale-galera
+        topologyKey: kubernetes.io/hostname
 
   tolerations:
     - key: "k8s.mariadb.com/ha"


### PR DESCRIPTION
AntiAffinity is enabled but the rule does not get set on the statefulsets as expected. Adding the rule manually to prevent the maria pods from coming up on the same node(s).

Possibly fixed upstream in an upcoming release:
 - [f86606162be96e7a36015037491c07747042efcf](https://github.com/mariadb-operator/mariadb-operator/commit/f86606162be96e7a36015037491c07747042efcf)