### PR TITLE
fix: adjust the default network for pods

### DIFF
--- a/ansible/inventory/genestack/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/ansible/inventory/genestack/group_vars/k8s_cluster/k8s-cluster.yml
@@ -73,12 +73,12 @@ kube_network_plugin: kube-ovn
 kube_network_plugin_multus: false
 
 # Kubernetes internal network for services, unused block of space.
-kube_service_addresses: 10.233.0.0/14
+kube_service_addresses: 10.233.0.0/18
 
 # internal network. When used, it will assign IP
 # addresses from this range to individual pods.
 # This network must be unused in your network infrastructure!
-kube_pods_subnet: 10.233.64.0/14
+kube_pods_subnet: 10.236.0.0/14
 
 # internal network node size allocation (optional). This is the size allocated
 # to each node for pod IP address allocation. Note that the number of pods per node is


### PR DESCRIPTION
The pod assignment network defaults we had created an overlap which could result in systemic failure. This change adjusts the deafult values so that there's no chance of overlap.