### PR TITLE
fix: add missing package for debian

### DIFF
--- a/ansible/roles/host_setup/vars/debian.yml
+++ b/ansible/roles/host_setup/vars/debian.yml
@@ -34,9 +34,9 @@ host_kernel_modules:
 ## Bare metal base packages
 _host_distro_packages:
   - acl
-  - apt-utils
   - apparmor-utils
   - apt-transport-https
+  - apt-utils
   - bridge-utils
   - cgroup-tools
   - curl
@@ -48,13 +48,14 @@ _host_distro_packages:
   - irqbalance
   - libkmod2
   - lvm2
+  - nfs-client
   - rsync
   - software-properties-common
   - sysstat
+  - systemd-timesyncd
   - time
   - vlan
   - wget
-  - nfs-client
 
 _hosts_package_list:
   - name: ca-certificates

--- a/ansible/roles/host_setup/vars/ubuntu.yml
+++ b/ansible/roles/host_setup/vars/ubuntu.yml
@@ -34,9 +34,9 @@ host_kernel_modules:
 ## Bare metal base packages
 _host_distro_packages:
   - acl
-  - apt-utils
   - apparmor-utils
   - apt-transport-https
+  - apt-utils
   - bridge-utils
   - cgroup-lite
   - curl
@@ -48,17 +48,16 @@ _host_distro_packages:
   - irqbalance
   - libkmod2
   - lvm2
+  - nfs-client
   - rsync
   - software-properties-common
   - sysstat
   - time
   - vlan
   - wget
-  - nfs-client
 
 _hosts_package_list:
   - name: ubuntu-cloud-keyring
     state: "{{ host_package_state }}"
   - name: ca-certificates
     state: latest
-


### PR DESCRIPTION
Debian needs systemd-timesyncd to be installed by default to support kubespray when deploying with NFS.

> To make it easier to see what packages we have installed the lists
  have been sorted.