### PR TITLE
DOC: Removed place holder text

### DIFF
--- a/docs/storage-swift-object-store.md
+++ b/docs/storage-swift-object-store.md
@@ -4,12 +4,6 @@
 
 Use the command-line utility `swift` to perform operations on your object store.
 
-## Requirements
-
-!!! note
-
-    FIXME: TBD
-
 ## Swift client documentation
 
 ``` shell


### PR DESCRIPTION
Removed requirements because it said "TBD: FIXME" I have reached out to Derek Moyes on what should be put in there, but I do not think that should be in our public facing docs. 