### PR TITLE
fix (multipath): consolidate restarts to single handler

### DIFF
--- a/ansible/playbooks/host-setup.yml
+++ b/ansible/playbooks/host-setup.yml
@@ -53,8 +53,7 @@
             group: root
             mode: "0644"
           notify:
-            - Restart multipathd systemd service
-            - Restart multipath-tools systemd service
+            - Restart multipathd and multipath-tools service
     - name: Install open-iscsi and multipath on nova compute nodes
       when:
         - enable_iscsi | default(false) | bool
@@ -78,15 +77,12 @@
             state: "{{ (_multipath_packages is changed) | ternary('restarted', 'started') }}"
             enabled: true
   handlers:
-    - name: Restart multipathd systemd service
+    - name: Restart multipathd and multipath-tools service
       ansible.builtin.systemd:
-        name: multipathd
+        name: "{{ item }}"
         state: restarted
         daemon_reload: true
         enabled: true
-    - name: Restart multipath-tools systemd service
-      ansible.builtin.systemd:
-        name: multipath-tools
-        state: restarted
-        daemon_reload: true
-        enabled: true
+      loop:
+        - multipathd
+        - multipath-tools


### PR DESCRIPTION
Orignally i had intended to have seperate handlers for multipathd and multipath-tools thinking there might be a time we want to restart either service.  After reviewing the playbook, we will want to restart both services on any etc/muiltipath.conf change.  No need for seperate handlers.  This PR consolidates both service restarts into a single handler.