### PR TITLE
fix: update default_availability_zones to a value

### DIFF
--- a/base-helm-configs/cinder/cinder-helm-overrides.yaml
+++ b/base-helm-configs/cinder/cinder-helm-overrides.yaml
@@ -759,7 +759,7 @@ conf:
   cinder:
     DEFAULT:
       storage_availability_zone: az1
-      default_availability_zone: null
+      default_availability_zone: az1
       allow_availability_zone_fallback: true
       scheduler_default_filters: AvailabilityZoneFilter,CapacityFilter,CapabilitiesFilter
       volume_usage_audit_period: hour

--- a/base-helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/base-helm-configs/neutron/neutron-helm-overrides.yaml
@@ -1754,7 +1754,7 @@ conf:
       # NOTE(portdirect): the bind port should not be defined, and is manipulated
       # via the endpoints section.
       bind_port: null
-      default_availability_zones: null
+      default_availability_zones: az1
       network_scheduler_driver: neutron.scheduler.dhcp_agent_scheduler.AZAwareWeightScheduler
       router_scheduler_driver: neutron.scheduler.l3_agent_scheduler.AZLeastRoutersScheduler
       dhcp_load_type: networks


### PR DESCRIPTION
This change updates default_availability_zones to ensure it has a default value. While this option is supposed to assume the value of the bound az, openstack helm returns a `<no value>` value which makes the services very upset. By setting a value we make the service happy, and we all want happy services.