### PR TITLE
ensure db pods live on seperate worker nodes

### DIFF
--- a/base-kustomize/mariadb-cluster/base/mariadb-replication.yaml
+++ b/base-kustomize/mariadb-cluster/base/mariadb-replication.yaml
@@ -12,6 +12,25 @@ spec:
   database: mariadb
   image: mariadb:10.11.7
 
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node-role.kubernetes.io/worker
+                operator: In
+                values:
+                  - worker
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - mariadb
+          topologyKey: kubernetes.io/hostname
+
   storage:
     size: 10Gi
     storageClassName: general
@@ -19,7 +38,7 @@ spec:
     waitForVolumeResize: true
     volumeClaimTemplate:
       accessModes:
-      - ReadWriteOnce
+        - ReadWriteOnce
       resources:
         requests:
           storage: 10Gi

--- a/base-kustomize/mariadb-cluster/base/mariadb-replication.yaml
+++ b/base-kustomize/mariadb-cluster/base/mariadb-replication.yaml
@@ -24,11 +24,11 @@ spec:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/name
-                operator: In
-                values:
-                  - mariadb
+          matchExpressions:
+            - key: app.kubernetes.io/instance
+              operator: In
+              values:
+                - mariadb-cluster
           topologyKey: kubernetes.io/hostname
 
   storage:


### PR DESCRIPTION
During testing, it was found that we are not applying affinity / anti-affinity to the mariadb-cluster pods.  This pr enforces affinity and anti-affinity to only allow db pods to de scheduled to worker nodes.