### PR TITLE
feat: update the playbook to support multibackend store

### DIFF
--- a/ansible/playbooks/deploy-cinder-volumes-reference.yaml
+++ b/ansible/playbooks/deploy-cinder-volumes-reference.yaml
@@ -150,6 +150,15 @@
         value: "{{ ansible_fqdn }}"
         create: true
 
+    - name: Ensure the backend configuration is set to our expected value
+      changed_when: false
+      community.general.ini_file:
+        path: "/etc/cinder/cinder.conf.stage"
+        section: DEFAULT
+        option: enabled_backends
+        value: "{{ cinder_backend_name }}"
+        create: true
+
     - name: Create the cinder-volume configuration
       ansible.builtin.copy:
         src: "/etc/cinder/cinder.conf.stage"
@@ -164,14 +173,17 @@
     - name: Set enabled backend fact
       set_fact:
         cinder_backend: |
-          {% set default_backend = (_kubernetes_cinder_etc_secret.resources[0].data['backends.conf'] | b64decode | community.general.from_ini)[cinder_backend_name] %}
-          {% set network_interface = hostvars[inventory_hostname][cinder_storage_network_interface]['ipv4']['address'] | default(ansible_default_ipv4.address) %}
-          {% set network_interface_secondary = hostvars[inventory_hostname][cinder_storage_network_interface_secondary]['ipv4']['address'] %}
-          {% set _ = default_backend.__setitem__("target_ip_address", network_interface) %}
-          {% if (custom_multipath | bool) %}
-          {%   set _ = default_backend.__setitem__("iscsi_secondary_ip_addresses", network_interface_secondary) %}
-          {% endif %}
-          {% set rendered_backend = {cinder_backend_name: default_backend} %}
+          {% set rendered_backend = {} %}
+          {% for backend in cinder_backend_name.split(',') %}
+          {%   set default_backend = (_kubernetes_cinder_etc_secret.resources[0].data['backends.conf'] | b64decode | community.general.from_ini)[backend] %}
+          {%   set network_interface = hostvars[inventory_hostname][cinder_storage_network_interface]['ipv4']['address'] | default(ansible_default_ipv4.address) %}
+          {%   set network_interface_secondary = hostvars[inventory_hostname][cinder_storage_network_interface_secondary]['ipv4']['address'] %}
+          {%   set _ = default_backend.__setitem__("target_ip_address", network_interface) %}
+          {%   if (custom_multipath | bool) %}
+          {%     set _ = default_backend.__setitem__("iscsi_secondary_ip_addresses", network_interface_secondary) %}
+          {%   endif %}
+          {%   set _ = rendered_backend.__setitem__(backend, default_backend) %}
+          {% endfor %}
           {{ rendered_backend }}
 
     - name: Create the cinder-volume backend configuration


### PR DESCRIPTION
This change will enable the backend store to run with multiple backends on a deployment host. This will ensure that only the backends we expect to run are deployed.