### PR TITLE
fix: add nvme-cli as a base package

### DIFF
--- a/Containerfiles/NovaEFI-Containerfile
+++ b/Containerfiles/NovaEFI-Containerfile
@@ -16,7 +16,7 @@ COPY --from=build /var/lib/openstack/. /var/lib/openstack/
 # Py Packages for the following features:
 # - Nova: Libosinfo
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y ovmf open-iscsi multipath-tools libgirepository-1.0-1 libgirepository1.0-dev \
-                                 libcairo2-dev python3-dev gcc libosinfo-bin gir1.2-libosinfo-1.0 nfs-common cryptsetup; \
+                                 libcairo2-dev python3-dev gcc libosinfo-bin gir1.2-libosinfo-1.0 nfs-common cryptsetup nvme-cli; \
     rm -rf /var/cache/apt/archives /var/lib/apt/lists; \
     apt clean; /var/lib/openstack/bin/pip install pygobject; \
     find /var/lib/openstack -regex '^.*\(__pycache__\|\.py[co]\)$' -delete

--- a/ansible/roles/host_setup/vars/debian.yml
+++ b/ansible/roles/host_setup/vars/debian.yml
@@ -52,6 +52,7 @@ _host_distro_packages:
   - libkmod2
   - lvm2
   - nfs-client
+  - nvme-cli
   - open-iscsi
   - rsync
   - software-properties-common

--- a/ansible/roles/host_setup/vars/ubuntu.yml
+++ b/ansible/roles/host_setup/vars/ubuntu.yml
@@ -51,6 +51,7 @@ _host_distro_packages:
   - libkmod2
   - lvm2
   - nfs-client
+  - nvme-cli
   - rsync
   - software-properties-common
   - sysstat


### PR DESCRIPTION
os-brick requires nvme-cli to be installed otherwise it throws warnings

``` log
2025-01-26 01:21:49.169 3229256 WARNING os_brick.privileged.nvmeof [-] Could not generate host nqn: [Errno 2] No such file or directory: 'nvme'
```

This change simply ensures that the tool is installed on our hosts by default.