### PR TITLE
Doc improvements

### DIFF
--- a/docs/k8s-kubespray.md
+++ b/docs/k8s-kubespray.md
@@ -57,6 +57,7 @@ Before running the Kubernetes deployment, make sure that all hosts have a proper
 ``` shell
 source /opt/genestack/scripts/genestack.rc
 ansible -m shell -a 'hostnamectl set-hostname {{ inventory_hostname }}' --become all
+ansible -m shell -a "grep 127.0.0.1 /etc/hosts | grep -q {{ inventory_hostname }} || sed -i '/^127.0.0.1/ s/$/ {{ inventory_hostname }}/' /etc/hosts" --become all
 ```
 
 !!! note


### PR DESCRIPTION
Without adding the hostname to /etc/hosts, we introduce slowness during privlege escalation (due to a DNS timeout). This additional command idempotently adds the hostname to /etc/hosts at the end of the line beginning with 127.0.0.1.