### PR TITLE
Update glance-helm-overrides.yaml

### DIFF
--- a/helm-configs/glance/glance-helm-overrides.yaml
+++ b/helm-configs/glance/glance-helm-overrides.yaml
@@ -17,18 +17,18 @@ release_group: null
 images:
   tags:
     test: docker.io/xrally/xrally-openstack:2.0.0
-    glance_storage_init: docker.io/openstackhelm/ceph-config-helper:latest-ubuntu_xenial
-    glance_metadefs_load: docker.io/openstackhelm/glance:wallaby-ubuntu_focal
-    db_init: docker.io/openstackhelm/heat:wallaby-ubuntu_focal
-    glance_db_sync: docker.io/openstackhelm/glance:wallaby-ubuntu_focal
-    db_drop: docker.io/openstackhelm/heat:wallaby-ubuntu_focal
-    ks_user: docker.io/openstackhelm/heat:wallaby-ubuntu_focal
-    ks_service: docker.io/openstackhelm/heat:wallaby-ubuntu_focal
-    ks_endpoints: docker.io/openstackhelm/heat:wallaby-ubuntu_focal
+    glance_storage_init: docker.io/openstackhelm/ceph-config-helper:latest-ubuntu_jammy
+    glance_metadefs_load: docker.io/openstackhelm/glance:2023.1-ubuntu_jammy
+    db_init: docker.io/openstackhelm/heat:2023.1-ubuntu_jammy
+    glance_db_sync: docker.io/openstackhelm/glance:2023.1-ubuntu_jammy
+    db_drop: docker.io/openstackhelm/heat:2023.1-ubuntu_jammy
+    ks_user: docker.io/openstackhelm/heat:2023.1-ubuntu_jammy
+    ks_service: docker.io/openstackhelm/heat:2023.1-ubuntu_jammy
+    ks_endpoints: docker.io/openstackhelm/heat:2023.1-ubuntu_jammy
     rabbit_init: docker.io/rabbitmq:3.7-management
-    glance_api: docker.io/openstackhelm/glance:wallaby-ubuntu_focal
+    glance_api: docker.io/openstackhelm/glance:2023.1-ubuntu_jammy
     # Bootstrap image requires curl
-    bootstrap: docker.io/openstackhelm/heat:wallaby-ubuntu_focal
+    bootstrap: docker.io/openstackhelm/heat:2023.1-ubuntu_jammy
     dep_check: quay.io/airshipit/kubernetes-entrypoint:v1.0.0
     image_repo_sync: docker.io/docker:17.07.0
   pull_policy: "IfNotPresent"


### PR DESCRIPTION
We probably should not be using wallaby and focal in a 2023.1 jammy environment