### PR TITLE
feat: add ops docs for ovn-to-openstack updates

### DIFF
--- a/docs/infrastructure-ovn-setup.md
+++ b/docs/infrastructure-ovn-setup.md
@@ -8,7 +8,6 @@
 
 Post deployment we need to setup neutron to work with our integrated OVN environment. To make that work we have to annotate or nodes. Within the following commands we'll use a lookup to label all of our nodes the same way, however, the power of this system is the ability to customize how our machines are labeled and therefore what type of hardware layout our machines will have. This gives us the ability to use different hardware in different machines, in different availability zones. While this example is simple your cloud deployment doesn't have to be.
 
-
 ## OVN Annotations
 
 | <div style="width:220px">key</div> | type | <div style="width:128px">value</div>  | notes |
@@ -31,6 +30,10 @@ You should set the annotations you need within your environment to meet the need
     ``` shell
     export ALL_NODES=$(kubectl get nodes -l 'openstack-network-node=enabled' -o 'jsonpath={.items[*].metadata.name}')
     ```
+
+!!! tip "Post Deployment"
+
+    Review the OVN Operations Guide for more information on how to manage your OVN environment post deployment. The guide can be found [here](ovn-kube-ovn-openstack.md). The guide will help you understand how to manage your OVN environment and how to troubleshoot issues that may arise.
 
 ### Set `ovn.openstack.org/int_bridge`
 

--- a/docs/ovn-kube-ovn-openstack.md
+++ b/docs/ovn-kube-ovn-openstack.md
@@ -1,0 +1,35 @@
+# OVN Post Deployment Updates
+
+Updates to the OVN environment can be made post deployment. All of the required OVN annotations are applied to the nodes in the cluster and can be changed at any time. However, in order to apply the changes, the label `ovn.openstack.org/configured` must be removed to permit the **ovn-setup** daemonset to reapply the configuration.
+
+!!! tip
+
+    Review the the OVN Deployment Guide for more information on how to manage your OVN environment post deployment. The guide can be found [here](infrastructure-ovn-setup.md).
+
+## Label Overview
+
+| <div style="width:220px">key</div> | type | <div style="width:128px">value</div>  | notes |
+|:-----|--|:----------------:|:------|
+| **ovn.openstack.org/configured** | int | `EPOC` | The EPOC time when the confirguration was last applied |
+
+### `ovn.openstack.org/configured`
+
+When the **ovn-setup** Daemonset runs, the `ovn.openstack.org/configured` label is applied to the nodes in the cluster. This label is used to determine if the configuration has been applied to the node. If the label is present, the **ovn-setup** Daemonset will not reapply the configuration to the node. If the label is removed, the **ovn-setup** Daemonset will reapply the configuration to the node.
+
+## Removing the `ovn.openstack.org/configured` label
+
+To remove the `ovn.openstack.org/configured` label from all nodes.
+
+``` shell
+kubectl label nodes ${NODE_NAME} ovn.openstack.org/configured-
+```
+
+!!! note "Global Configuration Updates"
+
+    The `ovn-setup` daemonset will reapply the configuration to the nodes in the cluster. If you need to reapply changes to all nodes within the cluster, you can remove the label from all nodes at the same time with the following command:
+
+    ``` shell
+    kubectl label nodes --all ovn.openstack.org/configured-
+    ```
+
+Once the label is removed, the **ovn-setup** Daemonset will immediately reapply the configuration to the nodes in the cluster automatically.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -250,6 +250,7 @@ nav:
               - Database Backup: infrastructure-ovn-db-backup.md
               - Monitoring introduction: ovn-monitoring-introduction.md
               - Claim Storm alert: ovn-alert-claim-storm.md
+              - Updating Kube OVN to OpenStack Configuration: ovn-kube-ovn-openstack.md
           - MariaDB:
               - Operations: infrastructure-mariadb-ops.md
       - Observability:


### PR DESCRIPTION
This change adds docs to highlight how we run updates to the environment when making changes to the ovn environment, for use with OpenStack.