### PR TITLE
chore: set the kube-ovn version

### DIFF
--- a/ansible/inventory/genestack/group_vars/k8s_cluster/k8s-net-kube-ovn.yml
+++ b/ansible/inventory/genestack/group_vars/k8s_cluster/k8s-net-kube-ovn.yml
@@ -1,4 +1,6 @@
 ---
+# kube-ovn version
+kube_ovn_version: v1.12.30
 
 # geneve or vlan
 kube_ovn_network_type: geneve


### PR DESCRIPTION
This change sets the kube-ovn version to the latest release within the stable 1.12.x series. By setting this option we're ensuring there's no drift in how our system is deployed and performs, even if the underlying version of kubespray or kubernetes changes.