### PR TITLE
add --service-type options to limit neutron provider networks from di…

### DIFF
--- a/docs/openstack-neutron-networks.md
+++ b/docs/openstack-neutron-networks.md
@@ -1,9 +1,10 @@
 # Creating Different Neutron Network Types
 
 The following commands are examples of creating several different network types.
-NOTE: When creating the subnet we are spefically limiting neutrons ability to attached
-ip's from Provider networks directly to instances with --service-type.  If you want
-to attach Provider network ip's directly to instances, remove those three lines.
+NOTE: When creating the subnet we are specifically limiting neutrons ability to attach
+ip's from Shared Provider networks directly to instances with --service-type.  If you want
+to attach Shared Provider Network's ip's directly to instances, remove lines beginning with
+--service-type
 
 ## Create Shared Provider Networks
 

--- a/docs/openstack-neutron-networks.md
+++ b/docs/openstack-neutron-networks.md
@@ -1,6 +1,9 @@
 # Creating Different Neutron Network Types
 
 The following commands are examples of creating several different network types.
+NOTE: When creating the subnet we are spefically limiting neutrons ability to attached
+ip's from Provider networks directly to instances with --service-type.  If you want
+to attach Provider network ip's directly to instances, remove those three lines.
 
 ## Create Shared Provider Networks
 
@@ -24,6 +27,9 @@ openstack --os-cloud default subnet create --subnet-range 172.16.24.0/22 \
                                            --allocation-pool start=172.16.25.150,end=172.16.25.200 \
                                            --dhcp \
                                            --network flat \
+                                           --service-type network:floatingip \
+                                           --service-type network:router_gateway \
+                                           --service-type network:distributed \
                                            flat_subnet
 ```
 
@@ -48,6 +54,9 @@ openstack --os-cloud default subnet create --subnet-range 10.10.10.0/23 \
                                            --allocation-pool start=10.10.11.10,end=10.10.11.254 \
                                            --dhcp \
                                            --network vlan404 \
+                                           --service-type network:floatingip \
+                                           --service-type network:router_gateway \
+                                           --service-type network:distributed \
                                            vlan404_subnet
 ```
 


### PR DESCRIPTION
We do not wish for Provider network's ip's provisioned from theirt subnets to be directly attached to instances.  Update the doc to reference how to manually create provider networks subnets with the three --service-type options.  This work was already being done in: https://github.com/rackerlabs/genestack/blob/main/ansible/playbooks/network-service-types.yaml 