### PR TITLE
disable antiaffintiy as its not currently supported

### DIFF
--- a/base-kustomize/mariadb-cluster/base/mariadb-replication.yaml
+++ b/base-kustomize/mariadb-cluster/base/mariadb-replication.yaml
@@ -11,7 +11,6 @@ spec:
   username: mariadb
   database: mariadb
   image: mariadb:10.11.7
-
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -21,15 +20,16 @@ spec:
                 operator: In
                 values:
                   - worker
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-          matchExpressions:
-            - key: app.kubernetes.io/instance
-              operator: In
-              values:
-                - mariadb-cluster
-          topologyKey: kubernetes.io/hostname
+    # NOTE: (brew) uncomment below when we update to a newer mariadb crd
+#    podAntiAffinity:
+#      requiredDuringSchedulingIgnoredDuringExecution:
+#        - labelSelector:
+#          matchExpressions:
+#            - key: app.kubernetes.io/instance
+#              operator: In
+#              values:
+#                - mariadb-cluster
+#          topologyKey: kubernetes.io/hostname
 
   storage:
     size: 10Gi


### PR DESCRIPTION
Currently anti-affinity is not supported by our version of the mariadb CRD.  This pr disables anti-affinity by commented it out until such time as we can update the version of the CRD we are using.