### PR TITLE
modify the annotation for the nginx-gateway-fabric to gateway-api-external

### DIFF
--- a/base-helm-configs/nginx-gateway-fabric/helm-overrides.yaml
+++ b/base-helm-configs/nginx-gateway-fabric/helm-overrides.yaml
@@ -88,7 +88,7 @@ service:
   externalTrafficPolicy: Cluster
   ## The annotations of the NGINX Gateway Fabric service.
   annotations:
-    "metallb.universe.tf/address-pool": "openstack-external"
+    "metallb.universe.tf/address-pool": "gateway-api-external"
     "metallb.universe.tf/allow-shared-ip": "openstack-external-svc"
 
   ## A list of ports to expose through the NGINX Gateway Fabric service. Update it to match the listener ports from


### PR DESCRIPTION
this PR is raised to modify the annotation in the nginx-gateway-fabric service to the gateway-api-external pool in metallb