### PR TITLE
fix: Use internal barbican endpoint type

### DIFF
--- a/base-helm-configs/cinder/cinder-helm-overrides.yaml
+++ b/base-helm-configs/cinder/cinder-helm-overrides.yaml
@@ -803,6 +803,8 @@ conf:
       use_multipath_for_image_xfer: False #Add Cinder Multipath support for image xfer
     database:
       max_retries: -1
+    barbican:
+      barbican_endpoint_type: internal
     key_manager:
       backend: barbican
     keystone_authtoken:


### PR DESCRIPTION
By default the barbican client in cinder uses `public`, but that is not ideal for communication between cinder and barbican in a local cluster. Update this to be internal, as public comms might not work in some environments by design.