### PR TITLE
fix: resource-cleaner script was missing "#!/bin/bash"

### DIFF
--- a/base-kustomize/gnocchi/base/configmap-bin.yaml
+++ b/base-kustomize/gnocchi/base/configmap-bin.yaml
@@ -55,3 +55,13 @@ data:
       key: $( echo ${ENCODED_KEYRING} )
     EOF
     kubectl apply --namespace ${NAMESPACE} -f ${SECRET}
+
+  gnocchi-resources-cleaner.sh: |
+    #!/bin/bash
+
+    set -ex
+
+    echo "Purging the deleted resources with its associated metrics which have lived more than ${DELETED_RESOURCES_TTL}"
+    gnocchi resource batch delete "ended_at < '-${DELETED_RESOURCES_TTL}'"
+
+    exit 0


### PR DESCRIPTION
The template for `gnocchi-resources-cleaner.sh` is missing the interpreter information for the script.  We could either update the script or update the cron-job settings.  I decided to update the script using the config map. 