### PR TITLE
feat: add oslo db dependency into nova-efi

### DIFF
--- a/.github/workflows/release-nova-uefi.yml
+++ b/.github/workflows/release-nova-uefi.yml
@@ -14,6 +14,15 @@ on:
           - master-ubuntu_jammy
           - 2023.1-ubuntu_jammy
           - 2023.2-ubuntu_jammy
+      pluginTag:
+        description: 'Set release used for the build environment'
+        required: true
+        default: 'master'
+        type: choice
+        options:
+          - "master"
+          - "2023.1"
+          - "2023.2"
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
@@ -61,3 +70,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ github.event.inputs.imageTag }}
+            PLUGIN_VERSION=${{ github.event.inputs.pluginTag }}

--- a/.github/workflows/smoke-nova-uefi.yml
+++ b/.github/workflows/smoke-nova-uefi.yml
@@ -39,3 +39,4 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/nova-efi:master-ubuntu_jammy
           build-args: |
             VERSION=master-ubuntu_jammy
+            PLUGIN_VERSION=master

--- a/Containerfiles/NovaEFI-Containerfile
+++ b/Containerfiles/NovaEFI-Containerfile
@@ -1,5 +1,14 @@
 ARG VERSION=master-ubuntu_jammy
-FROM openstackhelm/nova:$VERSION
+FROM openstackhelm/nova:$VERSION as build
+ARG PLUGIN_VERSION=master
+RUN apt update && apt install -y git
+RUN export ORIG_PLUGIN_VERSION="${PLUGIN_VERSION}"; \
+if [ "${PLUGIN_VERSION}" != 'master' ]; then export PLUGIN_VERSION=stable/${PLUGIN_VERSION}; fi; \
+. /var/lib/openstack/bin/activate; \
+/var/lib/openstack/bin/pip install git+https://github.com/openstack/oslo.db@${PLUGIN_VERSION}#egg=oslo_db
+
+FROM openstackhelm/nova:${VERSION}
+COPY --from=build /var/lib/openstack/. /var/lib/openstack/
 # Packages for the following features:
 # - Nova: EFI
 # - Nova: iSCSI


### PR DESCRIPTION
Fix resolve issues with oslo-db by building in the supported
release of oslo db using the branch instead of the assumed
package release.

Related-Fix: https://github.com/openstack/oslo.db/commit/be0515daa260811ad77b5eb5b78670c77eda2df6
Co-Authored-By Luke Repko <luke.repko@rackspace.com>
Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>