### PR TITLE
fix: Ensure build timeouts are set to 10 minutes

### DIFF
--- a/base-helm-configs/nova/nova-helm-overrides.yaml
+++ b/base-helm-configs/nova/nova-helm-overrides.yaml
@@ -1378,6 +1378,9 @@ conf:
       instance_usage_audit: True
       instance_usage_audit_period: hour
       resume_guests_state_on_host_boot: True
+      instance_build_timeout: 600
+      block_device_allocate_retries: 120
+      block_device_allocate_retries_interval: 5
     compute:
       max_disk_devices_to_attach: 8
     vnc:


### PR DESCRIPTION
This change adds three new nova options to ensure that new instances have up to 10 minutes to become active, even when using boot from volume.