### PR TITLE
Added patch for oslo_db to nova and neutron

### DIFF
--- a/.github/workflows/release-neutron-oslodb.yaml
+++ b/.github/workflows/release-neutron-oslodb.yaml
@@ -1,0 +1,73 @@
+#
+name: Create and publish a the Neutron oslodb patched image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  workflow_dispatch:
+    inputs:
+      imageTag:
+        description: 'Set tag for the image'
+        required: true
+        default: 'master-ubuntu_jammy'
+        type: choice
+        options:
+          - master-ubuntu_jammy
+          - 2023.1-ubuntu_jammy
+          - 2023.2-ubuntu_jammy
+      pluginTag:
+        description: 'Set release used for the build environment'
+        required: true
+        default: 'master'
+        type: choice
+        options:
+          - "master"
+          - "2023.1"
+          - "2023.2"
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Dynamically set MY_DATE environment variable
+        run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          file: Containerfiles/Neutron-oslo_db-Containerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/neutron-oslodb:${{ github.event.inputs.imageTag }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/neutron-oslodb:${{ github.event.inputs.imageTag }}-${{ env.MY_DATE }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.event.inputs.imageTag }}
+            PLUGIN_VERSION=${{ github.event.inputs.pluginTag }}

--- a/.github/workflows/release-nova-oslodb.yaml
+++ b/.github/workflows/release-nova-oslodb.yaml
@@ -1,0 +1,73 @@
+#
+name: Create and publish a the Nova oslodb patched image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  workflow_dispatch:
+    inputs:
+      imageTag:
+        description: 'Set tag for the image'
+        required: true
+        default: 'master-ubuntu_jammy'
+        type: choice
+        options:
+          - master-ubuntu_jammy
+          - 2023.1-ubuntu_jammy
+          - 2023.2-ubuntu_jammy
+      pluginTag:
+        description: 'Set release used for the build environment'
+        required: true
+        default: 'master'
+        type: choice
+        options:
+          - "master"
+          - "2023.1"
+          - "2023.2"
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Dynamically set MY_DATE environment variable
+        run: echo "MY_DATE=$(date +%s)" >> $GITHUB_ENV
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          file: Containerfiles/Nova-oslo_db-Containerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/nova-oslodb:${{ github.event.inputs.imageTag }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/nova-oslodb:${{ github.event.inputs.imageTag }}-${{ env.MY_DATE }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.event.inputs.imageTag }}
+            PLUGIN_VERSION=${{ github.event.inputs.pluginTag }}

--- a/Containerfiles/Neutron-oslo_db-Containerfile
+++ b/Containerfiles/Neutron-oslo_db-Containerfile
@@ -1,0 +1,12 @@
+# Patch oslo_db to help with deadlocks
+ARG VERSION=master-ubuntu_jammy
+FROM openstackhelm/neutron:$VERSION as build
+ARG PLUGIN_VERSION=master
+RUN apt update && apt install -y git
+RUN export ORIG_PLUGIN_VERSION="${PLUGIN_VERSION}"; \
+if [ "${PLUGIN_VERSION}" != 'master' ]; then export PLUGIN_VERSION=stable/${PLUGIN_VERSION}; fi; \
+. /var/lib/openstack/bin/activate; \
+/var/lib/openstack/bin/pip install git+https://github.com/openstack/oslo.db@${PLUGIN_VERSION}#egg=oslo_db
+
+FROM openstackhelm/neutron:${VERSION}
+COPY --from=build /var/lib/openstack/. /var/lib/openstack/

--- a/Containerfiles/Nova-oslo_db-Containerfile
+++ b/Containerfiles/Nova-oslo_db-Containerfile
@@ -1,0 +1,12 @@
+# Patch oslo_db to help with deadlocks
+ARG VERSION=master-ubuntu_jammy
+FROM openstackhelm/nova:$VERSION as build
+ARG PLUGIN_VERSION=master
+RUN apt update && apt install -y git
+RUN export ORIG_PLUGIN_VERSION="${PLUGIN_VERSION}"; \
+if [ "${PLUGIN_VERSION}" != 'master' ]; then export PLUGIN_VERSION=stable/${PLUGIN_VERSION}; fi; \
+. /var/lib/openstack/bin/activate; \
+/var/lib/openstack/bin/pip install git+https://github.com/openstack/oslo.db@${PLUGIN_VERSION}#egg=oslo_db
+
+FROM openstackhelm/nova:${VERSION}
+COPY --from=build /var/lib/openstack/. /var/lib/openstack/


### PR DESCRIPTION
The original patch added to nova is only connected to the compute nodes. It also has other patches in it. So I created a new one that only patched oslo_db.