### PR TITLE
fix(nova): enable stdout handler for root logger

### DIFF
--- a/base-helm-configs/nova/nova-helm-overrides.yaml
+++ b/base-helm-configs/nova/nova-helm-overrides.yaml
@@ -1510,7 +1510,7 @@ conf:
         - context
         - default
     logger_root:
-      level: INFO
+      level: WARNING
       handlers:
         - stdout
     logger_nova:


### PR DESCRIPTION
Noticed expected logging was missing when trying to troubleshoot an issue with Nova crashing. Found the root logger had a null handler, this should not be. Gave it `stdout` at which point I was able to see the errors and traceback from the relevant module(s).

JIRA: OSPC-1019