### PR TITLE
fix: OSPC-613 mariadb cleanup old backups

### DIFF
--- a/base-kustomize/mariadb-cluster/base/mariadb-backup.yaml
+++ b/base-kustomize/mariadb-cluster/base/mariadb-backup.yaml
@@ -16,3 +16,5 @@ spec:
           storage: 1Gi
       accessModes:
         - ReadWriteOnce
+  securityContext:
+    runAsUser: 0


### PR DESCRIPTION
The mariadb-backup init container already runs as root and tries to chmod `777` the backup files, but they get changed back to `0644` at some point later on. This results in the mariadb-operator pod running into a permission denied situation during its cleanup for the desired retention setting.

The fix herein simply runs the pod as root so that the mariadb-operator container in the pod has access to cleanup the old backups as needed.

This change fixes **NEW** backups, existing ones need to have the corresponding `CronJob` modified (see below).

While re-applying the `mariadb-backup` will update the existing `Backup`, the mariadb-operator does not seem to reconcile the `CronJob` for the securityContext attribute. One must update the `CronJob` manually or apply a patch to fix existing jobs without deleting and re-creating them.

This patch has been tested and does just that to add the needed securityContext to the existing `CronJob`:

```shell
kubectl patch cronjob mariadb-backup -n openstack --type='json' \
-p='[{"op": "add", "path": "/spec/jobTemplate/spec/template/spec/securityContext/runAsUser", "value": 0}]'
```

Ref: OSPC-613