### PR TITLE
Update mariadb-galera.yaml

### DIFF
--- a/kustomize/mariadb-cluster/base/mariadb-galera.yaml
+++ b/kustomize/mariadb-cluster/base/mariadb-galera.yaml
@@ -24,7 +24,7 @@ spec:
           storage: 10Gi
       storageClassName: general
 
-  replicas: 5
+  replicas: 3
   podSecurityContext:
     runAsUser: 0
 


### PR DESCRIPTION
Looks like we may have let a config bleed over to the repo. I don't think we need to have 5 replicas as a default.