### PR TITLE
fix: memcached size limits

### DIFF
--- a/base-helm-configs/memcached/memcached-helm-overrides.yaml
+++ b/base-helm-configs/memcached/memcached-helm-overrides.yaml
@@ -123,7 +123,18 @@ args: []
 ##   - name: FOO
 ##     value: "bar"
 ##
-extraEnvVars: []
+# Set the cache size limit to less than the PVC size, default is 10Gi, vlaue is written in megabytes
+# Review https://hub.docker.com/r/bitnami/memcached for more information.
+extraEnvVars:
+  - name: MEMCACHED_CACHE_SIZE
+    value: "9216"
+  - name: MEMCACHED_MAX_CONNECTIONS
+    value: "4096"
+  - name: MEMCACHED_THREADS
+    value: "8"
+  - name: MEMCACHED_MAX_ITEM_SIZE
+    value: "4194304"
+
 ## @param extraEnvVarsCM Name of existing ConfigMap containing extra env vars for Memcached nodes
 ##
 extraEnvVarsCM: ""


### PR DESCRIPTION
This change updates our memcached values file, without this change memcached is running stock settings, with only 64M of cache, 4 threads, and a very limited number of allowed connections. This adjusts the settings to run with known good configurations and documents how operators can change the values as needed.