### PR TITLE
fix: Barbican only has one worker

### DIFF
--- a/base-helm-configs/barbican/barbican-helm-overrides.yaml
+++ b/base-helm-configs/barbican/barbican-helm-overrides.yaml
@@ -372,7 +372,7 @@ conf:
       thunder-lock: true
       worker-reload-mercy: 80
       wsgi-file: /var/lib/openstack/bin/barbican-wsgi-api
-      processes: 1
+      processes: 4
   barbican:
     DEFAULT:
       host_href: http://barbican-api.openstack.svc.cluster.local:9311


### PR DESCRIPTION
This change ensures that barbican is started with multiple processes.