### PR TITLE
fix: (install scripts) include space in HELM_CMD additional args

### DIFF
--- a/bin/install-fluentbit.sh
+++ b/bin/install-fluentbit.sh
@@ -18,7 +18,7 @@ if compgen -G "${CONFIG_DIR}/*.yaml" > /dev/null; then
     done
 fi
 
-HELM_CMD+="${@}"
+HELM_CMD+=" ${@}"
 
 # Run the helm command
 echo "Executing Helm command:"

--- a/bin/install-grafana.sh
+++ b/bin/install-grafana.sh
@@ -23,7 +23,7 @@ if compgen -G "${CONFIG_DIR}/*.yaml" > /dev/null; then
     done
 fi
 
-HELM_CMD+="${@}"
+HELM_CMD+=" ${@}"
 
 # Run the helm command
 echo "Executing Helm command:"

--- a/bin/install-libvirt.sh
+++ b/bin/install-libvirt.sh
@@ -22,7 +22,7 @@ if compgen -G "${CONFIG_DIR}/*.yaml" > /dev/null; then
     done
 fi
 
-HELM_CMD+="${@}"
+HELM_CMD+=" ${@}"
 
 # Run the helm command
 echo "Executing Helm command:"

--- a/bin/install-mariadb-operator.sh
+++ b/bin/install-mariadb-operator.sh
@@ -53,7 +53,7 @@ if compgen -G "${CONFIG_DIR}/*.yaml" > /dev/null; then
     done
 fi
 
-HELM_CMD+="${@}"
+HELM_CMD+=" ${@}"
 
 # Run the helm command
 echo "Executing Helm command:"

--- a/bin/install-memcached.sh
+++ b/bin/install-memcached.sh
@@ -20,7 +20,7 @@ if compgen -G "${CONFIG_DIR}/*.yaml" > /dev/null; then
     done
 fi
 
-HELM_CMD+="${@}"
+HELM_CMD+=" ${@}"
 
 # Run the helm command
 echo "Executing Helm command:"

--- a/bin/install-postgres-operator.sh
+++ b/bin/install-postgres-operator.sh
@@ -23,7 +23,7 @@ if compgen -G "${CONFIG_DIR}/*.yaml" > /dev/null; then
     done
 fi
 
-HELM_CMD+="${@}"
+HELM_CMD+=" ${@}"
 
 # Run the helm command
 echo "Executing Helm command:"


### PR DESCRIPTION
When appending command line args to the scripts, we need to ensure we include a space between the HELM_CMD and the args being appended.