### PR TITLE
Fix an example to use letsencrypt for certificate

### DIFF
--- a/docs/infrastructure-letsencrypt.md
+++ b/docs/infrastructure-letsencrypt.md
@@ -32,12 +32,9 @@ EOF
 ## Use the proper TLS issuerRef
 
 !!! danger "Important for later helm installations!"
-    You must ensure your helm configuration is such that you set the
-    `endpoints.$service.host_fqdn_override.public.tls.issuerRef.name` for any
-    given endpoint to use our `letsencrypt-prod` ClusterIssuer. Similarly,
-    ensure that `endpoints.$service.host_fqdn_override.public.host`
-    is set to the external DNS hostname you plan to expose for a given
-    service endpoint.
+    The `letsencrypt-prod` ClusterIssuer is used to generate the certificate through cert-manager. This ClusterIssuer is applied using a Kustomize patch. However, to ensure that the certificate generation process is initiated, it is essential to include `endpoints.$service.host_fqdn_override.public.tls: {}` in the service helm override file.
+    Similarly, ensure that `endpoints.$service.host_fqdn_override.public.host` is set to the external DNS hostname you plan to expose for a given service endpoint.
+    This configuration is necessary for proper certificate generation and to ensure the service is accessible via the specified hostname.
 
 !!! example
     You can find several examples of this in the
@@ -48,11 +45,7 @@ EOF
       image:
         host_fqdn_override:
           public:
-            tls:
-              secretName: glance-tls-api
-              issuerRef:
-                name: letsencrpyt-prod
-                kind: ClusterIssuer
+            tls: {}
             host: glance.api.your.domain.tld
         port:
           api:

--- a/helm-configs/prod-example-openstack-overrides.yaml
+++ b/helm-configs/prod-example-openstack-overrides.yaml
@@ -103,11 +103,7 @@ endpoints:
   compute:
     host_fqdn_override:
       public:
-        tls:
-          secretName: nova-tls-api
-          issuerRef:
-            name: letsencrypt-prod
-            kind: ClusterIssuer
+        tls: {}
         host: nova.dfw-ospcv2-staging.ohthree.com
     port:
       api:
@@ -117,11 +113,7 @@ endpoints:
   compute_metadata:
     host_fqdn_override:
       public:
-        tls:
-          secretName: metadata-tls-metadata
-          issuerRef:
-            name: letsencrypt-prod
-            kind: ClusterIssuer
+        tls: {}
         host: metadata.nova.dfw-ospcv2-staging.ohthree.com
     port:
       metadata:
@@ -131,11 +123,7 @@ endpoints:
   compute_novnc_proxy:
     host_fqdn_override:
       public:
-        tls:
-          secretName: nova-novncproxy-tls-proxy
-          issuerRef:
-            name: letsencrypt-prod
-            kind: ClusterIssuer
+        tls: {}
         host: novnc.nova.dfw-ospcv2-staging.ohthree.com
     port:
       novnc_proxy:
@@ -145,11 +133,7 @@ endpoints:
   cloudformation:
     host_fqdn_override:
       public:
-        tls:
-          secretName: heat-tls-cfn
-          issuerRef:
-            name: letsencrypt-prod
-            kind: ClusterIssuer
+        tls: {}
         host: cloudformation.heat.dfw-ospcv2-staging.ohthree.com
     port:
       api:
@@ -159,11 +143,7 @@ endpoints:
   cloudwatch:
     host_fqdn_override:
       public:
-        tls:
-          secretName: heat-tls-cloudwatch
-          issuerRef:
-            name: letsencrypt-prod
-            kind: ClusterIssuer
+        tls: {}
         host: cloudwatch.heat.dfw-ospcv2-staging.ohthree.com
     port:
       api:
@@ -173,11 +153,7 @@ endpoints:
   dashboard:
     host_fqdn_override:
       public:
-        tls:
-          secretName: horizon-tls-web
-          issuerRef:
-            name: letsencrypt-prod
-            kind: ClusterIssuer
+        tls: {}
         host: dfw-ospcv2-staging.ohthree.com
     port:
       web:
@@ -210,11 +186,7 @@ endpoints:
         region_name: *region
     host_fqdn_override:
       public:
-        tls:
-          secretName: keystone-tls-api
-          issuerRef:
-            name: letsencrypt-prod
-            kind: ClusterIssuer
+        tls: {}
         host: keystone.dfw-ospcv2-staging.ohthree.com
     port:
       api:
@@ -228,11 +200,7 @@ endpoints:
   image:
     host_fqdn_override:
       public:
-        tls:
-          secretName: glance-tls-api
-          issuerRef:
-            name: letsencrypt-prod
-            kind: ClusterIssuer
+        tls: {}
         host: glance.dfw-ospcv2-staging.ohthree.com
     port:
       api:
@@ -242,11 +210,7 @@ endpoints:
   load_balancer:
     host_fqdn_override:
       public:
-        tls:
-          secretName: octavia-tls-api
-          issuerRef:
-            name: letsencrypt-prod
-            kind: ClusterIssuer
+        tls: {}
         host: octavia.dfw-ospcv2-staging.ohthree.com
     port:
       api:
@@ -256,11 +220,7 @@ endpoints:
   network:
     host_fqdn_override:
       public:
-        tls:
-          secretName: neutron-tls-server
-          issuerRef:
-            name: letsencrypt-prod
-            kind: ClusterIssuer
+        tls: {}
         host: neutron.dfw-ospcv2-staging.ohthree.com
     port:
       api:
@@ -270,11 +230,7 @@ endpoints:
   orchestration:
     host_fqdn_override:
       public:
-        tls:
-          secretName: heat-tls-api
-          issuerRef:
-            name: letsencrypt-prod
-            kind: ClusterIssuer
+        tls: {}
         host: heat.dfw-ospcv2-staging.ohthree.com
     port:
       api:
@@ -284,11 +240,7 @@ endpoints:
   placement:
     host_fqdn_override:
       public:
-        tls:
-          secretName: placement-tls-api
-          issuerRef:
-            name: letsencrypt-prod
-            kind: ClusterIssuer
+        tls: {}
         host: placement.dfw-ospcv2-staging.ohthree.com
     port:
       api:
@@ -298,11 +250,7 @@ endpoints:
   volume:
     host_fqdn_override:
       public:
-        tls:
-          secretName: cinder-tls-api
-          issuerRef:
-            name: letsencrypt-prod
-            kind: ClusterIssuer
+        tls: {}
         host: cinder.dfw-ospcv2-staging.ohthree.com
     port:
       api:
@@ -312,11 +260,7 @@ endpoints:
   volumev2:
     host_fqdn_override:
       public:
-        tls:
-          secretName: cinder-tls-api
-          issuerRef:
-            name: letsencrypt-prod
-            kind: ClusterIssuer
+        tls: {}
         host: cinder.dfw-ospcv2-staging.ohthree.com
     port:
       api:
@@ -326,11 +270,7 @@ endpoints:
   volumev3:
     host_fqdn_override:
       public:
-        tls:
-          secretName: cinder-tls-api
-          issuerRef:
-            name: letsencrypt-prod
-            kind: ClusterIssuer
+        tls: {}
         host: cinder.dfw-ospcv2-staging.ohthree.com
     port:
       api:


### PR DESCRIPTION
As we are patching the ingress resource using kustomize, we can skip the details in helm. 