### PR TITLE
fix: Add cinder volume netapp playbook

### DIFF
--- a/ansible/playbooks/deploy-cinder-netapp-volumes-reference.yaml
+++ b/ansible/playbooks/deploy-cinder-netapp-volumes-reference.yaml
@@ -1,0 +1,216 @@
+---
+- name: Run the cinder volume reference driver deployment
+  hosts: cinder_storage_nodes
+  gather_facts: true
+  become: true
+  vars:
+    cinder_release: "2024.1"
+    cinder_storage_network_interface: ansible_br_storage
+    cinder_storage_network_interface_secondary: ansible_br_storage_secondary
+    cinder_backend_name: "block-ha-performance-at-rest-encrypted,block-ha-standard-at-rest-encrypted"
+    custom_multipath: false
+  handlers:
+    - name: Restart cinder-volume-netapp systemd services
+      ansible.builtin.systemd:
+        name: "{{ item }}"
+        state: restarted
+        daemon_reload: true
+        enabled: true
+      loop:
+        - cinder-volume-netapp
+  tasks:
+    - name: K8S Facts block
+      delegate_to: "{{ groups['kube_control_plane'][0] }}"
+      block:
+        - name: Ensure python3-kubernetes is available
+          ansible.builtin.package:
+            name: python3-kubernetes
+            state: present
+            update_cache: true
+
+        - name: Read cinder-etc secrets
+          kubernetes.core.k8s_info:
+            kind: Secret
+            name: cinder-etc
+            namespace: openstack
+          register: _kubernetes_cinder_etc_secret
+
+    - name: Install required packages
+      ansible.builtin.package:
+        name:
+          - build-essential
+          - git
+          - open-iscsi
+          - python3-venv
+          - python3-dev
+          - qemu-block-extra
+          - qemu-utils
+        state: present
+        update_cache: true
+
+    - name: Upgrade pip and install required packages
+      ansible.builtin.pip:
+        name:
+          - pip
+          - pymysql
+          - "git+https://github.com/openstack/cinder@stable/{{ cinder_release }}"
+          - "git+https://github.com/rackerlabs/cinder-rxt.git"
+        state: present
+        virtualenv: /opt/cinder
+        virtualenv_command: python3 -m venv
+
+    - name: Create the cinder system user
+      ansible.builtin.user:
+        name: cinder
+        comment: Cinder system user
+        shell: /bin/false
+        system: true
+        createhome: true
+        home: /var/lib/cinder
+
+    - name: Create the cinder system group
+      ansible.builtin.group:
+        name: cinder
+        system: true
+
+    - name: Create the cinder service directory
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        owner: cinder
+        group: cinder
+        mode: "0755"
+      loop:
+        - /var/lib/cinder/backup
+        - /var/lib/cinder/tmp
+        - /var/lib/cinder/volumes
+
+    - name: Create symlink for the etc directory
+      ansible.builtin.file:
+        src: /opt/cinder/etc/cinder
+        dest: /etc/cinder
+        state: link
+        owner: cinder
+        group: cinder
+
+    - name: Create the cinder-volume-netapp systemd service units
+      ansible.builtin.copy:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        owner: root
+        group: root
+        mode: "{{ item.mode | default('0644') }}"
+      loop:
+        - src: "{{ playbook_dir }}/templates/cinder-netapp-volume.service"
+          dest: /etc/systemd/system/cinder-netapp-volume.service
+        - src: "{{ playbook_dir }}/templates/sudoers"
+          dest: /etc/sudoers.d/cinder-volume
+          mode: "0440"
+      notify:
+        - Restart cinder-volume-netapp systemd services
+
+    - name: Create the cinder-volume-netapp service configuration
+      ansible.builtin.copy:
+        content: "{{ _kubernetes_cinder_etc_secret.resources[0].data[item.src] | b64decode }}"
+        dest: "{{ item.dest }}"
+        owner: root
+        group: root
+        mode: "0644"
+      loop:
+        - src: "logging.conf"
+          dest: /etc/cinder/logging.conf
+        - src: "volume.filters"
+          dest: /etc/cinder/volume.filters
+      notify:
+        - Restart cinder-volume-netapp systemd services
+
+    - name: Create the cinder-volume-netapp configuration stage file
+      changed_when: false
+      ansible.builtin.copy:
+        content: "{{ _kubernetes_cinder_etc_secret.resources[0].data['cinder.conf'] | b64decode }}"
+        dest: "/etc/cinder/cinder.conf.stage"
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Replace the host in the cinder.conf.stage with the current Ansible FQDN in the stage file
+      changed_when: false
+      community.general.ini_file:
+        path: "/etc/cinder/cinder.conf.stage"
+        section: DEFAULT
+        option: host
+        value: "{{ ansible_fqdn }}"
+        create: true
+
+    - name: Ensure the backend configuration is set to our expected value
+      changed_when: false
+      community.general.ini_file:
+        path: "/etc/cinder/cinder.conf.stage"
+        section: DEFAULT
+        option: enabled_backends
+        value: "{{ cinder_backend_name }}"
+        create: true
+
+    - name: Create the cinder-volume-netapp configuration
+      ansible.builtin.copy:
+        src: "/etc/cinder/cinder.conf.stage"
+        dest: "/etc/cinder/cinder.conf"
+        owner: root
+        group: root
+        mode: "0644"
+        remote_src: true
+      notify:
+        - Restart cinder-volume-netapp systemd services
+
+    - name: Set enabled backend fact
+      set_fact:
+        cinder_backend: |
+          {% set rendered_backend = {} %}
+          {% for backend in cinder_backend_name.split(',') %}
+          {%   set default_backend = (_kubernetes_cinder_etc_secret.resources[0].data['backends.conf'] | b64decode | community.general.from_ini)[backend] %}
+          {%   set network_interface = hostvars[inventory_hostname][cinder_storage_network_interface]['ipv4']['address'] | default(ansible_default_ipv4.address) %}
+          {%   set network_interface_secondary = hostvars[inventory_hostname][cinder_storage_network_interface_secondary]['ipv4']['address'] %}
+          {%   set _ = default_backend.__setitem__("target_ip_address", network_interface) %}
+          {%   if (custom_multipath | bool) %}
+          {%     set _ = default_backend.__setitem__("iscsi_secondary_ip_addresses", network_interface_secondary) %}
+          {%   endif %}
+          {%   set _ = rendered_backend.__setitem__(backend, default_backend) %}
+          {% endfor %}
+          {{ rendered_backend }}
+
+    - name: Create the cinder-volume-netapp backend configuration
+      ansible.builtin.copy:
+        content: "{{ cinder_backend | community.general.to_ini }}"
+        dest: "/etc/cinder/netapp-backends.conf"
+        owner: root
+        group: root
+        mode: "0644"
+      notify:
+        - Restart cinder-volume-netapp systemd services
+
+    - name: Create the cinder-volume-netapp overrides configuration
+      ansible.builtin.copy:
+        content: |
+          [DEFAULT]
+          host = cinder-volume-netapp-worker
+        dest: "/etc/cinder/netapp-cinder.conf"
+        owner: root
+        group: root
+        mode: "0644"
+      notify:
+        - Restart cinder-volume-netapp systemd services
+
+    - name: Replace exec path in rootwrap
+      community.general.ini_file:
+        path: /etc/cinder/rootwrap.conf
+        section: DEFAULT
+        option: "{{ item.key }}"
+        value: "{{ item.value }}"
+        create: true
+      loop:
+        - key: "exec_dirs"
+          value: "/opt/cinder/bin,/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin,/usr/lpp/mmfs/bin"
+        - key: "filters_path"
+          value: "/etc/cinder/rootwrap.d"
+      notify:
+        - Restart cinder-volume-netapp systemd services

--- a/ansible/playbooks/templates/cinder-volume-netapp.service
+++ b/ansible/playbooks/templates/cinder-volume-netapp.service
@@ -1,0 +1,32 @@
+[Unit]
+Description = cinder-volume-netapp service
+After = network-online.target
+After = syslog.target
+
+[Service]
+Type = simple
+User = cinder
+Group = cinder
+ExecStart = /opt/cinder/bin/cinder-volume --config-file /etc/cinder/cinder.conf --config-file /etc/cinder/netapp-cinder.conf --config-file /etc/cinder/netapp-backends.conf
+ExecReload = /bin/kill -HUP $MAINPID
+# Give a reasonable amount of time for the server to start up/shut down
+TimeoutSec = 120
+Restart = on-failure
+RestartSec = 2
+# This creates a specific slice which all services will operate from
+#  The accounting options give us the ability to see resource usage through
+#  the `systemd-cgtop` command.
+Slice = cinder.slice
+# Set Accounting
+CPUAccounting = True
+BlockIOAccounting = True
+MemoryAccounting = True
+TasksAccounting = True
+# Set Sandboxing
+PrivateTmp = False
+PrivateDevices = False
+PrivateNetwork = False
+Environment = PATH=/opt/cinder/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+[Install]
+WantedBy = multi-user.target

--- a/base-kustomize/cinder/netapp/deploy-volume-netapp.yaml
+++ b/base-kustomize/cinder/netapp/deploy-volume-netapp.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 metadata:
   name: cinder-volume-netapp
   namespace: openstack
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -99,8 +100,6 @@ spec:
           image: image-kubernetes-entrypoint-init
           imagePullPolicy: IfNotPresent
           securityContext:
-            privledged: true
-            allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsUser: 65534
           env:
@@ -273,6 +272,8 @@ spec:
             capabilities:
               add:
                 - SYS_ADMIN
+            privileged: true
+            allowPrivilegeEscalation: true
             readOnlyRootFilesystem: true
           command:
             - /tmp/cinder-volume.sh

--- a/base-kustomize/cinder/netapp/kustomization.yaml
+++ b/base-kustomize/cinder/netapp/kustomization.yaml
@@ -6,10 +6,10 @@ images:
     newName: docker.io/openstackhelm/heat
     newTag: 2024.1-ubuntu_jammy
   - name: image-cinder-volume-netapp-init
-    newName: ghcr.io/rackerlabs/genestack/cinder-volume-rxt:2024.1-ubuntu_jammy-1731085441
+    newName: ghcr.io/rackerlabs/genestack/cinder-volume-rxt
     newTag: 2024.1-ubuntu_jammy
   - name: image-cinder-volume-netapp
-    newName: ghcr.io/rackerlabs/genestack/cinder-volume-rxt:2024.1-ubuntu_jammy-1731085441
+    newName: ghcr.io/rackerlabs/genestack/cinder-volume-rxt
     newTag: 2024.1-ubuntu_jammy
 
 resources:

--- a/docs/openstack-cinder-netapp-container.md
+++ b/docs/openstack-cinder-netapp-container.md
@@ -3,6 +3,10 @@
 This document provides information on configuring NetApp backends for the isolated Cinder volume worker. Each backend is defined by a set of
 11 comma-separated options, and multiple backends can be specified by separating them with semicolons.
 
+!!!  warning "The NetApp container is incompatible with iSCSI workloads"
+
+    The NetApp container is incompatible with iSCSI workloads. If the environment requires iSCSI support, review the [Cinder NetApp Worker ](openstack-cinder-netapp-worker.md) documentation instead.
+
 ## Backend Options
 
 Below is a table detailing each option, its position in the backend configuration, a description, and the expected data type.

--- a/docs/openstack-cinder-netapp-worker.md
+++ b/docs/openstack-cinder-netapp-worker.md
@@ -1,0 +1,114 @@
+# NetApp Volume Worker Configuration Documentation
+
+The NetApp Volume Worker is a cinder-volume service that is configured to use the NetApp ONTAP driver. This service is responsible for managing the creation, deletion, and management of volumes in the OpenStack environment. The NetApp Volume Worker is a stateful service that is deployed on a baremetal node that has access to the NetApp storage system.
+
+## Configuration
+
+The `deploy-cinder-volumes-netapp-reference.yaml` playbook is used to deploy the NetApp Volume Worker. The playbook will deploy the cinder-volume service on the specified nodes and configure the service to use the NetApp ONTAP driver. This playbook will read from the Kubernetes environment to determine the necessary configuration parameters for the NetApp ONTAP driver. As an operator, you will need to ensure that the necessary configuration parameters are set in the Kubernetes environment before running the playbook.
+
+### Backends Configuration
+
+The NetApp ONTAP driver requires a backend configuration to be set in the Kubernetes environment. The backend configuration specifies the storage system that the NetApp Volume Worker will use to create and manage volumes. The backend configuration is a Kubernetes secret that contains the necessary configuration parameters for the NetApp ONTAP driver. To define the backends, update the helm overrides file with the necessary configuration parameters.
+
+!!! example "Cinder NetApp Backend Configuration in Helm"
+
+    ``` yaml
+    conf:
+      backends:
+        block-ha-performance-at-rest-encrypted:
+          netapp_login: <LOGIN>
+          netapp_password: <PASSWORD>
+          netapp_server_hostname: <SERVER_NAME_OR_ADDRESS>
+          netapp_server_port: <SERVER_PORT>
+          netapp_storage_family: ontap_cluster
+          netapp_storage_protocol: iscsi
+          netapp_transport_type: http
+          netapp_vserver: <VSERVER>
+          netapp:qos_policy_group: <QOS_POLICY>
+          netapp_dedup: True
+          netapp_compression: True
+          netapp_thick_provisioned: True
+          netapp_lun_space_reservation: enabled
+          volume_driver: cinder.volume.drivers.netapp.common.NetAppDriver
+          volume_backend_name: block-ha-performance-at-rest-encrypted
+        block-ha-standard-at-rest-encrypted:
+          netapp_login: <LOGIN>
+          netapp_password: <PASSWORD>
+          netapp_server_hostname: <SERVER_NAME_OR_ADDRESS>
+          netapp_server_port: <SERVER_PORT>
+          netapp_storage_family: ontap_cluster
+          netapp_storage_protocol: iscsi
+          netapp_transport_type: http
+          netapp_vserver: <VSERVER>
+          netapp:qos_policy_group: <QOS_POLICY>
+          netapp_dedup: True
+          netapp_compression: True
+          netapp_thick_provisioned: True
+          netapp_lun_space_reservation: enabled
+          volume_driver: cinder.volume.drivers.netapp.common.NetAppDriver
+          volume_backend_name: block-ha-standard-at-rest-encrypted
+    ```
+
+### Detailed Variable Descriptions
+
+- **`LOGIN`**: The username credential required to authenticate with the NetApp storage system.
+- **`PASSWORD`**: The password credential required for authentication. Ensure this is kept secure.
+- **`SERVER_NAME_OR_ADDRESS`**: The address of the NetApp storage system. This can be either an IP address or a fully qualified domain name (FQDN).
+- **`SERVER_PORT`**: The port number used for communication with the NetApp storage system. Common ports are `80` for HTTP and `443` for HTTPS.
+- **`VSERVER`**: Specifies the virtual storage server (Vserver) on the NetApp storage system that will serve the volumes.
+- **`QOS_POLICY`**: The Quality of Service (QoS) policy group name that will be applied to volumes for this backend.
+
+## Host Setup
+
+The cinder target hosts need to have some basic setup run on them to make them compatible with our Logical Volume Driver.
+
+### Ensure DNS is working normally.
+
+Assuming your storage node was also deployed as a K8S node when we did our initial Kubernetes deployment, the DNS should already be
+operational for you; however, in the event you need to do some manual tweaking or if the node was note deployed as a K8S worker, then
+make sure you setup the DNS resolvers correctly so that your volume service node can communicate with our cluster.
+
+!!! note
+
+    This is expected to be our CoreDNS IP, in my case this is `169.254.25.10`.
+
+This is an example of my **systemd-resolved** conf found in `/etc/systemd/resolved.conf`
+``` conf
+[Resolve]
+DNS=169.254.25.10
+#FallbackDNS=
+Domains=openstack.svc.cluster.local svc.cluster.local cluster.local
+#LLMNR=no
+#MulticastDNS=no
+DNSSEC=no
+Cache=no-negative
+#DNSStubListener=yes
+```
+
+Restart your DNS service after changes are made.
+
+``` shell
+systemctl restart systemd-resolved.service
+```
+
+## Run the deployment
+
+The `deploy-cinder-volumes-netapp-reference.yaml` will target the `cinder_storage_nodes` group in the inventory file. The inventory file should be updated to reflect the actual hostnames of the nodes that will be running the cinder-volume-netapp service.
+
+``` shell
+ansible-playbook -i inventory-example.yaml deploy-cinder-volumes-netapp-reference.yaml
+```
+
+Once the playbook has finished executing, check the cinder api to verify functionality.
+
+``` shell
+root@openstack-node-0:~# kubectl --namespace openstack exec -ti openstack-admin-client -- openstack volume service list
++------------------+--------------------------------------------------------------------+------+---------+-------+----------------------------+
+| Binary           | Host                                                               | Zone | Status  | State | Updated At                 |
++------------------+--------------------------------------------------------------------+------+---------+-------+----------------------------+
+| cinder-scheduler | cinder-volume-worker                                               | nova | enabled | up    | 2023-12-26T17:43:07.000000 |
+| cinder-volume    | cinder-volume-netapp-worker@block-ha-performance-at-rest-encrypted | nova | enabled | up    | 2023-12-26T17:43:04.000000 |
++------------------+--------------------------------------------------------------------+------+---------+-------+----------------------------+
+```
+
+After the playbook has executed, the cinder-volume-netapp service should be running on the specified nodes and should be configured to use the NetApp ONTAP driver. The service should be able to create, delete, and manage volumes on the NetApp storage system. Validate the service is running by checking the cinder volume service list via the API or on the command line with `systemctl status cinder-volume-netapp`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -188,7 +188,9 @@ nav:
                   - Block Storage:
                       - Cinder: openstack-cinder.md
                       - LVM iSCSI: openstack-cinder-lvmisci.md
-                      - NETAPP: openstack-cinder-netapp.md
+                      - NETAPP:
+                        - Worker: openstack-cinder-netapp-worker.md
+                        - Containerized: openstack-cinder-netapp-container.md
                       - FIPS Cinder Encryption: openstack-cinder-fips-encryption.md
                   - Compute Kit:
                       - Compute Overview: openstack-compute-kit.md


### PR DESCRIPTION
This change adds a cinder volume netapp playbook to support running the cinder-volume service on baremetal, for the specific purpose of supporting netapp backends.

This change resolves defect OSPC-802 which was discovered in testing. With this change implemented, NetApp backends will be able to operate both data and bootable volumes.

Issue: https://rackspace.atlassian.net/browse/OSPC-802