### PR TITLE
fix: add ignore errors

### DIFF
--- a/ansible/playbooks/host-setup.yml
+++ b/ansible/playbooks/host-setup.yml
@@ -47,6 +47,7 @@
         state: stopped
         daemon_reload: true
         enabled: false
+      ignore_errors: true
       loop:
         - multipathd.socket
         - multipathd.service


### PR DESCRIPTION
While the playbook assumes that multipath is installed, there is a possibility that it is not. This change ensures that even when mp is being disabled that we don't fail in the event the services are not setup.