### PR TITLE
Allows use of environment variable in kustomize.sh

### DIFF
--- a/base-kustomize/kustomize.sh
+++ b/base-kustomize/kustomize.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
-pushd $(dirname "${BASH_SOURCE[0]}") &>/dev/null
-    cat <&0 > ${1}/../base/all.yaml
-    kubectl kustomize --reorder='none' ${1}
+KUSTOMIZE_DIR=${1:-$GENESTACK_KUSTOMIZE_ARG}
+pushd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null
+    cat <&0 > "${KUSTOMIZE_DIR}"/../base/all.yaml
+    kubectl kustomize --reorder='none' "${KUSTOMIZE_DIR}"
 popd &>/dev/null


### PR DESCRIPTION
Uses GENESTACK_KUSTOMIZE_ARG environment variable. Still allows for using a cli argument for kustomize.sh script