### PR TITLE
Enable servicemonitor in fluentbit helm config

### DIFF
--- a/helm-configs/fluentbit/fluentbit-helm-overrides.yaml
+++ b/helm-configs/fluentbit/fluentbit-helm-overrides.yaml
@@ -24,6 +24,13 @@ daemonSetVolumeMounts:
   - name: varlogcontainers
     mountPath: /var/log/containers
     readOnly: true
+serviceMonitor:
+  enabled: true
+  namespace: default
+  interval: 10s
+  scrapeTimeout: 10s
+  selector:
+    application: fluentbit-fluent-bit
 config:
   outputs: |
     [OUTPUT]


### PR DESCRIPTION
This enables the fluentbit service monitor fluentbit metrics in prometheus