### PR TITLE
docs: Use kustomize overlay for Nginx GW API

### DIFF
--- a/base-kustomize/gateway/base/files/nginx.conf
+++ b/base-kustomize/gateway/base/files/nginx.conf
@@ -29,6 +29,8 @@ http {
   sendfile on;
   tcp_nopush on;
 
+  server_tokens off;
+
   server {
     listen unix:/var/run/nginx/nginx-status.sock;
     access_log off;
@@ -37,4 +39,18 @@ http {
         stub_status;
     }
   }
+}
+
+stream {
+  variables_hash_bucket_size 512;
+  variables_hash_max_size 1024;
+
+  map_hash_max_size 2048;
+  map_hash_bucket_size 256;
+
+  log_format stream-main '$remote_addr [$time_local] '
+                         '$protocol $status $bytes_sent $bytes_received '
+                         '$session_time "$ssl_preread_server_name"';
+  access_log /dev/stdout stream-main;
+  include /etc/nginx/stream-conf.d/*.conf;
 }

--- a/docs/infrastructure-gateway-api.md
+++ b/docs/infrastructure-gateway-api.md
@@ -81,11 +81,14 @@ There are various implementations of the Gateway API. In this document, we will 
     === "Stable _(Recommended)_"
 
         ``` shell
-        cd /opt/genestack/submodules/nginx-gateway-fabric/charts
-
+        pushd /opt/genestack/submodules/nginx-gateway-fabric/charts || exit 1
         helm upgrade --install nginx-gateway-fabric ./nginx-gateway-fabric \
-                    --namespace=nginx-gateway \
-                    -f /etc/genestack/helm-configs/nginx-gateway-fabric/helm-overrides.yaml
+            --namespace=nginx-gateway \
+            -f /opt/genestack/base-helm-configs/nginx-gateway-fabric/helm-overrides.yaml \
+            -f /etc/genestack/helm-configs/nginx-gateway-fabric/helm-overrides.yaml \
+            --post-renderer /etc/genestack/kustomize/kustomize.sh \
+            --post-renderer-args gateway/overlay
+        popd || exit 1
         ```
 
     === "Experimental"


### PR DESCRIPTION
There is a patch in the `base` overlay which modifies proxy_buffers to account for large headers which is common in our envioronment and ultimately results in Nginx throwing a 502 and logging an error like, "upstream sent too big header while reading response header from upstream".

This update also includes the latest changes to the nginx.conf as obtained from a fresh install.

Starting in v1.5.0, the SnippetsFilterAPI was added which can be used in lieu of this configuration override, though it has to be enabled manually, and more testing is needed to implement the same.

Jira: OSPC-990
PR: #463