### PR TITLE
feat: Add plugins.yaml for camptocamp for Grafana

### DIFF
--- a/base-kustomize/grafana/base/kustomization.yaml
+++ b/base-kustomize/grafana/base/kustomization.yaml
@@ -11,4 +11,5 @@ helmCharts:
     valuesFile: grafana-values.yaml
     additionalValuesFiles:
       - datasources.yaml
+      - plugins.yaml
       - grafana-alerts.yaml

--- a/base-kustomize/grafana/base/plugins.yaml
+++ b/base-kustomize/grafana/base/plugins.yaml
@@ -1,0 +1,2 @@
+plugins:
+  - camptocamp-prometheus-alertmanager-datasource


### PR DESCRIPTION
I did CHG0156370 and deployed Grafana to SJC. Both SJC and DFW need this `plugins.yaml` and to have it added to `kustomization.yaml` to most closely match the actual deployed state of both environments.

I think we should add this in here? I've created this PR for those more familiar with Grafana, camptocamp, etc. to evaluate and merge if it looks warranted.