### PR TITLE
Enable resource limits on pods

### DIFF
--- a/helm-configs/cinder/cinder-helm-overrides.yaml
+++ b/helm-configs/cinder/cinder-helm-overrides.yaml
@@ -228,7 +228,7 @@ jobs:
       api:
         timeout: 30
   resources:
-    enabled: false
+    enabled: true
     api:
       requests:
         memory: "64Mi"

--- a/helm-configs/glance/glance-helm-overrides.yaml
+++ b/helm-configs/glance/glance-helm-overrides.yaml
@@ -865,7 +865,7 @@ pod:
             periodSeconds: 15
             timeoutSeconds: 10
   resources:
-    enabled: false
+    enabled: true
     api:
       requests:
         memory: "64Mi"

--- a/helm-configs/gnocchi/gnocchi-helm-overrides.yaml
+++ b/helm-configs/gnocchi/gnocchi-helm-overrides.yaml
@@ -260,7 +260,7 @@ pod:
       api:
         timeout: 30
   resources:
-    enabled: false
+    enabled: true
     api:
       requests:
         memory: "124Mi"

--- a/helm-configs/heat/heat-helm-overrides.yaml
+++ b/helm-configs/heat/heat-helm-overrides.yaml
@@ -1084,7 +1084,7 @@ pod:
       engine:
         timeout: 30
   resources:
-    enabled: false
+    enabled: true
     api:
       requests:
         memory: "64Mi"

--- a/helm-configs/horizon/horizon-helm-overrides.yaml
+++ b/helm-configs/horizon/horizon-helm-overrides.yaml
@@ -7078,7 +7078,7 @@ pod:
       horizon:
         timeout: 30
   resources:
-    enabled: false
+    enabled: true
     server:
       requests:
         memory: "64Mi"

--- a/helm-configs/keystone/keystone-helm-overrides.yaml
+++ b/helm-configs/keystone/keystone-helm-overrides.yaml
@@ -283,7 +283,7 @@ pod:
       api:
         timeout: 30
   resources:
-    enabled: false
+    enabled: true
     api:
       requests:
         memory: "64Mi"

--- a/helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/helm-configs/neutron/neutron-helm-overrides.yaml
@@ -741,7 +741,7 @@ pod:
       ironic_agent:
         timeout: 30
   resources:
-    enabled: false
+    enabled: true
     agent:
       dhcp:
         requests:

--- a/helm-configs/nova/nova-helm-overrides.yaml
+++ b/helm-configs/nova/nova-helm-overrides.yaml
@@ -2342,7 +2342,7 @@ pod:
       osapi:
         timeout: 30
   resources:
-    enabled: false
+    enabled: true
     compute:
       requests:
         memory: "128Mi"

--- a/helm-configs/octavia/octavia-helm-overrides.yaml
+++ b/helm-configs/octavia/octavia-helm-overrides.yaml
@@ -623,7 +623,7 @@ pod:
       api:
         timeout: 30
   resources:
-    enabled: false
+    enabled: true
     api:
       requests:
         memory: "64Mi"

--- a/helm-configs/placement/placement-helm-overrides.yaml
+++ b/helm-configs/placement/placement-helm-overrides.yaml
@@ -332,7 +332,7 @@ pod:
       api:
         timeout: 30
   resources:
-    enabled: false
+    enabled: true
     api:
       requests:
         memory: "64Mi"


### PR DESCRIPTION
We have been running without setting resource limits, which can cause all sorts of problem. This patch simply enabled the default resource limits set by the charts.

There might be need for further tuning of limits.