### PR TITLE
feat: Update k8s to the latest 1.30.4

### DIFF
--- a/ansible/inventory/genestack/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/ansible/inventory/genestack/group_vars/k8s_cluster/k8s-cluster.yml
@@ -17,7 +17,7 @@ kube_token_dir: "{{ kube_config_dir }}/tokens"
 kube_api_anonymous_auth: true
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
-kube_version: v1.28.12
+kube_version: v1.30.4
 
 # Where the binaries will be downloaded.
 # Note: ensure that you've enough disk space (about 1G)


### PR DESCRIPTION
This change was implemented to ensure that we're deploying a recent version of k8s by default.

Co-Authored-By: Luke Repko <luke.repko@rackspace.com>
Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>