### PR TITLE
spaces/tabs in genestack-multipath.conf

### DIFF
--- a/ansible/playbooks/templates/genestack-multipath.conf
+++ b/ansible/playbooks/templates/genestack-multipath.conf
@@ -1,48 +1,47 @@
 defaults {
-	find_multipaths		yes
-	failback		10
-	no_path_retry		10
-        polling_interval        2
+    find_multipaths      yes
+    failback             10
+    no_path_retry        10
+    polling_interval     2
 }
 blacklist {
-	devnode	"^nvme.*"
-	devnode "scini*"
-	devnode "^rbd[0-9]*"
-	devnode "^nbd[0-9]*"
+    devnode    "^nvme.*"
+    devnode    "scini*"
+    devnode    "^rbd[0-9]*"
+    devnode    "^nbd[0-9]*"
 }
 
 blacklist_exceptions {
 }
 devices {
-
-	device {
-		vendor			"IET"
-		product			"VIRTUAL-DISK"
-                path_selector           "queue-length 0"
-                path_grouping_policy    multibus
-                uid_attribute           ID_SERIAL
-                failback                immediate
-                prio                    const
-                no_path_retry           fail
-	}
-       device {
-		vendor                  "NETAPP"
-		product	                "LUN.*"
-                path_selector           "service-time 0"
-                no_path_retry           queue
-		path_checker            tur
-                detect_prio             yes
-                dev_loss_tmo            "infinity"
-                failback                immediate
-                fast_io_fail_tmo        5
-                features                "2 pg_init_retries 50"
-                flush_on_last_del       "yes"
-                hardware_handler        "0"
-                path_grouping_policy    "group_by_prio"
-                polling_interval        5
-                prio                    "ontap"
-                retain_attached_hw_handler  yes
-                rr_weight               "uniform"
-                user_friendly_names     no
-	}
+    device {
+        vendor                      "IET"
+        product                     "VIRTUAL-DISK"
+        path_selector               "queue-length 0"
+        path_grouping_policy        multibus
+        uid_attribute               ID_SERIAL
+        failback                    immediate
+        prio                        const
+        no_path_retry               fail
+    }
+    device {
+        vendor                      "NETAPP"
+        product                     "LUN.*"
+        path_selector               "service-time 0"
+        no_path_retry               queue
+        path_checker                tur
+        detect_prio                 yes
+        dev_loss_tmo                "infinity"
+        failback                    immediate
+        fast_io_fail_tmo            5
+        features                    "2 pg_init_retries 50"
+        flush_on_last_del           "yes"
+        hardware_handler            "0"
+        path_grouping_policy        "group_by_prio"
+        polling_interval            5
+        prio                        "ontap"
+        retain_attached_hw_handler  yes
+        rr_weight                   "uniform"
+        user_friendly_names         no
+    }
 }


### PR DESCRIPTION
Just cleaning up spacing to be consistent on Linux AND Mac