### PR TITLE
Switches cpu_model to host-model

### DIFF
--- a/helm-configs.example/nova/nova-helm-overrides.yaml
+++ b/helm-configs.example/nova/nova-helm-overrides.yaml
@@ -1436,7 +1436,7 @@ conf:
       rbd_secret_uuid: 457eb676-33da-42ec-9a8c-9293d545c337
       disk_cachemodes: "network=writeback"
       hw_disk_discard: unmap
-      cpu_mode: host-passthrough
+      cpu_mode: host-model
       volume_use_multipath: false  # Disabled because multipathd is not configured or running
     upgrade_levels:
       compute: auto


### PR DESCRIPTION
Switch cpu_model = host-model which uses the model from libvirt cpu_map that most closly matches the host and requests additional cpu flags to complete the match.

We need this to make live-migration work in rackspace env. For more info on cpu_modes see openstack docs on CPU models.