### PR TITLE
fix(prometheus): remove node affinity for the alertmanager installation (#439)

### DIFF
--- a/base-kustomize/prometheus/values.yaml
+++ b/base-kustomize/prometheus/values.yaml
@@ -799,15 +799,15 @@ alertmanager:
     ## Assign custom affinity rules to the alertmanager instance
     ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
     ##
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: node-role.kubernetes.io/worker
-                  operator: In
-                  values:
-                    - worker
+    # affinity:
+    #   nodeAffinity:
+    #     requiredDuringSchedulingIgnoredDuringExecution:
+    #       nodeSelectorTerms:
+    #         - matchExpressions:
+    #             - key: node-role.kubernetes.io/worker
+    #               operator: In
+    #               values:
+    #                 - worker
     # nodeAffinity:
     #   requiredDuringSchedulingIgnoredDuringExecution:
     #     nodeSelectorTerms:


### PR DESCRIPTION
Handle Alertmanager installation using `nodeSelector`