### PR TITLE
fix(grafana): change grant name to grafana-grant

### DIFF
--- a/base-kustomize/grafana/base/grafana-database.yaml
+++ b/base-kustomize/grafana/base/grafana-database.yaml
@@ -41,7 +41,7 @@ spec:
 apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
-  name: grant
+  name: grafana-grant
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep


### PR DESCRIPTION
All of the grants are prefixed with the service name, found grafana missing this convention so fixing it for style and to prevent confusion.