### PR TITLE
fix: resolve token size error

### DIFF
--- a/base-helm-configs/keystone/keystone-helm-overrides.yaml
+++ b/base-helm-configs/keystone/keystone-helm-overrides.yaml
@@ -499,7 +499,7 @@ conf:
   keystone:
     DEFAULT:
       log_config_append: /etc/keystone/logging.conf
-      max_token_size: 255
+      max_token_size: 300
       # NOTE(rk760n): if you need auth notifications to be sent, uncomment it
       # notification_opt_out: ""
     token:


### PR DESCRIPTION
Resolves error when token size generation exceeds 255.

``` log
2025-01-25 20:30:24.489983 2025-01-25 20:30:24.489 9 INFO keystone.token.token_formatters [None req-03c07355-b705-4591-bcc2-1dcf172ec5c0 5cc1aa7e42870935a560cf436ec7faed59981b4585e84993c56c4fc49edfe705 870adeaf387f4ad68f179dc989721269 - - c82f424b9db24fb4a86cb80359c6211f c82f424b9db24fb4a86cb80359c6211f] Fernet token created with length of 268 characters, which exceeds 255 characters
```

This change simply sets the limit to 300 as recommended when using other federation providers.