### PR TITLE
feat(metering): add hpa config for aio/base overlays

### DIFF
--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -2038,7 +2038,7 @@ pod:
         compute:
           enabled: true
           min_ready_seconds: 0
-          max_unavailable: 1
+          max_unavailable: 20%
   resources:
     enabled: false
     compute:

--- a/base-helm-configs/gnocchi/gnocchi-helm-overrides.yaml
+++ b/base-helm-configs/gnocchi/gnocchi-helm-overrides.yaml
@@ -232,7 +232,7 @@ pod:
       init_container: null
       gnocchi_tests:
   replicas:
-    api: 3
+    api: 1
   lifecycle:
     upgrades:
       deployments:
@@ -246,11 +246,11 @@ pod:
         metricd:
           enabled: true
           min_ready_seconds: 0
-          max_unavailable: 1
+          max_unavailable: 20%
         statsd:
           enabled: true
           min_ready_seconds: 0
-          max_unavailable: 1
+          max_unavailable: 20%
     disruption_budget:
       api:
         min_available: 0

--- a/base-kustomize/ceilometer/aio/kustomization.yaml
+++ b/base-kustomize/ceilometer/aio/kustomization.yaml
@@ -1,0 +1,14 @@
+bases:
+  - ../base
+
+patches:
+  - target:
+      kind: HorizontalPodAutoscaler
+      name: ceilometer-notification
+    patch: |-
+      - op: replace
+        path: /spec/minReplicas
+        value: 1
+      - op: replace
+        path: /spec/maxReplicas
+        value: 1

--- a/base-kustomize/ceilometer/base/hpa-ceilometer-notification.yaml
+++ b/base-kustomize/ceilometer/base/hpa-ceilometer-notification.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: ceilometer-notification
+  namespace: openstack
+spec:
+  maxReplicas: 9
+  minReplicas: 3
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 50
+          type: Utilization
+      type: Resource
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: ceilometer-notification

--- a/base-kustomize/ceilometer/base/kustomization.yaml
+++ b/base-kustomize/ceilometer/base/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - all.yaml
+  - hpa-ceilometer-notification.yaml

--- a/base-kustomize/gnocchi/aio/kustomization.yaml
+++ b/base-kustomize/gnocchi/aio/kustomization.yaml
@@ -1,0 +1,14 @@
+bases:
+  - ../base
+
+patches:
+  - target:
+      kind: HorizontalPodAutoscaler
+      name: gnocchi-api
+    patch: |-
+      - op: replace
+        path: /spec/minReplicas
+        value: 1
+      - op: replace
+        path: /spec/maxReplicas
+        value: 1

--- a/base-kustomize/gnocchi/base/hpa-gnocchi-api.yaml
+++ b/base-kustomize/gnocchi/base/hpa-gnocchi-api.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: gnocchi-api
+  namespace: openstack
+spec:
+  maxReplicas: 9
+  minReplicas: 3
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 50
+          type: Utilization
+      type: Resource
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: gnocchi-api

--- a/base-kustomize/gnocchi/base/kustomization.yaml
+++ b/base-kustomize/gnocchi/base/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
   - gnocchi-temp-keyring.yaml
   - all.yaml
+  - hpa-gnocchi-api.yaml
 
 patches:
   - path: configmap-bin.yaml

--- a/docs/openstack-ceilometer.md
+++ b/docs/openstack-ceilometer.md
@@ -46,7 +46,9 @@ rabbit://glance:$(kubectl --namespace openstack get secret glance-rabbitmq-passw
 rabbit://heat:$(kubectl --namespace openstack get secret heat-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)@rabbitmq.openstack.svc.cluster.local:5672/heat,\
 rabbit://keystone:$(kubectl --namespace openstack get secret keystone-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)@rabbitmq.openstack.svc.cluster.local:5672/keystone,\
 rabbit://neutron:$(kubectl --namespace openstack get secret neutron-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)@rabbitmq.openstack.svc.cluster.local:5672/neutron,\
-rabbit://nova:$(kubectl --namespace openstack get secret nova-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)@rabbitmq.openstack.svc.cluster.local:5672/nova}"
+rabbit://nova:$(kubectl --namespace openstack get secret nova-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)@rabbitmq.openstack.svc.cluster.local:5672/nova}" \
+    --post-renderer /opt/genestack/base-kustomize/kustomize.sh \
+    --post-renderer-args ceilometer/base
 ```
 
 !!! tip


### PR DESCRIPTION
This just adds the hpa configs to ceilometer and gnocchi. I tested each `aio` and `base` overlay in my lab to ensure the desired min replicas were achieved. I also tune the max_unavailable for related daemon-sets from 1 to 20% to speed up helm upgrade/installs.