### PR TITLE
fix(gnocchi): pg admin password ref new secret

### DIFF
--- a/bin/install-gnocchi.sh
+++ b/bin/install-gnocchi.sh
@@ -12,7 +12,7 @@ pushd /opt/genestack/submodules/openstack-helm-infra || exit
         --set endpoints.identity.auth.gnocchi.password="$(kubectl --namespace openstack get secret gnocchi-admin -o jsonpath='{.data.password}' | base64 -d)" \
         --set endpoints.oslo_db.auth.admin.password="$(kubectl --namespace openstack get secret mariadb -o jsonpath='{.data.root-password}' | base64 -d)" \
         --set endpoints.oslo_db.auth.gnocchi.password="$(kubectl --namespace openstack get secret gnocchi-db-password -o jsonpath='{.data.password}' | base64 -d)" \
-        --set endpoints.oslo_db_postgresql.auth.admin.password="$(kubectl --namespace openstack get secret postgresql-db-admin -o jsonpath='{.data.password}' | base64 -d)" \
+        --set endpoints.oslo_db_postgresql.auth.admin.password="$(kubectl --namespace openstack get secret postgres.postgres-cluster.credentials.postgresql.acid.zalan.do -o jsonpath='{.data.password}' | base64 -d)" \
         --set endpoints.oslo_db_postgresql.auth.gnocchi.password="$(kubectl --namespace openstack get secret gnocchi-pgsql-password -o jsonpath='{.data.password}' | base64 -d)" \
         --post-renderer /etc/genestack/kustomize/kustomize.sh \
         --post-renderer-args gnocchi/overlay "$@"


### PR DESCRIPTION
The Postgres operator installs the admin password into this secret. The old secret reference was from when installs were being done using openstack-helm-infra.