### PR TITLE
Fix: Updating openstack metrics polling interval and timeout

### DIFF
--- a/base-helm-configs/monitoring/openstack-metrics-exporter/openstack-metrics-exporter-helm-overrides.yaml
+++ b/base-helm-configs/monitoring/openstack-metrics-exporter/openstack-metrics-exporter-helm-overrides.yaml
@@ -12,8 +12,8 @@ image:
   pullPolicy: Always
 
 serviceMonitor:
-  interval: 3m
-  scrapeTimeout: 30s
+  interval: 5m
+  scrapeTimeout: 90s
 
 nodeSelector:
   openstack-control-plane: enabled


### PR DESCRIPTION
The openstack metrics exporter is a heavy exporter by default. Any additional strain on the system causes timeouts to occur. This fix should eliminate the timeout failures.