### PR TITLE
Specify "region_name" for the openstack clients in magnum.conf

### DIFF
--- a/base-helm-configs/magnum/magnum-helm-overrides.yaml
+++ b/base-helm-configs/magnum/magnum-helm-overrides.yaml
@@ -76,20 +76,28 @@ conf:
     glance_client:
       api_version: 2
       endpoint_type: publicURL
+      region_name: RegionOne
     nova_client:
       endpoint_type: publicURL
+      region_name: RegionOne
     cinder_client:
       endpoint_type: publicURL
+      region_name: RegionOne
     neutron_client:
       endpoint_type: publicURL
+      region_name: RegionOne
     barbican_client:
       endpoint_type: publicURL
+      region_name: RegionOne
     heat_client:
       endpoint_type: publicURL
+      region_name: RegionOne
     magnum_client:
       endpoint_type: publicURL
+      region_name: RegionOne
     octavia_client:
       endpoint_type: publicURL
+      region_name: RegionOne
     cluster:
       temp_cache_dir: /var/lib/magnum/certificate-cache
     oslo_messaging_notifications:


### PR DESCRIPTION
- Without `region_name`, creation of k8s cluster failed with below error:
```
magnum]# openstack coe cluster show new-k8s-cluster
+----------------------+---------------------------------------------------------------------------------------------------------------------------------------+
| Field                | Value                                                                                                                                 |
+----------------------+---------------------------------------------------------------------------------------------------------------------------------------+
| status               | CREATE_FAILED                                                                                                                         |
| health_status        | None                                                                                                                                  |
| cluster_template_id  | 739aad59-220c-45da-9195-f7377f5e675e                                                                                                  |
| node_addresses       | []                                                                                                                                    |
| uuid                 | 3e10e2a5-be37-4030-8f88-ba071d099724                                                                                                  |
| stack_id             | None                                                                                                                                  |
| status_reason        | region_name needs to be configured in magnum.conf

```

- I had to update the helm chart with the `region_name`
```
openstack coe cluster list
+--------------------------------------+-----------------+---------------------+------------+--------------+-----------------+---------------+
| uuid                                 | name            | keypair             | node_count | master_count | status          | health_status |
+--------------------------------------+-----------------+---------------------+------------+--------------+-----------------+---------------+
| 4191ca86-9f83-4d7d-846a-dcf39c4376c7 | new-k8s-cluster | 1335099-controller1 |          2 |            3 | CREATE_COMPLETE | HEALTHY       |
+--------------------------------------+-----------------+---------------------+------------+--------------+-----------------+---------------+
```