### PR TITLE
fix: Correct syntax errors in secret creation

### DIFF
--- a/bin/create-secrets.sh
+++ b/bin/create-secrets.sh
@@ -98,6 +98,7 @@ grafana_root_secret=$(generate_password 32)
 OUTPUT_FILE="/etc/genestack/kubesecrets.yaml"
 
 cat <<EOF > $OUTPUT_FILE
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -602,7 +603,7 @@ metadata:
 type: Opaque
 data:
   password: $(echo -n $grafana_secret | base64 -w0)
-  root-password $(echo -n $grafana_root_secret | base64 -w0)
+  root-password: $(echo -n $grafana_root_secret | base64 -w0)
   username: grafana
 EOF
 

--- a/bin/create-secrets.sh
+++ b/bin/create-secrets.sh
@@ -596,6 +596,14 @@ data:
   memcache_secret_key: $(echo -n $memcached_shared_secret | base64 -w0)
 ---
 apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubernetes.io/metadata.name: grafana
+    name: grafana
+  name: grafana
+---
+apiVersion: v1
 kind: Secret
 metadata:
   name: grafana-db
@@ -604,7 +612,7 @@ type: Opaque
 data:
   password: $(echo -n $grafana_secret | base64 -w0)
   root-password: $(echo -n $grafana_root_secret | base64 -w0)
-  username: grafana
+  username: $(echo -n grafana | base64 -w0)
 EOF
 
 rm nova_ssh_key nova_ssh_key.pub

--- a/docs/infrastructure-namespace.md
+++ b/docs/infrastructure-namespace.md
@@ -24,5 +24,5 @@ That will create a kubesecrets.yaml file located in /etc/genestack
 You can then apply it to kubernetes with the following command:
 
 ``` shell
-kubectl create -f /etc/genestack/kubesecrets.yaml -n openstack
+kubectl create -f /etc/genestack/kubesecrets.yaml
 ```


### PR DESCRIPTION
- Missing colon after root-password for grafana-db fixed.
- Missing document start "---" fixed.