### PR TITLE
Fix: Multipath blacklist compute root disks

### DIFF
--- a/ansible/playbooks/templates/genestack-multipath.conf
+++ b/ansible/playbooks/templates/genestack-multipath.conf
@@ -9,6 +9,8 @@ blacklist {
     devnode    "scini*"
     devnode    "^rbd[0-9]*"
     devnode    "^nbd[0-9]*"
+    devnode    "^sda[0-9]*"
+    devnode    "^sdb[0-9]*"
 }
 
 blacklist_exceptions {


### PR DESCRIPTION
Adding two blacklist lines to keep multipath from
dealing with the compute root disks /dev/sda[0-9]* and /dev/sdb[0-9]*.