### PR TITLE
fix: restore blackbox alerting rules and rabbitmq alert size

### DIFF
--- a/base-kustomize/prometheus/alerting_rules.yaml
+++ b/base-kustomize/prometheus/alerting_rules.yaml
@@ -46,6 +46,32 @@ additionalPrometheusRulesMap:
         annotations:
           summary: MySQL restarted (instance {{ $labels.instance }})
           description: "MySQL has just been restarted, less than one minute ago on {{ $labels.instance }}.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+  blackbox-alerts:
+    groups:
+      - name: Blackbox Alerts
+        rules:
+          - alert: TLS certificate expiring
+            expr: (probe_ssl_earliest_cert_expiry - time())/86400 < 60
+            labels:
+              severity: warning
+            annotations:
+              summary: "SSL certificate will expire soon on (instance {{ $labels.instance }})"
+              description: "SSL certificate expires within 60 days\n  VALUE = {{ $value }}\n  LABELS: {{ $labels }}"
+          - alert: TLS certificate expiring
+            expr: (probe_ssl_earliest_cert_expiry - time())/86400 < 30
+            labels:
+              severity: critical
+            annotations:
+              summary: "SSL certificate will expire soon on (instance {{ $labels.instance }})"
+              description: "SSL certificate expires within 30 days\n  VALUE = {{ $value }}\n  LABELS: {{ $labels }}"
+          - alert: Service Down
+            expr: probe_success == 0
+            for: 2m
+            labels:
+              severity: critical
+            annotations:
+              summary: "Service probe has failed for more than two minutes on (instance {{ $labels.instance }})"
+              description: "Service probe has failed for more than two minutes \n  LABELS: {{ $labels }}"
   volume-alerts:
     groups:
       - name: Volume Alerts

--- a/base-kustomize/prometheus/values.yaml
+++ b/base-kustomize/prometheus/values.yaml
@@ -2016,9 +2016,16 @@ prometheus-node-exporter:
     ##
     jobLabel: node-exporter
   releaseLabel: true
+  extraHostVolumeMounts:
+    - name: text-file-collector
+      hostPath: /opt/node_exporter/textfile_collector
+      mountPath: /var/lib/node_exporter/textfile_collector
+      readOnly: true
+      mountPropagation: HostToContainer
   extraArgs:
     - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
     - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
+    - --collector.textfile.directory=/var/lib/node_exporter/textfile_collector
   service:
     portName: http-metrics
   prometheus:


### PR DESCRIPTION
restores blackbox alerting rules and rabbitmq alert size from https://github.com/rackerlabs/genestack/commit/cb440e203a7d657bba5eb885f1522fc98542b6bb

which appears inadvertently removed in
https://github.com/rackerlabs/genestack/commit/3dfc4afcd397f1a155fcd39809704608b19df07b

JIRA:OSPC-689