### PR TITLE
feat: use AZs by default

### DIFF
--- a/base-helm-configs/cinder/cinder-helm-overrides.yaml
+++ b/base-helm-configs/cinder/cinder-helm-overrides.yaml
@@ -758,6 +758,10 @@ conf:
         app_name: cinder-volume
   cinder:
     DEFAULT:
+      storage_availability_zone: az1
+      default_availability_zone: null
+      allow_availability_zone_fallback: true
+      scheduler_default_filters: AvailabilityZoneFilter,CapacityFilter,CapabilitiesFilter
       volume_usage_audit_period: hour
       resource_query_filters_file: /etc/cinder/resource_filters.json
       log_config_append: /etc/cinder/logging.conf

--- a/base-helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/base-helm-configs/neutron/neutron-helm-overrides.yaml
@@ -1754,7 +1754,10 @@ conf:
       # NOTE(portdirect): the bind port should not be defined, and is manipulated
       # via the endpoints section.
       bind_port: null
-      default_availability_zones: nova
+      default_availability_zones: null
+      network_scheduler_driver: neutron.scheduler.dhcp_agent_scheduler.AZAwareWeightScheduler
+      router_scheduler_driver: neutron.scheduler.l3_agent_scheduler.AZLeastRoutersScheduler
+      dhcp_load_type: networks
       api_workers: 1
       rpc_workers: 4
       allow_overlapping_ips: True
@@ -1787,7 +1790,7 @@ conf:
       connection_recycle_time: 3600
       max_retries: -1
     agent:
-      availability_zone: nova
+      availability_zone: az1
       root_helper: sudo /var/lib/openstack/bin/neutron-rootwrap /etc/neutron/rootwrap.conf
       root_helper_daemon: sudo /var/lib/openstack/bin/neutron-rootwrap-daemon /etc/neutron/rootwrap.conf
     oslo_messaging_notifications:
@@ -1946,6 +1949,7 @@ conf:
         vni_ranges: 1:65536
         max_header_size: 38
       agent:
+        availability_zone: az1
         extensions: fip_qos,gateway_ip_qos
     ml2_conf_sriov: null
     taas:
@@ -1953,6 +1957,7 @@ conf:
         enabled: False
     openvswitch_agent:
       agent:
+        availability_zone: az1
         tunnel_types: vxlan
         l2_population: True
         arp_responder: True
@@ -1988,6 +1993,8 @@ conf:
       interface_driver: null
       dnsmasq_config_file: /etc/neutron/dnsmasq.conf
       force_metadata: True
+    agent:
+      availability_zone: az1
   dnsmasq: |
       #no-hosts
       #port=5353

--- a/base-helm-configs/nova/nova-helm-overrides.yaml
+++ b/base-helm-configs/nova/nova-helm-overrides.yaml
@@ -608,7 +608,7 @@ conf:
     tests:
       NovaAggregates.create_and_get_aggregate_details:
         - args:
-            availability_zone: nova
+            availability_zone: az1
           runner:
             concurrency: 1
             times: 1
@@ -618,7 +618,7 @@ conf:
               max: 0
       NovaAggregates.create_and_update_aggregate:
         - args:
-            availability_zone: nova
+            availability_zone: az1
           runner:
             concurrency: 1
             times: 1
@@ -1358,6 +1358,8 @@ conf:
     - cell0_database
   nova:
     DEFAULT:
+      default_availability_zone: az1
+      default_schedule_zone: null
       # NOTE(cloudnull): the vif_plugging_* options are an implemntation detail of the nova container when running with OVN
       vif_plugging_is_fatal: true
       vif_plugging_timeout: 300
@@ -1410,6 +1412,7 @@ conf:
       auth_type: password
       auth_version: v3
     cinder:
+      cross_az_attach: true
       catalog_info: volumev3::internalURL
     key_manager:
       backend: barbican

--- a/docs/adding-new-node.md
+++ b/docs/adding-new-node.md
@@ -82,7 +82,7 @@ labels and annotations.
    kubectl annotate \
         nodes \
         ${NODES} \
-        ovn.openstack.org/availability_zones='nova'
+        ovn.openstack.org/availability_zones='az1'
 ```
 
 4. Verify all the services are up and running

--- a/docs/infrastructure-ovn-setup.md
+++ b/docs/infrastructure-ovn-setup.md
@@ -17,7 +17,7 @@ Post deployment we need to setup neutron to work with our integrated OVN environ
 | **ovn.openstack.org/bridges** | str | `br-ex` | Comma separated list of bridges that will be created and plugged into OVS for a given node. |
 | **ovn.openstack.org/ports** | str | `br-ex:bond1` | Comma separated list of bridge mappings. Maps values from the **bridges** annotation to physical devices on a given node.  |
 | **ovn.openstack.org/mappings** | str | `physnet1:br-ex` | Comma separated list of neutron mappings. Maps a value that will be used in neutron to a value found in the **ports** annotation. |
-| **ovn.openstack.org/availability_zones** | str | `nova` | Colon separated list of Availability Zones a given node will serve. |
+| **ovn.openstack.org/availability_zones** | str | `az1` | Colon separated list of Availability Zones a given node will serve. |
 | **ovn.openstack.org/gateway** | str| `enabled` | If set to `enabled`, the node will be marked as a gateway. |
 
 ### Gather the network enabled nodes
@@ -92,12 +92,14 @@ Set the OVN availability zones which inturn creates neutron availability zones. 
 kubectl annotate \
         nodes \
         ${ALL_NODES} \
-        ovn.openstack.org/availability_zones='nova'
+        ovn.openstack.org/availability_zones='az1'
 ```
 
 !!! note
 
-    Any availability zone defined here should also be defined within your **neutron.conf**. The "nova" availability zone is an assumed defined, however, because we're running in a mixed OVN environment, we should define where we're allowed to execute OpenStack workloads.
+    Any availability zone defined here should also be defined within your **neutron.conf**. The "az1" availability zone is assumed by Genestack; however, because we're running in a mixed OVN environment, we define where we're allowed to execute OpenStack workloads ensuring we're not running workloads in an environment that doesn't have the network resources to support it.
+
+    Additionally, an availability zone can be used on different nodes and used to define where gateways reside. If you have multiple availability zones, you will need to define where the gateways will reside within your environment.
 
 ### Set `ovn.openstack.org/gateway`
 

--- a/docs/octavia-loadbalancer-setup-guide.md
+++ b/docs/octavia-loadbalancer-setup-guide.md
@@ -58,7 +58,7 @@ $ openstack --os-cloud default loadbalancer create --name OVN-Test --vip-subnet-
 | Field               | Value                                |
 +---------------------+--------------------------------------+
 | admin_state_up      | True                                 |
-| availability_zone   | None                                 |
+| availability_zone   | az1                                  |
 | created_at          | 2024-08-30T17:48:46                  |
 | description         |                                      |
 | flavor_id           | None                                 |

--- a/docs/openstack-cinder-fips-encryption.md
+++ b/docs/openstack-cinder-fips-encryption.md
@@ -48,7 +48,7 @@ kubectl --namespace openstack exec -ti openstack-admin-client -- openstack volum
 | Field               | Value                                |
 +---------------------+--------------------------------------+
 | attachments         | []                                   |
-| availability_zone   | nova                                 |
+| availability_zone   | az1                                  |
 | bootable            | false                                |
 | consistencygroup_id | None                                 |
 | created_at          | 2024-10-17T20:01:19.233106           |
@@ -78,7 +78,7 @@ Verify encryption field after volume is created:
 | Field                          | Value                                                         |
 +--------------------------------+---------------------------------------------------------------+
 | attachments                    | []                                                            |
-| availability_zone              | nova                                                          |
+| availability_zone              | az1                                                           |
 | bootable                       | false                                                         |
 | consistencygroup_id            | None                                                          |
 | created_at                     | 2024-10-17T20:01:19.000000                                    |

--- a/docs/openstack-cinder-lvmisci.md
+++ b/docs/openstack-cinder-lvmisci.md
@@ -127,7 +127,7 @@ root@openstack-flex-node-0:~# kubectl --namespace openstack exec -ti openstack-a
 | Field               | Value                                |
 +---------------------+--------------------------------------+
 | attachments         | []                                   |
-| availability_zone   | nova                                 |
+| availability_zone   | az1                                  |
 | bootable            | false                                |
 | consistencygroup_id | None                                 |
 | created_at          | 2023-12-26T17:46:15.639697           |


### PR DESCRIPTION
This change will ensure that Genestack operates with availability zones using common naming conventions by default. The AZ support is being added to Nova, Cinder, and Neutron.