### PR TITLE
fix(gwapi): allow custom nginx.conf

### DIFF
--- a/base-kustomize/gateway/base/files/nginx.conf
+++ b/base-kustomize/gateway/base/files/nginx.conf
@@ -1,0 +1,40 @@
+load_module /usr/lib/nginx/modules/ngx_http_js_module.so;
+include /etc/nginx/module-includes/*.conf;
+
+worker_processes auto;
+
+pid /var/run/nginx/nginx.pid;
+error_log stderr info;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  include /etc/nginx/conf.d/*.conf;
+  include /etc/nginx/mime.types;
+  js_import /usr/lib/nginx/modules/njs/httpmatches.js;
+
+  default_type application/octet-stream;
+
+  proxy_headers_hash_bucket_size 512;
+  proxy_headers_hash_max_size 1024;
+  proxy_buffer_size 16k;
+  proxy_buffers 4 16k;
+  server_names_hash_bucket_size 256;
+  server_names_hash_max_size 1024;
+  variables_hash_bucket_size 512;
+  variables_hash_max_size 1024;
+
+  sendfile on;
+  tcp_nopush on;
+
+  server {
+    listen unix:/var/run/nginx/nginx-status.sock;
+    access_log off;
+
+    location /stub_status {
+        stub_status;
+    }
+  }
+}

--- a/base-kustomize/gateway/base/kustomization.yaml
+++ b/base-kustomize/gateway/base/kustomization.yaml
@@ -1,0 +1,15 @@
+resources:
+  - all.yaml
+patches:
+  - path: nginx-conf-override.yaml
+    target:
+      kind: Deployment
+      name: nginx-gateway-fabric
+      namespace: nginx-gateway
+configMapGenerator:
+  - name: nginx-conf-override
+    namespace: nginx-gateway
+    options:
+      disableNameSuffixHash: true
+    files:
+      - files/nginx.conf

--- a/base-kustomize/gateway/base/nginx-conf-override.yaml
+++ b/base-kustomize/gateway/base/nginx-conf-override.yaml
@@ -1,0 +1,21 @@
+# A patch to override `nginx.conf` to support changes to
+# the Nginx configuration that are otherwise not possible.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-gateway-fabric
+  namespace: nginx-gateway
+spec:
+  template:
+    spec:
+      containers:
+        - name: nginx
+          volumeMounts:
+            - mountPath: /etc/nginx/nginx.conf
+              name: nginx-conf-override
+              subPath: nginx.conf
+      volumes:
+        - name: nginx-conf-override
+          configMap:
+            name: nginx-conf-override

--- a/docs/infrastructure-gateway-api.md
+++ b/docs/infrastructure-gateway-api.md
@@ -69,11 +69,15 @@ There are various implementations of the Gateway API. In this document, we will 
     === "Stable _(Recommended)_"
 
         ``` shell
-        cd /opt/genestack/submodules/nginx-gateway-fabric/charts/nginx-gateway-fabric
+        cd /opt/genestack/submodules/nginx-gateway-fabric/charts
 
-        helm upgrade --install nginx-gateway-fabric . \
+        helm upgrade --install nginx-gateway-fabric ./nginx-gateway-fabric \
                     --namespace=nginx-gateway \
-                    -f /etc/genestack/helm-configs/nginx-gateway-fabric/helm-overrides.yaml
+                    --wait \
+                    --timeout 10m \
+                    -f /opt/genestack/base-helm-configs/nginx-gateway-fabric/helm-overrides.yaml \
+                    --post-renderer /opt/genestack/base-kustomize/kustomize.sh \
+                    --post-renderer-args gateway/base
         ```
 
     === "Experimental"


### PR DESCRIPTION
There is no easy way to add `proxy_buffer_size` or similar parameters to Nginx via CRD. A feature for the same is being worked on and might be released early November per [nginxinc/nginx-gateway-fabric/#1398](https://github.com/nginxinc/nginx-gateway-fabric/issues/1398#issuecomment-2274235810).

As a workaround, this change includes the default nginx configuration as deployed in the current version of nginx gateway fabric. It will be made available to the nginx pod at `/etc/nginx/nginx.conf` by supplanting the nginx-gateway deployment with a kustomize patch that overrides `nginx.conf` via a mounted configMap volume containing said file.

Several additional parameters, `proxy_buffer_size` and `proxy_buffers` are being included at this time, to account for some large header payloads being proxied from Gnocchi.