### PR TITLE
fix: resolve Kustomize deprecations

### DIFF
--- a/base-kustomize/argocd/base/kustomization.yaml
+++ b/base-kustomize/argocd/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - namespace.yaml
 

--- a/base-kustomize/backups/etcd/kustomization.yaml
+++ b/base-kustomize/backups/etcd/kustomization.yaml
@@ -1,2 +1,4 @@
+sortOptions:
+  order: fifo
 resources:
   - etcd-backup.yaml

--- a/base-kustomize/barbican/aio/kustomization.yaml
+++ b/base-kustomize/barbican/aio/kustomization.yaml
@@ -1,2 +1,4 @@
-bases:
+sortOptions:
+  order: fifo
+resources:
   - ../base

--- a/base-kustomize/barbican/base/kustomization.yaml
+++ b/base-kustomize/barbican/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - barbican-mariadb-database.yaml
   - barbican-rabbitmq-queue.yaml

--- a/base-kustomize/ceilometer/aio/kustomization.yaml
+++ b/base-kustomize/ceilometer/aio/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+sortOptions:
+  order: fifo
+resources:
   - ../base
 
 patches:

--- a/base-kustomize/ceilometer/base/kustomization.yaml
+++ b/base-kustomize/ceilometer/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - all.yaml
   - hpa-ceilometer-notification.yaml

--- a/base-kustomize/cinder/aio/kustomization.yaml
+++ b/base-kustomize/cinder/aio/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+sortOptions:
+  order: fifo
+resources:
   - ../base
 
 patches:

--- a/base-kustomize/cinder/base/kustomization.yaml
+++ b/base-kustomize/cinder/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - cinder-mariadb-database.yaml
   - cinder-rabbitmq-queue.yaml

--- a/base-kustomize/cinder/netapp/kustomization.yaml
+++ b/base-kustomize/cinder/netapp/kustomization.yaml
@@ -12,6 +12,8 @@ images:
     newName: ghcr.io/rackerlabs/genestack/cinder-volume-rxt
     newTag: 2024.1-ubuntu_jammy
 
+sortOptions:
+  order: fifo
 resources:
   - configmap-etc.yaml
   - deploy-volume-netapp.yaml

--- a/base-kustomize/designate/aio/kustomization.yaml
+++ b/base-kustomize/designate/aio/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+sortOptions:
+  order: fifo
+resources:
   - ../base
 
 patches:

--- a/base-kustomize/designate/base/kustomization.yaml
+++ b/base-kustomize/designate/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - designate-mariadb-database.yaml
   - designate-rabbitmq-queue.yaml

--- a/base-kustomize/envoyproxy-gateway/base/kustomization.yaml
+++ b/base-kustomize/envoyproxy-gateway/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - './namespace.yaml'
   - './gatewayclass.yaml'

--- a/base-kustomize/gateway/base/kustomization.yaml
+++ b/base-kustomize/gateway/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - all.yaml
 patches:

--- a/base-kustomize/gateway/envoyproxy/kustomization.yaml
+++ b/base-kustomize/gateway/envoyproxy/kustomization.yaml
@@ -1,2 +1,4 @@
+sortOptions:
+  order: fifo
 resources:
   - './gateway.yaml'         # namespace: envoy-gateway-system (common gateway)

--- a/base-kustomize/gateway/nginx-gateway-fabric/kustomization.yaml
+++ b/base-kustomize/gateway/nginx-gateway-fabric/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - internal-gateway-api.yaml # namespace: nginx-gateway (common gateway)
   - internal-gateway-issuer.yaml #namespace: nginx-gateway

--- a/base-kustomize/glance/aio/kustomization.yaml
+++ b/base-kustomize/glance/aio/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+sortOptions:
+  order: fifo
+resources:
   - ../base
 
 patches:

--- a/base-kustomize/glance/base/kustomization.yaml
+++ b/base-kustomize/glance/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - glance-mariadb-database.yaml
   - glance-rabbitmq-queue.yaml

--- a/base-kustomize/gnocchi/aio/kustomization.yaml
+++ b/base-kustomize/gnocchi/aio/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+sortOptions:
+  order: fifo
+resources:
   - ../base
 
 patches:

--- a/base-kustomize/gnocchi/base/kustomization.yaml
+++ b/base-kustomize/gnocchi/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - gnocchi-temp-keyring.yaml
   - all.yaml

--- a/base-kustomize/grafana/base/kustomization.yaml
+++ b/base-kustomize/grafana/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - ns-grafana.yaml
   - azure-client-secret.yaml

--- a/base-kustomize/heat/aio/kustomization.yaml
+++ b/base-kustomize/heat/aio/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+sortOptions:
+  order: fifo
+resources:
   - ../base
 
 patches:

--- a/base-kustomize/heat/base/kustomization.yaml
+++ b/base-kustomize/heat/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - heat-mariadb-database.yaml
   - heat-rabbitmq-queue.yaml

--- a/base-kustomize/horizon/aio/kustomization.yaml
+++ b/base-kustomize/horizon/aio/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+sortOptions:
+  order: fifo
+resources:
   - ../base
 
 patches:

--- a/base-kustomize/horizon/base/kustomization.yaml
+++ b/base-kustomize/horizon/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - horizon-mariadb-database.yaml
   - all.yaml

--- a/base-kustomize/k8s-dashboard/kustomization.yaml
+++ b/base-kustomize/k8s-dashboard/kustomization.yaml
@@ -1,2 +1,4 @@
+sortOptions:
+  order: fifo
 resources:
   - dashboard-rbac-default.yaml

--- a/base-kustomize/keystone/aio/kustomization.yaml
+++ b/base-kustomize/keystone/aio/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+sortOptions:
+  order: fifo
+resources:
   - ../base
 
 patches:

--- a/base-kustomize/keystone/base/kustomization.yaml
+++ b/base-kustomize/keystone/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - keystone-mariadb-database.yaml
   - keystone-rabbitmq-queue.yaml

--- a/base-kustomize/kustomize.sh
+++ b/base-kustomize/kustomize.sh
@@ -3,5 +3,5 @@ set -e
 KUSTOMIZE_DIR=${1:-$GENESTACK_KUSTOMIZE_ARG}
 pushd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null
     cat <&0 > "${KUSTOMIZE_DIR}"/../base/all.yaml
-    kubectl kustomize --reorder='none' "${KUSTOMIZE_DIR}"
+    kubectl kustomize "${KUSTOMIZE_DIR}"
 popd &>/dev/null

--- a/base-kustomize/magnum/aio/kustomization.yaml
+++ b/base-kustomize/magnum/aio/kustomization.yaml
@@ -1,2 +1,4 @@
-bases:
+sortOptions:
+  order: fifo
+resources:
   - ../base

--- a/base-kustomize/magnum/base/kustomization.yaml
+++ b/base-kustomize/magnum/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - magnum-mariadb-database.yaml
   - magnum-rabbitmq-queue.yaml

--- a/base-kustomize/mariadb-cluster/aio/kustomization.yaml
+++ b/base-kustomize/mariadb-cluster/aio/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+sortOptions:
+  order: fifo
+resources:
   - "../base"
 
 patches:

--- a/base-kustomize/mariadb-cluster/base/kustomization.yaml
+++ b/base-kustomize/mariadb-cluster/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - mariadb-configmap.yaml
   - mariadb-replication.yaml

--- a/base-kustomize/mariadb-cluster/galera/kustomization.yaml
+++ b/base-kustomize/mariadb-cluster/galera/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+sortOptions:
+  order: fifo
+resources:
   - "../base"
 
 patches:

--- a/base-kustomize/mariadb-operator/kustomization.yaml
+++ b/base-kustomize/mariadb-operator/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - ns-mariadb.yaml
 

--- a/base-kustomize/memcached/aio/kustomization.yaml
+++ b/base-kustomize/memcached/aio/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+sortOptions:
+  order: fifo
 resources:
   - ../base
 

--- a/base-kustomize/memcached/base-monitoring/kustomization.yaml
+++ b/base-kustomize/memcached/base-monitoring/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+sortOptions:
+  order: fifo
 resources:
   - ../base
 

--- a/base-kustomize/memcached/base/kustomization.yaml
+++ b/base-kustomize/memcached/base/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+sortOptions:
+  order: fifo
 resources:
   - all.yaml
 

--- a/base-kustomize/neutron/aio/kustomization.yaml
+++ b/base-kustomize/neutron/aio/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+sortOptions:
+  order: fifo
+resources:
   - ../base
 
 patches:

--- a/base-kustomize/neutron/base/kustomization.yaml
+++ b/base-kustomize/neutron/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - neutron-mariadb-database.yaml
   - neutron-rabbitmq-queue.yaml

--- a/base-kustomize/nova/aio/kustomization.yaml
+++ b/base-kustomize/nova/aio/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+sortOptions:
+  order: fifo
+resources:
   - ../base
 
 patches:

--- a/base-kustomize/nova/base/kustomization.yaml
+++ b/base-kustomize/nova/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - nova-mariadb-database.yaml
   - nova-rabbitmq-queue.yaml

--- a/base-kustomize/octavia/aio/kustomization.yaml
+++ b/base-kustomize/octavia/aio/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+sortOptions:
+  order: fifo
+resources:
   - ../base
 
 patches:

--- a/base-kustomize/octavia/base/kustomization.yaml
+++ b/base-kustomize/octavia/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - octavia-mariadb-database.yaml
   - octavia-rabbitmq-queue.yaml

--- a/base-kustomize/openstack/kustomization.yaml
+++ b/base-kustomize/openstack/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - ns-openstack.yaml
   - issuer-kube-system-selfsigned.yaml

--- a/base-kustomize/ovn-backup/base/kustomization.yaml
+++ b/base-kustomize/ovn-backup/base/kustomization.yaml
@@ -12,5 +12,7 @@ configMapGenerator:
   - name: ovn-backup-config
     envs:
     - ovn-backup.config
+sortOptions:
+  order: fifo
 resources:
   - ovn-backup.yaml

--- a/base-kustomize/ovn/kustomization.yaml
+++ b/base-kustomize/ovn/kustomization.yaml
@@ -1,2 +1,4 @@
+sortOptions:
+  order: fifo
 resources:
   - ovn-setup.yaml

--- a/base-kustomize/placement/aio/kustomization.yaml
+++ b/base-kustomize/placement/aio/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+sortOptions:
+  order: fifo
+resources:
   - ../base
 
 patches:

--- a/base-kustomize/placement/base/kustomization.yaml
+++ b/base-kustomize/placement/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - placement-mariadb-database.yaml
   - all.yaml

--- a/base-kustomize/postgres-cluster/aio/kustomization.yaml
+++ b/base-kustomize/postgres-cluster/aio/kustomization.yaml
@@ -1,2 +1,4 @@
+sortOptions:
+  order: fifo
 resources:
   - postgres-cluster.yaml

--- a/base-kustomize/postgres-cluster/base/kustomization.yaml
+++ b/base-kustomize/postgres-cluster/base/kustomization.yaml
@@ -1,2 +1,4 @@
+sortOptions:
+  order: fifo
 resources:
   - postgres-cluster.yaml

--- a/base-kustomize/postgres-operator/kustomization.yaml
+++ b/base-kustomize/postgres-operator/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - ns-postgres.yaml
 

--- a/base-kustomize/prometheus-mysql-exporter/kustomization.yaml
+++ b/base-kustomize/prometheus-mysql-exporter/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - monitoring_user_create.yaml
   - monitoring_user_grant.yaml

--- a/base-kustomize/prometheus/base/kustomization.yaml
+++ b/base-kustomize/prometheus/base/kustomization.yaml
@@ -1,2 +1,4 @@
+sortOptions:
+  order: fifo
 resources:
   - all.yaml

--- a/base-kustomize/rabbitmq-cluster/aio/kustomization.yaml
+++ b/base-kustomize/rabbitmq-cluster/aio/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+sortOptions:
+  order: fifo
+resources:
   - ../base
 
 patches:

--- a/base-kustomize/rabbitmq-cluster/base/kustomization.yaml
+++ b/base-kustomize/rabbitmq-cluster/base/kustomization.yaml
@@ -1,2 +1,4 @@
+sortOptions:
+  order: fifo
 resources:
   - rabbitmq-cluster.yaml

--- a/base-kustomize/rabbitmq-operator/kustomization.yaml
+++ b/base-kustomize/rabbitmq-operator/kustomization.yaml
@@ -1,2 +1,4 @@
+sortOptions:
+  order: fifo
 resources:
   - cluster-operator.yaml

--- a/base-kustomize/rabbitmq-topology-operator/kustomization.yaml
+++ b/base-kustomize/rabbitmq-topology-operator/kustomization.yaml
@@ -1,2 +1,4 @@
+sortOptions:
+  order: fifo
 resources:
   - messaging-topology-operator-with-certmanager.yaml

--- a/base-kustomize/rook-cluster-external-pvc/kustomization.yaml
+++ b/base-kustomize/rook-cluster-external-pvc/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - cluster-on-pvc.yaml
   - toolbox.yaml

--- a/base-kustomize/rook-cluster/kustomization.yaml
+++ b/base-kustomize/rook-cluster/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - rook-cluster.yaml
   - toolbox.yaml

--- a/base-kustomize/rook-defaults-external-pvc/kustomization.yaml
+++ b/base-kustomize/rook-defaults-external-pvc/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - filesystem.yaml
   - storageclass-cephfs.yaml

--- a/base-kustomize/rook-defaults/kustomization.yaml
+++ b/base-kustomize/rook-defaults/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - filesystem.yaml
   - storageclass-cephfs.yaml

--- a/base-kustomize/rook-operator/kustomization.yaml
+++ b/base-kustomize/rook-operator/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - crds.yaml
   - common.yaml

--- a/base-kustomize/sealed-secrets/base/kustomization.yaml
+++ b/base-kustomize/sealed-secrets/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - './namespace.yaml'
 namespace: sealed-secrets

--- a/base-kustomize/skyline/aio/kustomization.yaml
+++ b/base-kustomize/skyline/aio/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+sortOptions:
+  order: fifo
+resources:
   - ../base
 
 patches:

--- a/base-kustomize/skyline/base/kustomization.yaml
+++ b/base-kustomize/skyline/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - skyline-mariadb-database.yaml
   - services.yaml

--- a/base-kustomize/topolvm/general/kustomization.yaml
+++ b/base-kustomize/topolvm/general/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - ns-topolvm.yaml
 

--- a/base-kustomize/vault-secrets-operator/base/kustomization.yaml
+++ b/base-kustomize/vault-secrets-operator/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - './namespace.yaml'
 

--- a/base-kustomize/vault/base/kustomization.yaml
+++ b/base-kustomize/vault/base/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - './namespace.yaml'
   - './ssl/'

--- a/base-kustomize/vault/base/local_storage/kustomization.yaml
+++ b/base-kustomize/vault/base/local_storage/kustomization.yaml
@@ -1,3 +1,5 @@
+sortOptions:
+  order: fifo
 resources:
   - './local_sc.yaml'
   - './vault-dwpp.yaml'

--- a/base-kustomize/vault/base/ssl/kustomization.yaml
+++ b/base-kustomize/vault/base/ssl/kustomization.yaml
@@ -1,4 +1,6 @@
 namespace: vault
+sortOptions:
+  order: fifo
 resources:
   - './vault-selfsigned-issuer.yaml'
   - './vault-selfsigned-ca.yaml'


### PR DESCRIPTION
Kustomize has deprecated the use of a couple feature flags and we need to make adjustments to ensure that we're maintaining the environment in expected ways.

* remove the CLI option from `kustomize.sh` to disable automatic reordering
* add the `sortOptions` keyword to the base kustomization files to ensure resource sorting is handled as fifo.
* replace the `bases` keyword with the `resources` keyword