### PR TITLE
feat: add policy so users can see their assigned roles

### DIFF
--- a/base-helm-configs/keystone/keystone-helm-overrides.yaml
+++ b/base-helm-configs/keystone/keystone-helm-overrides.yaml
@@ -569,7 +569,8 @@ conf:
   # A sample of the value override can be found in sample file:
   # tools/overrides/example/keystone_domain_config.yaml
   # ks_domains:
-  policy: {}
+  policy:
+    "identity:list_system_grants_for_user": "rule:admin_required or (role:reader and system_scope:all) or rule:owner"
   access_rules: {}
   rabbitmq:
     policies: []


### PR DESCRIPTION
This change is needed so that skyline can report on user assigned roles from the dashboard.