### PR TITLE
fix: rename generated secrets file and fix perms

### DIFF
--- a/bin/create-secrets.sh
+++ b/bin/create-secrets.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2086
 
 generate_password() {
     < /dev/urandom tr -dc _A-Za-z0-9 | head -c${1:-32}
@@ -54,7 +55,7 @@ ceilometer_keystone_admin_password=$(generate_password 32)
 ceilometer_keystone_test_password=$(generate_password 32)
 ceilometer_rabbitmq_password=$(generate_password 32)
 
-OUTPUT_FILE="/etc/genestack/secrets.yaml"
+OUTPUT_FILE="/etc/genestack/kubesecrets.yaml"
 
 cat <<EOF > $OUTPUT_FILE
 apiVersion: v1
@@ -490,6 +491,5 @@ data:
 EOF
 
 rm nova_ssh_key nova_ssh_key.pub
-
+chmod 0640 ${OUTPUT_FILE}
 echo "Secrets YAML file created as ${OUTPUT_FILE}"
-

--- a/docs/infrastructure-namespace.md
+++ b/docs/infrastructure-namespace.md
@@ -12,10 +12,10 @@ Then you can create all needed secrets by running the create-secrets.sh command 
 /opt/genestack/bin/create-secrets.sh
 ```
 
-That will create a secrets.yaml file located in /etc/genestack
+That will create a kubesecrets.yaml file located in /etc/genestack
 
 You can then apply them to kubernetes with the following command:
 
 ``` shell
-kubectl apply -f /etc/genestack/secrets.yaml -n openstack
+kubectl apply -f /etc/genestack/kubesecrets.yaml -n openstack
 ```


### PR DESCRIPTION
We already have a secrets.yaml in several regions at this location in the repository we store genestack configurations. To avoid confusion and the possibility of that being overwritten, let's rename this newly added secrets file.

Considering the sensitivty of the secrets therein, let's take away global read perms too.