### PR TITLE
fix(rook): Tolerate the PreferNoSchedule taint

### DIFF
--- a/base-kustomize/rook-cluster/rook-cluster.yaml
+++ b/base-kustomize/rook-cluster/rook-cluster.yaml
@@ -174,6 +174,8 @@ spec:
       tolerations:
       - key: storage-node
         operator: Exists
+      - effect: PreferNoSchedule
+        operator: Exists
   # placement:
   #   all:
   #     nodeAffinity:

--- a/docs/storage-ceph-rook-internal.md
+++ b/docs/storage-ceph-rook-internal.md
@@ -9,8 +9,16 @@ hide:
 
 ``` shell
 kubectl apply -k /etc/genestack/kustomize/rook-operator/
-kubectl -n rook-ceph set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.13.7
 ```
+
+!!! tip "Manually specifying the rook-operator image"
+
+    Under certain circumstances it may be required to do this, below is an
+    example of how one can pin the operator version if so desired.
+
+    ``` shell
+    kubectl -n rook-ceph set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.13.7
+    ```
 
 ## Deploy the Rook cluster
 


### PR DESCRIPTION
When deploying rook-ceph internally, the `osd` pods do not come online when a node is tainted with `PreferNoSchedule`. This adds a toleration for the same. Also we unpin the operator version, leaving a note to the operator on how they can specify one if needed.