### PR TITLE
feat: update kubespray to v2.26.0

### DIFF
--- a/ansible/inventory/genestack/group_vars/k8s_cluster/addons.yml
+++ b/ansible/inventory/genestack/group_vars/k8s_cluster/addons.yml
@@ -173,6 +173,7 @@ cert_manager_controller_extra_args:
 
 # MetalLB deployment
 metallb_enabled: true
+metallb_namespace: metallb-system
 metallb_speaker_enabled: "{{ metallb_enabled }}"
 # metallb_version: v0.13.9
 # metallb_protocol: "layer2"

--- a/ansible/inventory/genestack/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/ansible/inventory/genestack/group_vars/k8s_cluster/k8s-cluster.yml
@@ -17,7 +17,7 @@ kube_token_dir: "{{ kube_config_dir }}/tokens"
 kube_api_anonymous_auth: true
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
-kube_version: v1.28.6
+kube_version: v1.28.12
 
 # Where the binaries will be downloaded.
 # Note: ensure that you've enough disk space (about 1G)

--- a/docs/k8s-kubespray-upgrade.md
+++ b/docs/k8s-kubespray-upgrade.md
@@ -14,7 +14,7 @@ Running upgrades with Kubespary is handled by the `upgrade-cluster.yml` playbook
 
 ## Preparing the upgrade
 
-When running Kubespray using the Genestack submodule, review the [Genestack Update Process](https://github.com/rackerlabs/genestack/wiki/Running-a-Genestack-upgrade) before continuing with the kubespray upgrade and deployment.
+When running Kubespray using the Genestack submodule, review the [Genestack Update Process](https://docs.rackspacecloud.com/genestack-upgrade) before continuing with the kubespray upgrade and deployment.
 
 Genestack stores inventory in the `/etc/genestack/inventory` directory. Before running the upgrade, you will need to set the **kube_version** variable to your new target version. This variable is generally found within the `/etc/genestack/inventory/group_vars/k8s_cluster/k8s-cluster.yml` file.
 
@@ -40,10 +40,14 @@ Change to the `kubespary` directory.
 cd /opt/genestack/submodules/kubespray
 ```
 
+!!! note
+
+    When running an upgrade be sure to set the `kube_version` variable to the desired version number.
+
 Now run the upgrade.
 
 ``` shell
-ansible-playbook upgrade-cluster.yml
+ansible-playbook upgrade-cluster.yml -e kube_version=${VERSION_NUMBER}
 ```
 
 !!! note
@@ -55,8 +59,22 @@ ansible-playbook upgrade-cluster.yml
 When running an upgrade, it is possible to force the upgrade by running the cluster playbook with the `upgrade_cluster_setup` flag set to **true**. This option is a lot faster, though does introduce the possibility of service disruption during the upgrade operation.
 
 ``` shell
-ansible-playbook cluster.yml -e upgrade_cluster_setup=true
+ansible-playbook cluster.yml -e upgrade_cluster_setup=true -e kube_version=${VERSION_NUMBER}
 ```
+
+### Upgrade Hangs
+
+There are times when an upgrade will hang, in these cases you may need to use a second terminal to check the status of the upgrade.
+
+!!! example "Hung Namespace Finalizers"
+
+    If you find that the upgrade is hanging on a namespace, you may need to remove the finalizers from the namespace to allow the upgrade to continue.
+
+    ``` shell
+    kubectl get namespace "${NAMESPACE}" -o json \
+        | tr -d "\n" | sed "s/\"finalizers\": \[[^]]\+\]/\"finalizers\": []/" \
+        | kubectl replace --raw "/api/v1/namespaces/${NAMESPACE}/finalize" -f -
+    ```
 
 ### Post upgrade operations
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
-ansible>=6.7.0,<=8.5.0
+ansible>9.0,<10.0
+ansible-core<2.17.0
 cryptography==43.0.1
 jinja2==3.1.4
 jmespath==1.0.1
+jsonschema<=4.23.0
 MarkupSafe==2.1.3
 netaddr==0.9.0
 pbr==5.11.1


### PR DESCRIPTION
This change retains support for our current version of Kubernetes but also ensures that we have future support for upgrades as needed.