### PR TITLE
feat: enable nova-ssh and tweak daemonsets

### DIFF
--- a/helm-configs/nova/nova-helm-overrides.yaml
+++ b/helm-configs/nova/nova-helm-overrides.yaml
@@ -1468,6 +1468,7 @@ conf:
     loggers:
       keys:
         - root
+        - oslo.db
         - nova
         - os.brick
     handlers:
@@ -1487,6 +1488,11 @@ conf:
       handlers:
         - stdout
       qualname: nova
+    logger_oslo.db:
+      level: DEBUG
+      handlers:
+        - stdout
+      qualname: oslo_db.api
     logger_os.brick:
       level: INFO
       handlers:

--- a/helm-configs/nova/nova-helm-overrides.yaml
+++ b/helm-configs/nova/nova-helm-overrides.yaml
@@ -2330,7 +2330,7 @@ pod:
         compute:
           enabled: true
           min_ready_seconds: 0
-          max_unavailable: 1
+          max_unavailable: 20%
     disruption_budget:
       metadata:
         min_available: 0

--- a/helm-configs/nova/nova-helm-overrides.yaml
+++ b/helm-configs/nova/nova-helm-overrides.yaml
@@ -256,7 +256,7 @@ network:
       enabled: false
       port: 30682
   ssh:
-    enabled: false
+    enabled: true
     port: 8022
     from_subnet: 0.0.0.0/0
     key_types:

--- a/kustomize/libvirt/helm/libvirt-helm-overrides.yaml
+++ b/kustomize/libvirt/helm/libvirt-helm-overrides.yaml
@@ -94,7 +94,7 @@ conf:
     cert_file: "/etc/pki/libvirt/servercert.pem"
     key_file: "/etc/pki/libvirt/private/serverkey.pem"
     auth_unix_rw: "none"
-    listen_addr: 127.0.0.1
+    listen_addr: 0.0.0.0
     log_level: "3"
     log_outputs: "1:file:/var/log/libvirt/libvirtd.log"
   qemu:

--- a/kustomize/libvirt/helm/libvirt-helm-overrides.yaml
+++ b/kustomize/libvirt/helm/libvirt-helm-overrides.yaml
@@ -222,7 +222,7 @@ pod:
         libvirt:
           enabled: true
           min_ready_seconds: 0
-          max_unavailable: 1
+          max_unavailable: 20%
   resources:
     enabled: false
     libvirt:


### PR DESCRIPTION
This is to enable ssh for nova compute pods to support migrations. Creating an ed25519 keypair for security and performance. Also a tweak to the daemonsets nova-compute-default and libvirt daemonsets is being made to set max_unavailable to a sane percentage of nodes in lieu of just 1 which may result in deployment times far exceeding the default timeout value in large environments.