### PR TITLE
Switches glance store backend to swift

### DIFF
--- a/helm-configs.example/glance/glance-helm-overrides.yaml
+++ b/helm-configs.example/glance/glance-helm-overrides.yaml
@@ -1,5 +1,5 @@
 # radosgw, rbd, swift or pvc
-storage: pvc  # This should likely be set to swift or rbd in production
+storage: swift  # Use override to switch to pvc in dev env
 
 labels:
   api:
@@ -252,6 +252,10 @@ conf:
       filesystem_store_datadir: /var/lib/glance/images
       default_swift_reference: ref1
       swift_store_container: glance
+      swift_auth_address: https://swift.cluster.local
+      swift_auth_version: 3
+      swift_user: glance:glance-store
+      swift_password: override_from_your_secrets_files
       swift_store_create_container_on_put: true
       swift_store_config_file: /etc/glance/swift-store.conf
       swift_store_endpoint_type: internalURL
@@ -367,6 +371,11 @@ conf:
     auth_address = {{ tuple "ceph_object_store" "public" "api" . | include "helm-toolkit.endpoints.keystone_endpoint_uri_lookup" }}
     user = {{ .Values.endpoints.ceph_object_store.auth.glance.username }}:swift
     key = {{ .Values.endpoints.ceph_object_store.auth.glance.password }}
+    {{- else if eq .Values.storage "swift" }}
+    auth_version = {{ .Values.conf.glance.glance_store.swift_auth_version }}
+    auth_address = {{ .Values.conf.glance.glance_store.swift_auth_address }}
+    user = {{ .Values.conf.glance.glance_store.swift_user }}
+    key = {{ .Values.conf.glance.glance_store.swift_password }}
     {{- else }}
     user = {{ .Values.endpoints.identity.auth.glance.project_name }}:{{ .Values.endpoints.identity.auth.glance.username }}
     key = {{ .Values.endpoints.identity.auth.glance.password }}


### PR DESCRIPTION
This provides the options to move the glance store to swift. We leave the default value to pvc so as
not to break existing deployments accidently. Howerver, providing a override on the helm command to --storage=pvc will deploy a glance with pvc backend.

These values should be overwritten in your region
specific secrets file to ensure no mistake.