### PR TITLE
fix: tunedown neutron rpcworkers

### DIFF
--- a/base-helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/base-helm-configs/neutron/neutron-helm-overrides.yaml
@@ -1772,7 +1772,7 @@ conf:
       router_scheduler_driver: neutron.scheduler.l3_agent_scheduler.AZLeastRoutersScheduler
       dhcp_load_type: networks
       api_workers: 8
-      rpc_workers: 16
+      rpc_workers: 4
       rpc_state_report_workers: 4
       allow_overlapping_ips: True
       state_path: /var/lib/neutron


### PR DESCRIPTION
Unfortunately all worker processes have a 'reported_hosts' set to
    remember from which host it has seen agent reports already. But right
    after a server start when that set is still empty, each worker will
    unconditionally write the received physnet-segment information into
    the db. This means we multiply the load on the db and rpc workers by
    a factor of the rpc worker count.