### PR TITLE
fix: remove nova az reference

### DIFF
--- a/docs/openstack-neutron-networks.md
+++ b/docs/openstack-neutron-networks.md
@@ -8,7 +8,7 @@ The following commands are examples of creating several different network types.
 
 ``` shell
 openstack --os-cloud default network create --share \
-                                            --availability-zone-hint nova \
+                                            --availability-zone-hint az1 \
                                             --external \
                                             --provider-network-type flat \
                                             --provider-physical-network physnet1 \
@@ -31,7 +31,7 @@ openstack --os-cloud default subnet create --subnet-range 172.16.24.0/22 \
 
 ``` shell
 openstack --os-cloud default network create --share \
-                                            --availability-zone-hint nova \
+                                            --availability-zone-hint az1 \
                                             --external \
                                             --provider-segment 404 \
                                             --provider-network-type vlan \


### PR DESCRIPTION
This change removes the old "nova" availability zone reference. 