### PR TITLE
OSPC-498 Specifying ook/ceph:v1.13.7 as the image

### DIFF
--- a/docs/storage-ceph-rook-internal.md
+++ b/docs/storage-ceph-rook-internal.md
@@ -4,7 +4,6 @@
 
 ``` shell
 kubectl apply -k /opt/genestack/kustomize/rook-operator/
-kubectl -n rook-ceph set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.13.7
 ```
 
 ## Deploy the Rook cluster

--- a/kustomize/rook-operator/operator.yaml
+++ b/kustomize/rook-operator/operator.yaml
@@ -581,7 +581,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
         - name: rook-ceph-operator
-          image: rook/ceph:master
+          image: rook/ceph:v1.13.7
           args: ["ceph", "operator"]
           securityContext:
             runAsNonRoot: true


### PR DESCRIPTION
This cleans up the install of the rook operator.