### PR TITLE
feat: update rabbitmq config

### DIFF
--- a/base-helm-configs/barbican/barbican-helm-overrides.yaml
+++ b/base-helm-configs/barbican/barbican-helm-overrides.yaml
@@ -415,14 +415,14 @@ conf:
     oslo_middleware:
       enable_proxy_headers_parsing: true
     oslo_messaging_rabbit:
-      amqp_durable_queues: true
+      amqp_durable_queues: false
       # We define use of quorum queues via kustomize but this was enabling HA queues instead
       # ha_queues are deprecated, explicitly set to false and set quorum_queue true
       rabbit_ha_queues: false
       rabbit_quorum_queue: true
       # TODO: Not available until 2024.1, but once it is, we want to enable these!
       # new feature ref; https://docs.openstack.org/releasenotes/oslo.messaging/2024.1.html
-      rabbit_transient_quorum_queue: true
+      rabbit_transient_quorum_queue: false
       use_queue_manager: true
       # Reconnect after a node outage more quickly
       rabbit_interval_max: 10
@@ -656,7 +656,7 @@ endpoints:
     hosts:
       default: rabbitmq-nodes
     host_fqdn_override:
-      default: null
+      default: rabbitmq.openstack.svc.cluster.local
     path: /barbican
     scheme: rabbit
     port:

--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -101,14 +101,14 @@ conf:
     oslo_concurrency:
       lock_path: /tmp/ceilometer
     oslo_messaging_rabbit:
-      amqp_durable_queues: true
+      amqp_durable_queues: false
       # We define use of quorum queues via kustomize but this was enabling HA queues instead
       # ha_queues are deprecated, explicitly set to false and set quorum_queue true
       rabbit_ha_queues: false
       rabbit_quorum_queue: true
       # TODO: Not available until 2024.1, but once it is, we want to enable these!
       # new feature ref; https://docs.openstack.org/releasenotes/oslo.messaging/2024.1.html
-      rabbit_transient_quorum_queue: true
+      rabbit_transient_quorum_queue: false
       use_queue_manager: true
       # Reconnect after a node outage more quickly
       rabbit_interval_max: 10
@@ -1944,7 +1944,7 @@ endpoints:
     hosts:
       default: rabbitmq
     host_fqdn_override:
-      default: null
+      default: rabbitmq.openstack.svc.cluster.local
     path: /ceilometer
     scheme: rabbit
     port:

--- a/base-helm-configs/cinder/cinder-helm-overrides.yaml
+++ b/base-helm-configs/cinder/cinder-helm-overrides.yaml
@@ -830,14 +830,14 @@ conf:
     oslo_middleware:
       enable_proxy_headers_parsing: true
     oslo_messaging_rabbit:
-      amqp_durable_queues: true
+      amqp_durable_queues: false
       # We define use of quorum queues via kustomize but this was enabling HA queues instead
       # ha_queues are deprecated, explicitly set to false and set quorum_queue true
       rabbit_ha_queues: false
       rabbit_quorum_queue: true
       # TODO: Not available until 2024.1, but once it is, we want to enable these!
       # new feature ref; https://docs.openstack.org/releasenotes/oslo.messaging/2024.1.html
-      rabbit_transient_quorum_queue: true
+      rabbit_transient_quorum_queue: false
       use_queue_manager: true
       # Reconnect after a node outage more quickly
       rabbit_interval_max: 10
@@ -1369,7 +1369,7 @@ endpoints:
     hosts:
       default: rabbitmq-nodes
     host_fqdn_override:
-      default: null
+      default: rabbitmq.openstack.svc.cluster.local
     path: /cinder
     scheme: rabbit
     port:

--- a/base-helm-configs/designate/designate-helm-overrides.yaml
+++ b/base-helm-configs/designate/designate-helm-overrides.yaml
@@ -476,14 +476,14 @@ conf:
     oslo_messaging_notifications:
       driver: messagingv2
     oslo_messaging_rabbit:
-      amqp_durable_queues: true
+      amqp_durable_queues: false
       # We define use of quorum queues via kustomize but this was enabling HA queues instead
       # ha_queues are deprecated, explicitly set to false and set quorum_queue true
       rabbit_ha_queues: false
       rabbit_quorum_queue: true
       # TODO: Not available until 2024.1, but once it is, we want to enable these!
       # new feature ref; https://docs.openstack.org/releasenotes/oslo.messaging/2024.1.html
-      rabbit_transient_quorum_queue: true
+      rabbit_transient_quorum_queue: false
       use_queue_manager: true
       # Reconnect after a node outage more quickly
       rabbit_interval_max: 10
@@ -723,7 +723,7 @@ endpoints:
     hosts:
       default: rabbitmq-nodes
     host_fqdn_override:
-      default: null
+      default: rabbitmq.openstack.svc.cluster.local
     path: /designate
     scheme: rabbit
     port:

--- a/base-helm-configs/glance/glance-helm-overrides.yaml
+++ b/base-helm-configs/glance/glance-helm-overrides.yaml
@@ -271,14 +271,14 @@ conf:
     oslo_messaging_notifications:
       driver: messagingv2
     oslo_messaging_rabbit:
-      amqp_durable_queues: true
+      amqp_durable_queues: false
       # We define use of quorum queues via kustomize but this was enabling HA queues instead
       # ha_queues are deprecated, explicitly set to false and set quorum_queue true
       rabbit_ha_queues: false
       rabbit_quorum_queue: true
       # TODO: Not available until 2024.1, but once it is, we want to enable these!
       # new feature ref; https://docs.openstack.org/releasenotes/oslo.messaging/2024.1.html
-      rabbit_transient_quorum_queue: true
+      rabbit_transient_quorum_queue: false
       use_queue_manager: true
       # Reconnect after a node outage more quickly
       rabbit_interval_max: 10
@@ -648,7 +648,7 @@ endpoints:
     hosts:
       default: rabbitmq-nodes
     host_fqdn_override:
-      default: null
+      default: rabbitmq.openstack.svc.cluster.local
     path: /glance
     scheme: rabbit
     port:

--- a/base-helm-configs/heat/heat-helm-overrides.yaml
+++ b/base-helm-configs/heat/heat-helm-overrides.yaml
@@ -375,14 +375,14 @@ conf:
     oslo_concurrency:
       lock_path: /tmp/heat
     oslo_messaging_rabbit:
-      amqp_durable_queues: true
+      amqp_durable_queues: false
       # We define use of quorum queues via kustomize but this was enabling HA queues instead
       # ha_queues are deprecated, explicitly set to false and set quorum_queue true
       rabbit_ha_queues: false
       rabbit_quorum_queue: true
       # TODO: Not available until 2024.1, but once it is, we want to enable these!
       # new feature ref; https://docs.openstack.org/releasenotes/oslo.messaging/2024.1.html
-      rabbit_transient_quorum_queue: true
+      rabbit_transient_quorum_queue: false
       use_queue_manager: true
       # Reconnect after a node outage more quickly
       rabbit_interval_max: 10
@@ -913,7 +913,7 @@ endpoints:
     hosts:
       default: rabbitmq-nodes
     host_fqdn_override:
-      default: null
+      default: rabbitmq.openstack.svc.cluster.local
     path: /heat
     scheme: rabbit
     port:

--- a/base-helm-configs/keystone/keystone-helm-overrides.yaml
+++ b/base-helm-configs/keystone/keystone-helm-overrides.yaml
@@ -527,14 +527,14 @@ conf:
     oslo_messaging_notifications:
       driver: messagingv2
     oslo_messaging_rabbit:
-      amqp_durable_queues: true
+      amqp_durable_queues: false
       # We define use of quorum queues via kustomize but this was enabling HA queues instead
       # ha_queues are deprecated, explicitly set to false and set quorum_queue true
       rabbit_ha_queues: false
       rabbit_quorum_queue: true
       # TODO: Not available until 2024.1, but once it is, we want to enable these!
       # new feature ref; https://docs.openstack.org/releasenotes/oslo.messaging/2024.1.html
-      rabbit_transient_quorum_queue: true
+      rabbit_transient_quorum_queue: false
       use_queue_manager: true
       # Reconnect after a node outage more quickly
       rabbit_interval_max: 10
@@ -1016,7 +1016,7 @@ endpoints:
     hosts:
       default: rabbitmq-nodes
     host_fqdn_override:
-      default: null
+      default: rabbitmq.openstack.svc.cluster.local
     path: /keystone
     scheme: rabbit
     port:

--- a/base-helm-configs/keystone/keystone-helm-overrides.yaml
+++ b/base-helm-configs/keystone/keystone-helm-overrides.yaml
@@ -758,13 +758,15 @@ conf:
               max: 0
   mpm_event: |
     <IfModule mpm_event_module>
-      ServerLimit         1024
+      ServerLimit         16
       StartServers        32
       MinSpareThreads     32
-      MaxSpareThreads     256
-      ThreadsPerChild     25
-      MaxRequestsPerChild 128
-      ThreadLimit         720
+      MaxSpareThreads     128
+      ThreadLimit         64
+      ThreadsPerChild     16
+      MaxRequestWorkers   256
+      MaxMemFree          256
+      MaxConnectionsPerChild 0
     </IfModule>
   wsgi_keystone: |
     {{- $portInt := tuple "identity" "service" "api" $ | include "helm-toolkit.endpoints.endpoint_port_lookup" }}
@@ -779,11 +781,12 @@ conf:
     CustomLog /dev/stdout proxy env=forwarded
 
     <VirtualHost *:{{ $portInt }}>
-        WSGIDaemonProcess keystone-public processes=1 threads=1 user=keystone group=keystone display-name=%{GROUP}
+        WSGIDaemonProcess keystone-public processes=2 threads=8 user=keystone group=keystone display-name=%{GROUP}
         WSGIProcessGroup keystone-public
         WSGIScriptAlias / /var/www/cgi-bin/keystone/keystone-wsgi-public
         WSGIApplicationGroup %{GLOBAL}
         WSGIPassAuthorization On
+        LimitRequestBody 114688
         <IfVersion >= 2.4>
           ErrorLogFormat "%{cu}t %M"
         </IfVersion>

--- a/base-helm-configs/magnum/magnum-helm-overrides.yaml
+++ b/base-helm-configs/magnum/magnum-helm-overrides.yaml
@@ -105,14 +105,14 @@ conf:
     oslo_concurrency:
       lock_path: /tmp/magnum
     oslo_messaging_rabbit:
-      amqp_durable_queues: true
+      amqp_durable_queues: false
       # We define use of quorum queues via kustomize but this was enabling HA queues instead
       # ha_queues are deprecated, explicitly set to false and set quorum_queue true
       rabbit_ha_queues: false
       rabbit_quorum_queue: true
       # TODO: Not available until 2024.1, but once it is, we want to enable these!
       # new feature ref; https://docs.openstack.org/releasenotes/oslo.messaging/2024.1.html
-      rabbit_transient_quorum_queue: true
+      rabbit_transient_quorum_queue: false
       use_queue_manager: true
       # Reconnect after a node outage more quickly
       rabbit_interval_max: 10
@@ -506,7 +506,7 @@ endpoints:
     hosts:
       default: rabbitmq-nodes
     host_fqdn_override:
-      default: null
+      default: rabbitmq.openstack.svc.cluster.local
     path: /magnum
     scheme: rabbit
     port:

--- a/base-helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/base-helm-configs/neutron/neutron-helm-overrides.yaml
@@ -1809,14 +1809,14 @@ conf:
     oslo_messaging_notifications:
       driver: messagingv2
     oslo_messaging_rabbit:
-      amqp_durable_queues: true
+      amqp_durable_queues: false
       # We define use of quorum queues via kustomize but this was enabling HA queues instead
       # ha_queues are deprecated, explicitly set to false and set quorum_queue true
       rabbit_ha_queues: false
       rabbit_quorum_queue: true
       # TODO: Not available until 2024.1, but once it is, we want to enable these!
       # new feature ref; https://docs.openstack.org/releasenotes/oslo.messaging/2024.1.html
-      rabbit_transient_quorum_queue: true
+      rabbit_transient_quorum_queue: false
       use_queue_manager: true
       # Reconnect after a node outage more quickly
       rabbit_interval_max: 10
@@ -2257,7 +2257,7 @@ endpoints:
     hosts:
       default: rabbitmq-nodes
     host_fqdn_override:
-      default: null
+      default: rabbitmq.openstack.svc.cluster.local
     path: /neutron
     scheme: rabbit
     port:

--- a/base-helm-configs/nova/nova-helm-overrides.yaml
+++ b/base-helm-configs/nova/nova-helm-overrides.yaml
@@ -1460,14 +1460,14 @@ conf:
     oslo_messaging_notifications:
       driver: messagingv2
     oslo_messaging_rabbit:
-      amqp_durable_queues: true
+      amqp_durable_queues: false
       # We define use of quorum queues via kustomize but this was enabling HA queues instead
       # ha_queues are deprecated, explicitly set to false and set quorum_queue true
       rabbit_ha_queues: false
       rabbit_quorum_queue: true
       # TODO: Not available until 2024.1, but once it is, we want to enable these!
       # new feature ref; https://docs.openstack.org/releasenotes/oslo.messaging/2024.1.html
-      rabbit_transient_quorum_queue: true
+      rabbit_transient_quorum_queue: false
       use_queue_manager: true
       # Reconnect after a node outage more quickly
       rabbit_interval_max: 10
@@ -1715,7 +1715,7 @@ endpoints:
     hosts:
       default: rabbitmq-nodes
     host_fqdn_override:
-      default: null
+      default: rabbitmq.openstack.svc.cluster.local
     path: /nova
     scheme: rabbit
     port:

--- a/base-helm-configs/octavia/octavia-helm-overrides.yaml
+++ b/base-helm-configs/octavia/octavia-helm-overrides.yaml
@@ -247,14 +247,14 @@ conf:
     oslo_concurrency:
       lock_path: /tmp/octavia
     oslo_messaging_rabbit:
-      amqp_durable_queues: true
+      amqp_durable_queues: false
       # We define use of quorum queues via kustomize but this was enabling HA queues instead
       # ha_queues are deprecated, explicitly set to false and set quorum_queue true
       rabbit_ha_queues: false
       rabbit_quorum_queue: true
       # TODO: Not available until 2024.1, but once it is, we want to enable these!
       # new feature ref; https://docs.openstack.org/releasenotes/oslo.messaging/2024.1.html
-      rabbit_transient_quorum_queue: true
+      rabbit_transient_quorum_queue: false
       use_queue_manager: true
       # Reconnect after a node outage more quickly
       rabbit_interval_max: 10
@@ -526,7 +526,7 @@ endpoints:
     hosts:
       default: rabbitmq-nodes
     host_fqdn_override:
-      default: null
+      default: rabbitmq.openstack.svc.cluster.local
     path: /octavia
     scheme: rabbit
     port:

--- a/base-helm-configs/placement/placement-helm-overrides.yaml
+++ b/base-helm-configs/placement/placement-helm-overrides.yaml
@@ -74,14 +74,14 @@ conf:
     oslo_concurrency:
       lock_path: /tmp/octavia
     oslo_messaging_rabbit:
-      amqp_durable_queues: true
+      amqp_durable_queues: false
       # We define use of quorum queues via kustomize but this was enabling HA queues instead
       # ha_queues are deprecated, explicitly set to false and set quorum_queue true
       rabbit_ha_queues: false
       rabbit_quorum_queue: true
       # TODO: Not available until 2024.1, but once it is, we want to enable these!
       # new feature ref; https://docs.openstack.org/releasenotes/oslo.messaging/2024.1.html
-      rabbit_transient_quorum_queue: true
+      rabbit_transient_quorum_queue: false
       use_queue_manager: true
       # Reconnect after a node outage more quickly
       rabbit_interval_max: 10

--- a/base-kustomize/rabbitmq-cluster/base/rabbitmq-cluster.yaml
+++ b/base-kustomize/rabbitmq-cluster/base/rabbitmq-cluster.yaml
@@ -12,7 +12,7 @@ spec:
       cpu: 500m
       memory: 2Gi
     limits:
-      memory: 32Gi
+      memory: 2Gi
   rabbitmq:
     additionalConfig: |
       cluster_partition_handling = pause_minority


### PR DESCRIPTION
Update the config to revert the use of `rabbit_transient_quorum_queue`, while this option works, it appears to be buggy and not quite ready for full scale operations.

This change also sets the rabbitmq service to use the fqdn of the rabbitmq svc load-balancer.