### PR TITLE
fix: resolve gateway-api-external reference

### DIFF
--- a/manifests/metallb/metallb-openstack-service-lb.yml
+++ b/manifests/metallb/metallb-openstack-service-lb.yml
@@ -2,7 +2,7 @@
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
 metadata:
-  name: openstack-external
+  name: gateway-api-external
   namespace: metallb-system
 spec:
   addresses:
@@ -16,13 +16,13 @@ metadata:
   namespace: metallb-system
 spec:
   ipAddressPools:
-    - openstack-external
-  nodeSelectors:  # Optional block to limit nodes for a given advertisement
-    - matchLabels:
-        kubernetes.io/hostname: controller01.your.domain.tld
-    - matchLabels:
-        kubernetes.io/hostname: controller02.your.domain.tld
-    - matchLabels:
-        kubernetes.io/hostname: controller03.your.domain.tld
-  interfaces:  # Optional block to limit ifaces used to advertise VIPs
-    - br-mgmt
+    - gateway-api-external
+  # nodeSelectors:  # Optional block to limit nodes for a given advertisement
+  #   - matchLabels:
+  #       kubernetes.io/hostname: controller01.your.domain.tld
+  #   - matchLabels:
+  #       kubernetes.io/hostname: controller02.your.domain.tld
+  #   - matchLabels:
+  #       kubernetes.io/hostname: controller03.your.domain.tld
+  # interfaces:  # Optional block to limit ifaces used to advertise VIPs
+  #   - br-mgmt


### PR DESCRIPTION
The pool name we were setting doesn't match the nginx-gateway reference. This change makes them match.