### PR TITLE
chore: update hpa settings

### DIFF
--- a/base-kustomize/barbican/base/hpa-barbican-api.yaml
+++ b/base-kustomize/barbican/base/hpa-barbican-api.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           type: AverageValue

--- a/base-kustomize/ceilometer/base/hpa-ceilometer-notification.yaml
+++ b/base-kustomize/ceilometer/base/hpa-ceilometer-notification.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           type: AverageValue

--- a/base-kustomize/cinder/base/hpa-cinder-api.yaml
+++ b/base-kustomize/cinder/base/hpa-cinder-api.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           type: AverageValue

--- a/base-kustomize/cinder/base/hpa-cinder-scheduler.yaml
+++ b/base-kustomize/cinder/base/hpa-cinder-scheduler.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           type: AverageValue

--- a/base-kustomize/glance/base/hpa-glance-api.yaml
+++ b/base-kustomize/glance/base/hpa-glance-api.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           type: AverageValue

--- a/base-kustomize/gnocchi/base/hpa-gnocchi-api.yaml
+++ b/base-kustomize/gnocchi/base/hpa-gnocchi-api.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           type: AverageValue

--- a/base-kustomize/heat/base/hpa-heat-api.yaml
+++ b/base-kustomize/heat/base/hpa-heat-api.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           type: AverageValue

--- a/base-kustomize/heat/base/hpa-heat-cfn.yaml
+++ b/base-kustomize/heat/base/hpa-heat-cfn.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           type: AverageValue

--- a/base-kustomize/heat/base/hpa-heat-engine.yaml
+++ b/base-kustomize/heat/base/hpa-heat-engine.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           type: AverageValue

--- a/base-kustomize/horizon/base/hpa-horizon-api.yaml
+++ b/base-kustomize/horizon/base/hpa-horizon-api.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           type: AverageValue

--- a/base-kustomize/keystone/base/hpa-keystone-api.yaml
+++ b/base-kustomize/keystone/base/hpa-keystone-api.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           type: AverageValue

--- a/base-kustomize/magnum/base/hpa-magnum-api.yaml
+++ b/base-kustomize/magnum/base/hpa-magnum-api.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           type: AverageValue

--- a/base-kustomize/magnum/base/hpa-magnum-conductor.yaml
+++ b/base-kustomize/magnum/base/hpa-magnum-conductor.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           type: AverageValue

--- a/base-kustomize/neutron/base/hpa-neutron-server.yaml
+++ b/base-kustomize/neutron/base/hpa-neutron-server.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 70
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           type: AverageValue

--- a/base-kustomize/nova/base/hpa-nova-api-metadata.yaml
+++ b/base-kustomize/nova/base/hpa-nova-api-metadata.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           type: AverageValue

--- a/base-kustomize/nova/base/hpa-nova-api-osapi.yaml
+++ b/base-kustomize/nova/base/hpa-nova-api-osapi.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           type: AverageValue

--- a/base-kustomize/nova/base/hpa-nova-conductor.yaml
+++ b/base-kustomize/nova/base/hpa-nova-conductor.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 70
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           type: AverageValue

--- a/base-kustomize/nova/base/hpa-nova-novncproxy.yaml
+++ b/base-kustomize/nova/base/hpa-nova-novncproxy.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           type: AverageValue

--- a/base-kustomize/nova/base/hpa-nova-scheduler.yaml
+++ b/base-kustomize/nova/base/hpa-nova-scheduler.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 70
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           type: AverageValue

--- a/base-kustomize/octavia/base/hpa-octavia-api.yaml
+++ b/base-kustomize/octavia/base/hpa-octavia-api.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           averageValue: 500Mi

--- a/base-kustomize/octavia/base/hpa-octavia-worker.yaml
+++ b/base-kustomize/octavia/base/hpa-octavia-worker.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           averageValue: 500Mi

--- a/base-kustomize/placement/base/hpa-placement-api.yaml
+++ b/base-kustomize/placement/base/hpa-placement-api.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           averageValue: 500Mi

--- a/base-kustomize/skyline/base/hpa-skyline-apiserver.yaml
+++ b/base-kustomize/skyline/base/hpa-skyline-apiserver.yaml
@@ -8,12 +8,6 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
-    - resource:
         name: memory
         target:
           averageValue: 500Mi


### PR DESCRIPTION
This change is removing the CPU HPA metric. This metric is unused in our deployments, so the setup is at best doing nothing and at worst creating load that doesn't need to be there.

Common deployment

``` shell
NAME                      REFERENCE                            TARGETS                                            MINPODS   MAXPODS   REPLICAS   AGE
barbican-api              Deployment/barbican-api              cpu: <unknown>/50%, memory: 119750656/500Mi        3         9         3          38d
ceilometer-notification   Deployment/ceilometer-notification   cpu: <unknown>/50%, memory: 122153642666m/500Mi    3         9         3          2d12h
cinder-api                Deployment/cinder-api                cpu: <unknown>/50%, memory: 575287296/500Mi        3         9         4          38d
cinder-scheduler          Deployment/cinder-scheduler          cpu: <unknown>/50%, memory: 119204522666m/500Mi    3         9         3          38d
glance-api                Deployment/glance-api                cpu: <unknown>/50%, memory: 574466730666m/500Mi    3         9         6          4d18h
gnocchi-api               Deployment/gnocchi-api               cpu: <unknown>/50%, memory: 153123498666m/500Mi    3         9         3          2d12h
heat-api                  Deployment/heat-api                  cpu: <unknown>/50%, memory: 570041685333m/500Mi    3         9         3          45h
heat-cfn                  Deployment/heat-cfn                  cpu: <unknown>/50%, memory: 146959018666m/500Mi    3         9         3          45h
heat-engine               Deployment/heat-engine               cpu: <unknown>/50%, memory: 724417649777m/500Mi    3         9         9          45h
keystone-api              Deployment/keystone-api              cpu: <unknown>/50%, memory: 766432142222m/500Mi    3         9         9          38d
magnum-api                Deployment/magnum-api                cpu: <unknown>/50%, memory: 83405482666m/500Mi     3         9         3          2d3h
magnum-conductor          StatefulSet/magnum-conductor         cpu: <unknown>/50%, memory: 1513799224888m/1Gi     3         9         9          2d3h
memcached                 StatefulSet/memcached                cpu: 4%/70%                                        3         9         3          4d18h
neutron-server            Deployment/neutron-server            cpu: <unknown>/70%, memory: 10785601763555m/2Gi    3         9         9          38d
nova-api-metadata         Deployment/nova-api-metadata         cpu: <unknown>/50%, memory: 347193344/500Mi        3         9         3          38d
nova-api-osapi            Deployment/nova-api-osapi            cpu: <unknown>/50%, memory: 1282790286222m/500Mi   3         9         9          38d
nova-conductor            Deployment/nova-conductor            cpu: <unknown>/70%, memory: 840034076444m/500Mi    3         9         9          38d
nova-novncproxy           Deployment/nova-novncproxy           cpu: <unknown>/50%, memory: 103875925333m/500Mi    3         9         3          38d
nova-scheduler            Deployment/nova-scheduler            cpu: <unknown>/70%, memory: 9110932593777m/1Gi     3         9         9          38d
octavia-api               Deployment/octavia-api               cpu: <unknown>/50%, memory: 686977024/500Mi        3         9         9          4d13h
octavia-worker            Deployment/octavia-worker            cpu: <unknown>/50%, memory: 303745706666m/500Mi    3         9         3          4d13h
placement-api             Deployment/placement-api             cpu: <unknown>/50%, memory: 344465408/500Mi        3         9         3          38d
skyline-apiserver         Deployment/skyline-apiserver         cpu: <unknown>/50%, memory: <unknown>/500Mi        3         9         0          4d17h
```

So this change is removing all of the CPU metrics from our builds, for all of the openstack services.