### PR TITLE
doc: Fix Prometheus post-checking command in docs to match release name

### DIFF
--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -26,7 +26,7 @@ information, take a look at [Prometheus Kube Stack](https://github.com/prometheu
     If the installation is successful, you should see the related exporter pods
     in the prometheus namespace.
     ``` shell
-    kubectl -n prometheus get pods -l "release=prometheus"
+    kubectl -n prometheus get pods -l "release=kube-prometheus-stack"
     ```
 
 ## Update Alertmanager Configuration


### PR DESCRIPTION
release name went from prometheus to kube-prometheus stack here: https://github.com/rackerlabs/genestack/commit/a468178df47062aa2a9d5367e44cabbbdf3d2db5