### PR TITLE
fix: remove config-template

### DIFF
--- a/ansible-collection-requirements.yml
+++ b/ansible-collection-requirements.yml
@@ -8,9 +8,6 @@ collections:
   - name: https://github.com/ansible-collections/community.general
     version: 8.2.0
     type: git
-  - name: https://opendev.org/openstack/ansible-config_template
-    version: 2.1.0
-    type: git
   - name: https://github.com/ansible-collections/kubernetes.core
     version: 3.2.0
     type: git

--- a/ansible/roles/host_setup/defaults/main.yml
+++ b/ansible/roles/host_setup/defaults/main.yml
@@ -29,10 +29,6 @@ host_environment_path:
   - /sbin
   - /bin
 
-# Allows the ability to override or add extra parameters to the systemd global config
-# that will be applied by default to all units
-systemd_global_overrides: {}
-
 # The following garbage collection values are set to better support lots of neutron networks/routers.
 #  Used for setting the net.ipv4/6.neigh.default.gc_thresh* values. This assumes that facts were
 #  gathered to obtain the total amount of memory available on a given host. If no facts are gathered

--- a/ansible/roles/host_setup/handlers/main.yml
+++ b/ansible/roles/host_setup/handlers/main.yml
@@ -28,7 +28,3 @@
   until: _restart  is success
   retries: 5
   delay: 2
-
-- name: Systemd daemon reload
-  systemd:
-    daemon_reload: yes

--- a/ansible/roles/host_setup/tasks/main.yml
+++ b/ansible/roles/host_setup/tasks/main.yml
@@ -55,18 +55,6 @@
     group: "root"
     mode: "0755"
 
-- name: Add DefaultEnvironment to systemd
-  openstack.config_template.config_template:
-    src: systemd-environment.j2
-    dest: /etc/systemd/system.conf.d/genestack-default-environment.conf
-    owner: "root"
-    group: "root"
-    mode: "0644"
-    config_overrides: "{{ systemd_global_overrides }}"
-    config_type: ini
-  notify: Systemd daemon reload
-  when: systemd_global_overrides is defined
-
 - name: Remove the blacklisted packages
   package:
     name: "{{ host_package_list | selectattr('state', 'equalto', 'absent') | map(attribute='name') | list }}"

--- a/ansible/roles/host_setup/templates/modprobe.conf.j2
+++ b/ansible/roles/host_setup/templates/modprobe.conf.j2
@@ -1,4 +1,3 @@
-# {{ ansible_managed }}
 # Modules from the genestack host_setup role
 {% for module in host_kernel_modules + host_specific_kernel_modules %}
 {{ module.name }}

--- a/ansible/roles/host_setup/templates/sysstat.cron.debian.j2
+++ b/ansible/roles/host_setup/templates/sysstat.cron.debian.j2
@@ -1,5 +1,3 @@
-# {{ ansible_managed }}
-
 # The first element of the path is a directory where the debian-sa1 script is located
 PATH=/usr/lib/sysstat:/usr/sbin:/usr/sbin:/usr/bin:/sbin:/bin
 

--- a/ansible/roles/host_setup/templates/sysstat.default.j2
+++ b/ansible/roles/host_setup/templates/sysstat.default.j2
@@ -1,5 +1,3 @@
-# {{ ansible_managed }}
-
 #
 # Default settings for /etc/init.d/sysstat, /etc/cron.d/sysstat
 # and /etc/cron.daily/sysstat files

--- a/ansible/roles/host_setup/templates/systemd-environment.j2
+++ b/ansible/roles/host_setup/templates/systemd-environment.j2
@@ -1,4 +1,0 @@
-# {{ ansible_managed }}
-
-[Manager]
-DefaultEnvironment=REQUESTS_CA_BUNDLE={{ ca_bundle_path }}


### PR DESCRIPTION
The config-template module, while useful, wasn't being used, so we removed it.