### PR TITLE
Update jinja2 to 3.1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ansible>=6.7.0,<=8.5.0
 cryptography==42.0.4
-jinja2==3.1.2
+jinja2==3.1.4
 jmespath==1.0.1
 MarkupSafe==2.1.3
 netaddr==0.9.0


### PR DESCRIPTION
There is a dependabot alert on jinja2 version.
We need this updated to 3.1.4

Ref: https://github.com/rackerlabs/genestack/security/dependabot/8