### PR TITLE
chore: add helm annotations to kustomize

### DIFF
--- a/base-kustomize/barbican/base/barbican-mariadb-database.yaml
+++ b/base-kustomize/barbican/base/barbican-mariadb-database.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "barbican"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -22,6 +25,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "barbican"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -42,6 +48,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "barbican"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   mariaDbRef:
     name: mariadb-cluster

--- a/base-kustomize/barbican/base/barbican-rabbitmq-queue.yaml
+++ b/base-kustomize/barbican/base/barbican-rabbitmq-queue.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "barbican"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   tags:
   - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
@@ -23,6 +26,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "barbican"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   name: "barbican" # vhost name; required and cannot be updated
   defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
@@ -44,6 +50,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "barbican"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   name: barbican-qq # name of the queue
   vhost: "barbican" # default to '/' if not provided
@@ -61,6 +70,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "barbican"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   vhost: "barbican" # name of a vhost
   userReference:

--- a/base-kustomize/ceilometer/base/ceilometer-rabbitmq-queue.yaml
+++ b/base-kustomize/ceilometer/base/ceilometer-rabbitmq-queue.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "ceilometer"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   tags:
   - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
@@ -23,6 +26,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "ceilometer"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   name: "ceilometer" # vhost name; required and cannot be updated
   defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
@@ -44,6 +50,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "ceilometer"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   name: ceilometer-qq # name of the queue
   vhost: "ceilometer" # default to '/' if not provided
@@ -61,6 +70,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "ceilometer"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   vhost: "ceilometer" # name of a vhost
   userReference:

--- a/base-kustomize/cinder/base/cinder-mariadb-database.yaml
+++ b/base-kustomize/cinder/base/cinder-mariadb-database.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "cinder"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -22,6 +25,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "cinder"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -42,6 +48,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "cinder"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   mariaDbRef:
     name: mariadb-cluster

--- a/base-kustomize/cinder/base/cinder-rabbitmq-queue.yaml
+++ b/base-kustomize/cinder/base/cinder-rabbitmq-queue.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "cinder"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   tags:
   - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
@@ -23,6 +26,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "cinder"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   name: "cinder" # vhost name; required and cannot be updated
   defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
@@ -44,6 +50,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "cinder"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   name: cinder-qq # name of the queue
   vhost: "cinder" # default to '/' if not provided
@@ -61,6 +70,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "cinder"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   vhost: "cinder" # name of a vhost
   userReference:

--- a/base-kustomize/designate/base/designate-mariadb-database.yaml
+++ b/base-kustomize/designate/base/designate-mariadb-database.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "designate"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -22,6 +25,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "designate"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -42,6 +48,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "designate"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   mariaDbRef:
     name: mariadb-cluster

--- a/base-kustomize/designate/base/designate-rabbitmq-queue.yaml
+++ b/base-kustomize/designate/base/designate-rabbitmq-queue.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "designate"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   tags:
   - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
@@ -23,6 +26,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "designate"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   name: "designate" # vhost name; required and cannot be updated
   defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
@@ -44,6 +50,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "designate"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   name: designate-qq # name of the queue
   vhost: "designate" # default to '/' if not provided
@@ -61,6 +70,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "designate"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   vhost: "designate" # name of a vhost
   userReference:

--- a/base-kustomize/glance/base/glance-mariadb-database.yaml
+++ b/base-kustomize/glance/base/glance-mariadb-database.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "glance"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -22,6 +25,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "glance"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -42,6 +48,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "glance"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   mariaDbRef:
     name: mariadb-cluster

--- a/base-kustomize/glance/base/glance-rabbitmq-queue.yaml
+++ b/base-kustomize/glance/base/glance-rabbitmq-queue.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "glance"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   tags:
   - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
@@ -23,6 +26,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "glance"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   name: "glance" # vhost name; required and cannot be updated
   defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
@@ -44,6 +50,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "glance"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   name: glance-qq # name of the queue
   vhost: "glance" # default to '/' if not provided
@@ -61,6 +70,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "glance"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   vhost: "glance" # name of a vhost
   userReference:

--- a/base-kustomize/grafana/base/grafana-database.yaml
+++ b/base-kustomize/grafana/base/grafana-database.yaml
@@ -5,6 +5,9 @@ metadata:
   name: mariadb-cluster
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "grafana"
+    meta.helm.sh/release-namespace: "openstack"
   labels:
     app.kubernetes.io/managed-by: Helm
 data:
@@ -18,6 +21,9 @@ metadata:
   namespace: grafana
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "grafana"
+    meta.helm.sh/release-namespace: "openstack"
   labels:
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -136,6 +142,9 @@ metadata:
   namespace: grafana
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "grafana"
+    meta.helm.sh/release-namespace: "openstack"
   labels:
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -174,6 +183,9 @@ metadata:
   namespace: grafana
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "grafana"
+    meta.helm.sh/release-namespace: "openstack"
   labels:
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -193,6 +205,9 @@ metadata:
   namespace: grafana
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "grafana"
+    meta.helm.sh/release-namespace: "openstack"
   labels:
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -216,6 +231,9 @@ metadata:
   namespace: grafana
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "grafana"
+    meta.helm.sh/release-namespace: "openstack"
   labels:
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/base-kustomize/heat/base/heat-mariadb-database.yaml
+++ b/base-kustomize/heat/base/heat-mariadb-database.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "heat"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -22,6 +25,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "heat"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -42,6 +48,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "heat"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   mariaDbRef:
     name: mariadb-cluster

--- a/base-kustomize/horizon/base/horizon-mariadb-database.yaml
+++ b/base-kustomize/horizon/base/horizon-mariadb-database.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "horizon"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -22,6 +25,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "horizon"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -42,6 +48,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "horizon"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   mariaDbRef:
     name: mariadb-cluster

--- a/base-kustomize/keystone/base/keystone-mariadb-database.yaml
+++ b/base-kustomize/keystone/base/keystone-mariadb-database.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "keystone"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -22,6 +25,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "keystone"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -42,6 +48,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "keystone"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   mariaDbRef:
     name: mariadb-cluster

--- a/base-kustomize/keystone/base/keystone-rabbitmq-queue.yaml
+++ b/base-kustomize/keystone/base/keystone-rabbitmq-queue.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "keystone"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   tags:
   - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
@@ -23,6 +26,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "keystone"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   name: "keystone" # vhost name; required and cannot be updated
   defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
@@ -44,6 +50,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "keystone"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   name: keystone-qq # name of the queue
   vhost: "keystone" # default to '/' if not provided
@@ -61,6 +70,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "keystone"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   vhost: "keystone" # name of a vhost
   userReference:

--- a/base-kustomize/magnum/base/magnum-mariadb-database.yaml
+++ b/base-kustomize/magnum/base/magnum-mariadb-database.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "magnum"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -22,6 +25,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "magnum"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -42,6 +48,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "magnum"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   mariaDbRef:
     name: mariadb-cluster

--- a/base-kustomize/magnum/base/magnum-rabbitmq-queue.yaml
+++ b/base-kustomize/magnum/base/magnum-rabbitmq-queue.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "magnum"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   tags:
   - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
@@ -23,6 +26,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "magnum"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   name: "magnum" # vhost name; required and cannot be updated
   defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
@@ -37,6 +43,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "magnum"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   name: magnum-qq # name of the queue
   vhost: "magnum" # default to '/' if not provided
@@ -54,6 +63,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "magnum"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   vhost: "magnum" # name of a vhost
   userReference:

--- a/base-kustomize/neutron/base/neutron-mariadb-database.yaml
+++ b/base-kustomize/neutron/base/neutron-mariadb-database.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "neutron"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -22,6 +25,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "neutron"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -42,6 +48,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "neutron"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   mariaDbRef:
     name: mariadb-cluster

--- a/base-kustomize/neutron/base/neutron-rabbitmq-queue.yaml
+++ b/base-kustomize/neutron/base/neutron-rabbitmq-queue.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "neutron"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   tags:
   - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
@@ -23,6 +26,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "neutron"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   name: "neutron" # vhost name; required and cannot be updated
   defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
@@ -44,6 +50,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "neutron"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   name: neutron-qq # name of the queue
   vhost: "neutron" # default to '/' if not provided
@@ -61,6 +70,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "neutron"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   vhost: "neutron" # name of a vhost
   userReference:

--- a/base-kustomize/nova/base/nova-mariadb-database.yaml
+++ b/base-kustomize/nova/base/nova-mariadb-database.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "nova"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -22,6 +25,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "nova"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -39,6 +45,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "nova"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -56,6 +65,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "nova"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -76,6 +88,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "nova"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   mariaDbRef:
     name: mariadb-cluster
@@ -95,6 +110,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "nova"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   mariaDbRef:
     name: mariadb-cluster
@@ -114,6 +132,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "nova"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   mariaDbRef:
     name: mariadb-cluster

--- a/base-kustomize/nova/base/nova-rabbitmq-queue.yaml
+++ b/base-kustomize/nova/base/nova-rabbitmq-queue.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "nova"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   tags:
   - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
@@ -23,6 +26,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "nova"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   name: "nova" # vhost name; required and cannot be updated
   defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
@@ -44,6 +50,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "nova"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   name: nova-qq # name of the queue
   vhost: "nova" # default to '/' if not provided
@@ -61,6 +70,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "nova"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   vhost: "nova" # name of a vhost
   userReference:

--- a/base-kustomize/octavia/base/octavia-mariadb-database.yaml
+++ b/base-kustomize/octavia/base/octavia-mariadb-database.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "octavia"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -22,6 +25,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "octavia"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -42,6 +48,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "octavia"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   mariaDbRef:
     name: mariadb-cluster

--- a/base-kustomize/octavia/base/octavia-rabbitmq-queue.yaml
+++ b/base-kustomize/octavia/base/octavia-rabbitmq-queue.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "octavia"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   tags:
   - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
@@ -23,6 +26,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "octavia"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   name: "octavia" # vhost name; required and cannot be updated
   defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
@@ -44,6 +50,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "octavia"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   name: octavia-qq # name of the queue
   vhost: "octavia" # default to '/' if not provided
@@ -61,6 +70,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "octavia"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   vhost: "octavia" # name of a vhost
   userReference:

--- a/base-kustomize/placement/base/placement-mariadb-database.yaml
+++ b/base-kustomize/placement/base/placement-mariadb-database.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "placement"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the database to be created with a different name than the resource name
   # name: data-custom
@@ -22,6 +25,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "placement"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   # If you want the user to be created with a different name than the resource name
   # name: user-custom
@@ -42,6 +48,9 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
+    app.kubernetes.io/managed-by: "Helm"
+    meta.helm.sh/release-name: "placement"
+    meta.helm.sh/release-namespace: "openstack"
 spec:
   mariaDbRef:
     name: mariadb-cluster

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -172,8 +172,6 @@ nav:
               - TopoLVM: storage-topolvm.md
               - External Storage CSI: storage-external-block.md
               - Longhorn: storage-longhorn.md
-          - Secrets:
-              - Sealed Secrets: sealed-secrets.md
           - Infrastructure:
               - infrastructure-overview.md
               - Namespace: infrastructure-namespace.md


### PR DESCRIPTION
This change ensures that helm annotations are always used, even if a given manifest is applied directly. This is useful for support when uninstalling/installing services.