### PR TITLE
Fix the barbican-api service endpoint in barbican.conf

### DIFF
--- a/base-helm-configs/barbican/barbican-helm-overrides.yaml
+++ b/base-helm-configs/barbican/barbican-helm-overrides.yaml
@@ -375,7 +375,7 @@ conf:
       processes: 1
   barbican:
     DEFAULT:
-      host_href: http://barbican.openstack.svc.cluster.local
+      host_href: http://barbican-api.openstack.svc.cluster.local:9311
       transport_url: null
       log_config_append: /etc/barbican/logging.conf
     keystone_authtoken:


### PR DESCRIPTION
- Barbican service endpoint is http://barbican-api.openstack.svc.cluster.local:9311
- With current configuration, accessing the internal endpoints tries to query `http://barbican.openstack.svc.cluster.local/v1/`:
```
# openstack endpoint list --service barbican --interface internal
+----------------------------------+-----------+--------------+--------------+---------+-----------+-------------------------------------------------------+
| ID                               | Region    | Service Name | Service Type | Enabled | Interface | URL                                                   |
+----------------------------------+-----------+--------------+--------------+---------+-----------+-------------------------------------------------------+
| 78c25951ce53408089edb1458216810f | RegionOne | barbican     | key-manager  | True    | internal  | http://barbican-api.openstack.svc.cluster.local:9311/ |
+----------------------------------+-----------+--------------+--------------+---------+-----------+-------------------------------------------------------+

root@openstack-admin-client:/# curl http://barbican-api.openstack.svc.cluster.local:9311/
{"versions": {"values": [{"id": "v1", "status": "stable", "links": [{"rel": "self", "href": "http://barbican.openstack.svc.cluster.local/v1/"}, {"rel": "describedby", "type": "text/html", "href": "https://docs.openstack.org/"}], "media-types": [{"base": "application/json", "type": "application/vnd.openstack.key-manager-v1+json"}]}]}}

root@openstack-admin-client:/# curl http://barbican.openstack.svc.cluster.local/v1/
curl: (6) Could not resolve host: barbican.openstack.svc.cluster.local
```
- k8s service output:
```
# kubectl get svc -n openstack |egrep -i barbican
barbican-api                               ClusterIP      10.233.17.195   <none>        9311/TCP                                                                                                                       19d
```