### PR TITLE
grafana and other doc updates

### DIFF
--- a/docs/accelerated-computing-infrastructure.md
+++ b/docs/accelerated-computing-infrastructure.md
@@ -40,6 +40,7 @@ The high-performance, fixed-port switches are designed to meet the demands of mo
       necessary for modern, next-generation networks.
 
 **Key Use Cases**:
+
   1. **High-Density Data Center Access**: For data centers needing flexible port speeds (1G to 100G) to connect virtualized
      servers, storage, and applications.
 
@@ -150,6 +151,7 @@ These high-performance computing (HPC) servers are designed to handle the most d
         SUSE, Ubuntu, VMware ESXi, and others, making them versatile for various workloads and environments.
 
 **Key Use Cases**:
+
   1. **AI/ML Model Training and Inference**: For deep learning, real-time AI inference, and AI model training.
 
   2. **High-Performance Computing (HPC)**: For scientific research, simulations, and computational-intensive tasks.
@@ -213,6 +215,7 @@ The high-performance application delivery and security controller are designed t
       for diverse infrastructures.
 
 **Key Use Cases**:
+
   1. **Large Enterprises and Data Centers**: Perfect for organizations needing efficient traffic management, enhanced application
      performance, and robust security.
 
@@ -269,6 +272,7 @@ This next-generation firewall is designed for large-scale environments, includin
       operational costs and minimizing environmental impact.
 
 **Key Use Cases**:
+
   1. **Enterprise Data Centers**: Ideal for large data centers requiring high throughput, threat protection, and efficient traffic
      management.
 

--- a/docs/adding-new-node.md
+++ b/docs/adding-new-node.md
@@ -6,6 +6,7 @@ In order to add a new worker node, we follow the steps as outlined by the kubesp
 Lets assume we are adding one new worker node: `computegpu001.p40.example.com` and add to relevant sections.
 
 1. Add the node to your ansible inventory file
+
 ```shell
    vim /etc/genestack/inventory/inventory.yaml
 ```
@@ -13,12 +14,14 @@ Lets assume we are adding one new worker node: `computegpu001.p40.example.com` a
 2. Ensure hostname is correctly set and hosts file has 127.0.0.1 entry
 
 3. Run scale.yaml to add the node to your cluster
+
 ```shell
    source /opt/genestack/scripts/genestack.rc
    ansible-playbook scale.yml --limit compute-12481.rackerlabs.dev.local --become
 ```
 
 Once step 3 competes succesfully, validate that the node is up and running in the cluster
+
 ```shell
    kubectl get nodes | grep compute-12481.rackerlabs.dev.local
 ```
@@ -45,11 +48,13 @@ Once the node is added in k8s cluster, adding the node to openstack service is s
 labels and annotations.
 
 1. Export the nodes to add
+
 ```shell
    export NODES='compute-12481.rackerlabs.dev.local'
 ```
 
 2. For compute node add the following labels
+
 ```shell
    # Label the openstack compute nodes
    kubectl label node compute-12481.rackerlabs.dev.local openstack-compute-node=enabled
@@ -59,6 +64,7 @@ labels and annotations.
 ```
 
 3. Add the right annotations to the node
+
 ```shell
    kubectl annotate \
         nodes \
@@ -87,6 +93,7 @@ labels and annotations.
 ```
 
 4. Verify all the services are up and running
+
 ```shell
    kubectl get pods -n openstack -o wide | grep "computegpu"
 ```

--- a/docs/alerting-info.md
+++ b/docs/alerting-info.md
@@ -9,7 +9,6 @@ to maintain the health of our systems.
 In this document we'll dive a bit deeper into the alerting components and how they're configured and used to maintain the health of our genestack.
 Please take a look at the [Monitoring Information Doc](monitoring-info.md) for more information regarding how the metrics and stats are collected in order to make use of our alerting mechanisms.
 
-
 ## Prometheus Alerting
 
 As noted in the [Monitoring Information Doc](monitoring-info.md) we make heavy use of [Prometheus](https://prometheus.io) and within the Genestack workflow specifically we deploy the [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) which handles deployment of the Prometheus servers, operators, alertmanager and various other components.
@@ -47,7 +46,6 @@ To deploy any new rules you would simply run the [Prometheus Deployment](prometh
     --8<-- "bin/install-prometheus.sh"
     ```
 
-
 ## Alert Manager
 
 The kube-prometheus-stack not only contains our monitoring components such as Prometheus and related CRD's, but it also contains another important features, the [Alert Manager](https://prometheus.io/docs/alerting/latest/alertmanager/).
@@ -61,11 +59,11 @@ The below diagram gives a better idea of how the Alert Manager works with Promet
 Genestack provides a basic [alertmanager_config](https://github.com/rackerlabs/genestack/blob/main/base-helm-configs/prometheus/alertmanager_config.yaml) that's separated out from the primary Prometheus configurations for similar reasons the [alerting rules](https://github.com/rackerlabs/genestack/blob/main/base-helm-configs/prometheus/alerting_rules.yaml) are.
 Here we can see the key components of the Alert Manager config that allows us to group and send our alerts to external services for further action.
 
- * [Inhibit Rules](https://prometheus.io/docs/alerting/latest/configuration/#inhibition-related-settings)
+* [Inhibit Rules](https://prometheus.io/docs/alerting/latest/configuration/#inhibition-related-settings)
     Inhibition rules allows us to establish dependencies between systems or services so that only the most relevant set of alerts are sent out during an outage
- * [Routes](https://prometheus.io/docs/alerting/latest/configuration/#route-related-settings)
+* [Routes](https://prometheus.io/docs/alerting/latest/configuration/#route-related-settings)
     Routing-related settings allow configuring how alerts are routed, aggregated, throttled, and muted based on time.
- * [Receivers](https://prometheus.io/docs/alerting/latest/configuration/#general-receiver-related-settings)
+* [Receivers](https://prometheus.io/docs/alerting/latest/configuration/#general-receiver-related-settings)
     Receiver settings allow configuring notification destinations for our alerts.
 
 These are all explained in greater detail in the [Alert Manager Docs](https://prometheus.io/docs/alerting/latest/configuration/#configuration).

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -8,5 +8,6 @@ hide:
 
 ![Genestack Logo](assets/images/genestack-cropped-small.png){ align=left : style="filter:drop-shadow(#3c3c3c 0.5rem 0.5rem 10px);" }
 
-## :octicons-quote-24: Available Regions:
+## :octicons-quote-24: Available Regions
+
 - [SJC](https://status.api.sjc3.rackspacecloud.com/) ![status](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Frackerlabs%2Frs-flex-uptime%2Frefs%2Fheads%2Fmaster%2Fstatus.json)

--- a/docs/documentation-standards.md
+++ b/docs/documentation-standards.md
@@ -106,8 +106,8 @@ Bullets are used to denote unordered lists.  To have nested layers of bullets, y
 This will render like this:
 
 - Bullet
-    - Sub bullet
-        - Sub sub bullet
+  - Sub bullet
+    - Sub sub bullet
 
 **NOTE:** [Markdownlint](#markdownlint) will complain, saying that you should _indent by 2_ unless you change or ignore rule [MD007](https://github.com/DavidAnson/markdownlint/blob/main/doc/md007.md){:target="_blank"}.
 

--- a/docs/etcd-backup.md
+++ b/docs/etcd-backup.md
@@ -11,7 +11,6 @@ matching is-etcd-backup-enabled.
 3. Secrets required for the backup to function. These include the location of the
 S3 endpoint, access keys, and etcd certs to access etcd endpoints.
 
-
 Label one or more box in the cluster to run the job:
 
 ```
@@ -38,7 +37,6 @@ kubectl --namespace openstack \
 !!! note
 
     Make sure to use the correct values for your region.
-
 
 Next, Deploy the backup job:
 

--- a/docs/genestack-logging.md
+++ b/docs/genestack-logging.md
@@ -6,7 +6,6 @@
 
 Genestack logging is a straight forward system that collects, stores and provides an interface to search and read logs on-demand.  The storage backend is open to fit the needs of your deployment, so whether backing up to Openstack Swift, S3, Ceph, or file-share, Genestack logging can fit in your environment.
 
-
 Out-of-box Genestack logging is comprised of three separate technologies:
 
 - [Fluentbit](https://fluentbit.io/), a fast and lightweight telemetry agent for logs, metrics, and traces for Linux, macOS, Windows, and BSD family operating systems.  Fluentbit grabs log entries immediately from your Kubernetes application and ships them to Loki for aggregation
@@ -47,7 +46,7 @@ Let's break down the process of how Fluent Bit, Kubernetes, Loki, and OpenStack 
 
     OpenStack Swift, or other S3-Compatible storage solutions such Ceph,  provides object storage leveraging Swift's durability and scalability to store archived logs for extended periods.
 
-### Key Benefits of This Architecture:
+### Key Benefits of This Architecture
 
 - Efficient Log Collection: Fluent Bit's lightweight design and efficient data transfer mechanisms ensure timely log collection.
 - Scalable Log Aggregation: Loki's distributed architecture can handle large volumes of logs and scale horizontally to meet increasing demands.

--- a/docs/genestack-upgrade.md
+++ b/docs/genestack-upgrade.md
@@ -2,7 +2,7 @@
 
 Running a genestack upgrade is fairly simple and consists of mainly updating the `git` checkout and then running through the needed `helm` charts to deploy updated applications.
 
-## Change to the genestack directory.
+## Change to the genestack directory
 
 ``` shell
 cd /opt/genestack

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -53,6 +53,10 @@ Before running the deployment script, you must set the `custom_host` value `graf
         --8<-- "base-helm-configs/grafana/azure-overrides.yaml.example"
         ```
 
+## Listeners and Routes
+
+Listeners and Routes should have been configureed when you installed the Gateway API.  If so some reason they were not created, please following the install guide here: [Gateway API](infrastructure-gateway-api-custom.md)
+
 ## Installation
 
 Run the Grafana deployment Script `bin/install-grafana.sh`

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ hide:
 
     [:octicons-comment-24: Join the Discord](https://discord.gg/2mN5yZvV3a)
 
--   :material-alpha:{ .xl .middle } - __Genestack__  __/dʒen.ə.stæk/__
+- :material-alpha:{ .xl .middle } - __Genestack__  __/dʒen.ə.stæk/__
 
     1. The Genesis of your Open-Infrastructure
     2. Your new favorite ecosystem
@@ -23,14 +23,14 @@ hide:
     4. The cloud simplified
     5. Hybrid by design
 
--   :material-abacus:{ .xl .middle } __Rackspace Cloud Solutions__
+- :material-abacus:{ .xl .middle } __Rackspace Cloud Solutions__
 
     Where Kubernetes and OpenStack tango in the cloud. Imagine a waltz between systems that deploy what you need.
     Operators play the score, managing the complexity with a flick of their digital batons. They unify the chaos,
     making scaling and management a piece of cake. Think of it like a conductor effortlessly guiding a cacophony
     into a symphony.
 
--   :material-cloud:{ .lg } __Simple Solutions__
+- :material-cloud:{ .lg } __Simple Solutions__
 
     Learn about the components.
 

--- a/docs/infrastructure-gateway-api-custom.md
+++ b/docs/infrastructure-gateway-api-custom.md
@@ -32,7 +32,7 @@ kubectl patch -n nginx-gateway gateway flex-gateway \
 
 !!! note "This step is not needed if all routes were applied when the Gateway API was deployed"
 
-A custom gateway route can be used when setting up the service. The custom route make it possible to for a domain like `your.domain.tld` to be used for the service.
+A custom gateway route can be used when setting up the service. The custom route make it possible for a domain like `your.domain.tld` to be used.
 
 ??? abstract "Example routes file found in `/opt/genestack/etc/gateway-api/routes`"
 

--- a/docs/infrastructure-mariadb.md
+++ b/docs/infrastructure-mariadb.md
@@ -17,10 +17,12 @@
         ```
 
 ## Deploy the mariadb operator
+
 ```
 cluster_name=`kubectl config view --minify -o jsonpath='{.clusters[0].name}'`
 echo $cluster_name
 ```
+
 If `cluster_name` was anything other than `cluster.local` you should pass that as a parameter to the installer
 
 !!! example "Run the mariadb-operator deployment Script `bin/install-mariadb-operator.sh` You can include cluster_name paramater. No paramaters deploys with `cluster.local` cluster name."

--- a/docs/infrastructure-memcached.md
+++ b/docs/infrastructure-memcached.md
@@ -20,7 +20,7 @@
 
 View the [memcached exporter](prometheus-memcached-exporter.md) instructions to install a HA ready memcached cluster with monitoring and metric collection enabled.
 
-## Verify readiness with the following command.
+## Verify readiness with the following command
 
 ``` shell
 kubectl --namespace openstack get horizontalpodautoscaler.autoscaling memcached -w

--- a/etc/gateway-api/listeners/grafana-https.json
+++ b/etc/gateway-api/listeners/grafana-https.json
@@ -1,0 +1,27 @@
+[
+    {
+        "op": "add",
+        "path": "/spec/listeners/-",
+        "value": {
+            "name": "grafana-https",
+            "port": 443,
+            "protocol": "HTTPS",
+            "hostname": "grafana.your.domain.tld",
+            "allowedRoutes": {
+                "namespaces": {
+                    "from": "All"
+                }
+            },
+            "tls": {
+                "certificateRefs": [
+                    {
+                        "group": "",
+                        "kind": "Secret",
+                        "name": "grafana-gw-tls-secret"
+                    }
+                ],
+                "mode": "Terminate"
+            }
+        }
+    }
+]

--- a/etc/gateway-api/listeners/loki-https.json
+++ b/etc/gateway-api/listeners/loki-https.json
@@ -1,0 +1,17 @@
+[
+    {
+        "op": "add",
+        "path": "/spec/listeners/-",
+        "value": {
+            "name": "loki-http",
+            "port": 80,
+            "protocol": "HTTP",
+            "hostname": "internal.loki-gateway.your.domain.tld",
+            "allowedRoutes": {
+                "namespaces": {
+                    "from": "All"
+                }
+            }
+        }
+    }
+]

--- a/etc/gateway-api/routes/custom-grafana-routes.yaml
+++ b/etc/gateway-api/routes/custom-grafana-routes.yaml
@@ -1,0 +1,25 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: grafana-gateway-route
+  namespace: grafana
+spec:
+  hostnames:
+  - grafana.your.domain.tld
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: flex-gateway
+    namespace: nginx-gateway
+    sectionName: grafana-https
+  rules:
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: grafana
+      port: 80
+      weight: 1
+    matches:
+    - path:
+        type: PathPrefix
+        value: /

--- a/etc/gateway-api/routes/custom-loki-internal-routes.yaml
+++ b/etc/gateway-api/routes/custom-loki-internal-routes.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: internal-loki-gateway-route
+  namespace: grafana
+spec:
+  parentRefs:
+  - name: flex-gateway
+    sectionName: loki-http
+    namespace: nginx-gateway
+  hostnames:
+  - "internal.loki-gateway.your.domain.tld"
+  rules:
+    - backendRefs:
+      - name: loki-gateway
+        port: 80


### PR DESCRIPTION
added grafana / loki listener patches to base as well as route examples.  Expanded on the grafana doc to include a Listener and Route section that redirects back to the Gateway API docs if needing to patch the nginx-gateway or add a httproute.  Also ran the docs through a linter.

