### PR TITLE
Update barbican-helm-overrides.yaml keystone endpoint

### DIFF
--- a/base-helm-configs/barbican/barbican-helm-overrides.yaml
+++ b/base-helm-configs/barbican/barbican-helm-overrides.yaml
@@ -574,7 +574,7 @@ endpoints:
     name: barbican
     hosts:
       default: barbican-api
-      public: barbican
+      public: barbican-api
     host_fqdn_override:
       default:
         tls:
@@ -590,7 +590,7 @@ endpoints:
     port:
       api:
         default: 9311
-        public: 80
+        public: 9311
         service: 9311
   oslo_db:
     auth:


### PR DESCRIPTION
Current public barbican endpoint does not resolve nor is there an listener on port 80, moving public endpoint to barbican-api and port 9311.