### PR TITLE
fix: Add oneshot service for queue max handling

### DIFF
--- a/ansible/roles/host_setup/files/queue_max.service
+++ b/ansible/roles/host_setup/files/queue_max.service
@@ -1,0 +1,10 @@
+[Unit]
+Description = Oneshot service for queue max
+After = network-online.target
+
+[Service]
+Type = oneshot
+ExecStart = /usr/local/bin/queue_max.sh
+
+[Install]
+WantedBy = multi-user.target

--- a/ansible/roles/host_setup/files/queue_max.sh
+++ b/ansible/roles/host_setup/files/queue_max.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2086,SC2046
+set -e
+
+# NOTE(cloudnull): This script is intended to be run on a system that has
+#                  multiple physical network interfaces. The script will
+#                  disable the hardware offload for the interfaces and set
+#                  the RX and TX queue sizes to 90% of the maximum value
+#                  to avoid packet loss.
+#
+#                  This script was written because the default values for
+#                  the RX and TX queue sizes are often too low practical
+#                  applications and has been observed to cause packet loss
+#                  in some cases, when the system is under heavy load.
+
+function ethernetDevs () {
+    # Returns all physical devices
+    ip -details -json link show | jq -r '.[] |
+        if .linkinfo.info_kind // .link_type == "loopback" or (.ifname | test("idrac+")) then
+            empty
+        else
+            .ifname
+        end
+    '
+}
+
+function functionSetMax () {
+    echo "Setting queue max $dev"
+    # The RX value is set to 90% of the max value to avoid packet loss
+    ethtool -G $1 rx $(ethtool --json -g $1 | jq '.[0] | ."rx-max" * .9 | round')
+    # The TX value is set to the max value
+    ethtool -G $1 tx $(ethtool --json -g $1 | jq '.[0] | ."tx-max"')
+}
+
+function functionHWTCOffloadOff () {
+    if [[ $(ethtool --json -k $1 | jq '.[] | ."hw-tc-offload"') != "null" ]]; then
+        echo "Disabling hw tc offload $dev"
+        ethtool -K $1 hw-tc-offload off
+    fi
+}
+
+jq --version || (echo "jq is not installed. Attempting to install jq" && apt update && apt -y install jq)
+
+ethernetDevs | while read -r dev; do
+    functionSetMax $dev
+    functionHWTCOffloadOff $dev
+done

--- a/ansible/roles/host_setup/handlers/main.yml
+++ b/ansible/roles/host_setup/handlers/main.yml
@@ -32,3 +32,9 @@
 - name: Systemd daemon reload
   ansible.builtin.systemd:
     daemon_reload: true
+
+- name: Restart sysstat
+  ansible.builtin.systemd:
+    name: "queue_max.service"
+    state: "restarted"
+    enabled: true

--- a/ansible/roles/host_setup/tasks/configure_hosts.yml
+++ b/ansible/roles/host_setup/tasks/configure_hosts.yml
@@ -65,3 +65,16 @@
   ansible.builtin.include_tasks: sysstat.yml
   when:
     - host_sysstat_enabled | bool
+
+- name: Create queue max script
+  ansible.builtin.copy:
+    src: queue_max.sh
+    dest: /usr/local/bin/queue_max.sh
+    mode: "0755"
+
+- name: Create queue max service
+  ansible.builtin.copy:
+    src: queue_max.service
+    dest: /etc/systemd/system/queue_max.service
+    mode: "0644"
+  notify: Load and start queue_max service


### PR DESCRIPTION
Implement the service one shot for automatically setting the queue max.

Related Issue: https://rackspace.atlassian.net/browse/OSPC-832
Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>