### PR TITLE
chore: bin/scripts cleanup

### DIFF
--- a/bin/install-fluentbit.sh
+++ b/bin/install-fluentbit.sh
@@ -16,7 +16,7 @@ for dir in "$GLOBAL_OVERRIDES_DIR" "$SERVICE_CONFIG_DIR"; do
     fi
 done
 
-HELM_CMD+=" $*"
+HELM_CMD+=" $@"
 
 echo "Executing Helm command:"
 echo "${HELM_CMD}"

--- a/bin/install-grafana.sh
+++ b/bin/install-grafana.sh
@@ -22,7 +22,7 @@ for dir in "$GLOBAL_OVERRIDES_DIR" "$SERVICE_CONFIG_DIR"; do
     fi
 done
 
-HELM_CMD+=" $*"
+HELM_CMD+=" $@"
 
 echo "Executing Helm command:"
 echo "${HELM_CMD}"

--- a/bin/install-libvirt.sh
+++ b/bin/install-libvirt.sh
@@ -24,7 +24,7 @@ for dir in "$GLOBAL_OVERRIDES_DIR" "$SERVICE_CONFIG_DIR"; do
     fi
 done
 
-HELM_CMD+=" $*"
+HELM_CMD+=" $@"
 
 echo "Executing Helm command:"
 echo "${HELM_CMD}"

--- a/bin/install-mariadb-operator.sh
+++ b/bin/install-mariadb-operator.sh
@@ -53,7 +53,7 @@ if compgen -G "${CONFIG_DIR}/*.yaml" > /dev/null; then
     done
 fi
 
-HELM_CMD+=" $*"
+HELM_CMD+=" $@"
 
 # Run the helm command
 echo "Executing Helm command:"

--- a/bin/install-memcached.sh
+++ b/bin/install-memcached.sh
@@ -24,7 +24,7 @@ for dir in "$GLOBAL_OVERRIDES_DIR" "$SERVICE_CONFIG_DIR"; do
     fi
 done
 
-HELM_CMD+=" $*"
+HELM_CMD+=" $@"
 
 echo "Executing Helm command:"
 echo "${HELM_CMD}"

--- a/bin/install-postgres-operator.sh
+++ b/bin/install-postgres-operator.sh
@@ -23,7 +23,7 @@ if compgen -G "${CONFIG_DIR}/*.yaml" > /dev/null; then
     done
 fi
 
-HELM_CMD+=" $*"
+HELM_CMD+=" $@"
 
 # Run the helm command
 echo "Executing Helm command:"

--- a/bin/install-prometheus.sh
+++ b/bin/install-prometheus.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2124,SC2145,SC2294
 
 # Set default directories
 GENESTACK_DIR="${GENESTACK_DIR:-/opt/genestack}"
@@ -40,8 +41,12 @@ helm repo add prometheus-community https://prometheus-community.github.io/helm-c
 helm repo update
 
 # Run the Helm upgrade/install command using the collected --values arguments
-helm upgrade --install kube-prometheus-stack prometheus-community/kube-prometheus-stack \
-    --create-namespace --namespace=prometheus --timeout 10m \
-    "${values_args[@]}" \
-    --post-renderer "$GENESTACK_CONFIG_DIR/kustomize/kustomize.sh" \
-    --post-renderer-args prometheus/overlay "$*"
+HELM_CMD="helm upgrade --install kube-prometheus-stack prometheus-community/kube-prometheus-stack --create-namespace --namespace=prometheus --timeout 10m"
+HELM_CMD+=" ${values_args[@]}"
+HELM_CMD+=" --post-renderer $GENESTACK_CONFIG_DIR/kustomize/kustomize.sh"
+HELM_CMD+=" --post-renderer-args prometheus/overlay"
+HELM_CMD+=" $@"
+
+echo "Executing Helm command:"
+echo "${HELM_CMD}"
+eval "${HELM_CMD}"

--- a/bin/install-template.sh
+++ b/bin/install-template.sh
@@ -31,7 +31,7 @@ if compgen -G "${CONFIG_DIR}/*.yaml" > /dev/null; then
     done
 fi
 
-HELM_CMD+=" $*"
+HELM_CMD+=" $@"
 
 # Run the helm command
 echo "Executing Helm command:"

--- a/scripts/convert_osa_inventory.py
+++ b/scripts/convert_osa_inventory.py
@@ -27,67 +27,72 @@ import logging
 import parser
 import sys
 
-logger = logging.getLogger('convert_osa_inventory')
+logger = logging.getLogger("convert_osa_inventory")
 
-inventory_skel = { 'all': {
-                    'hosts': {},
-                    'children' : {},
-                    'vars': {},
-                    }
-                }
+inventory_skel = {
+    "all": {
+        "hosts": {},
+        "children": {},
+        "vars": {},
+    }
+}
+
 
 def parse_args(args):
     parser = argparse.ArgumentParser(
-        usage='%(prog)s',
-        description='OSA Inventory Converter to k8s',
-        epilog='Generator Licensed "Apache 2.0"')
+        usage="%(prog)s",
+        description="OSA Inventory Converter to k8s",
+        epilog='Generator Licensed "Apache 2.0"',
+    )
 
     parser.add_argument(
-        '-d',
-        '--debug',
-        help=('Append output debug messages to log file.'),
-        action='store_true',
+        "-d",
+        "--debug",
+        help=("Append output debug messages to log file."),
+        action="store_true",
         default=False,
     )
 
     parser.add_argument(
-        '--hosts_file',
-        help=('Defines the output file for the k8s hosts inventory'),
-        nargs='?',
-        default='/etc/genestack/inventory/hosts.yml',
+        "--hosts_file",
+        help=("Defines the output file for the k8s hosts inventory"),
+        nargs="?",
+        default="/etc/genestack/inventory/hosts.yml",
     )
 
     parser.add_argument(
-        '--ansible_user',
-        help=('Set user for ansible logins with implies use of become directive'),
-        nargs='?',
-        default='root',
+        "--ansible_user",
+        help=("Set user for ansible logins with implies use of become directive"),
+        nargs="?",
+        default="root",
     )
 
     return vars(parser.parse_args(args))
 
-def load_osa_inventory(file='/etc/openstack_deploy/openstack_inventory.json'):
+
+def load_osa_inventory(file="/etc/openstack_deploy/openstack_inventory.json"):
     try:
         with open(file) as fp:
             inventory = json.load(fp)
     except Exception as ex:
-        logger.debug('load_inventory: %s',ex)
+        logger.debug("load_inventory: %s", ex)
         raise SystemExit
 
     return inventory
+
 
 def hosts_from_group(inventory=dict(), groups=list()):
     hosts = list()
 
     try:
         for group in groups:
-            for host in inventory[group]['hosts']:
+            for host in inventory[group]["hosts"]:
                 if host not in hosts:
                     hosts.append(host)
     except KeyError:
         pass
     finally:
-        return(hosts)
+        return hosts
 
 
 def main(debug=False, **kwargs):
@@ -98,7 +103,7 @@ def main(debug=False, **kwargs):
 
     if debug:
         log_fmt = "%(lineno)d - %(funcName)s: %(message)s"
-        logging.basicConfig(format=log_fmt, filename='convert_osa_inventory.log')
+        logging.basicConfig(format=log_fmt, filename="convert_osa_inventory.log")
         logger.setLevel(logging.DEBUG)
 
     osa_inv = load_osa_inventory()
@@ -109,89 +114,90 @@ def main(debug=False, **kwargs):
         and filter controller hosts from the nova_compute group
         in situations where ironic compute services are deployed
     """
-    controller_nodes = hosts_from_group(osa_inv, ['os-infra_hosts'])
-    #worker_nodes = [ h for h in hosts_from_group(osa_inv, ['nova_compute', 'storage_hosts', 'osds', 'mon'])
-    worker_nodes = [ h for h in hosts_from_group(osa_inv, ['nova_compute', 'storage_hosts'])
-                        if h not in hosts_from_group(osa_inv, ['os-infra_hosts']) ]
+    controller_nodes = hosts_from_group(osa_inv, ["os-infra_hosts"])
+    # worker_nodes = [ h for h in hosts_from_group(osa_inv, ['nova_compute', 'storage_hosts', 'osds', 'mon'])
+    worker_nodes = [
+        h
+        for h in hosts_from_group(osa_inv, ["nova_compute", "storage_hosts"])
+        if h not in hosts_from_group(osa_inv, ["os-infra_hosts"])
+    ]
 
-    if (len(controller_nodes) < 3 or len(worker_nodes) < 1):
-        logger.debug('No controller_nodes/worker_nodes %d / %d',controller_nodes, worker_nodes)
-        raise SystemExit('Insufficient controller (os-infra_hosts) and '
-                         'worker hosts (compute etc) defined in OSA Inventory')
+    if len(controller_nodes) < 3 or len(worker_nodes) < 1:
+        logger.debug(
+            "No controller_nodes/worker_nodes %d / %d", controller_nodes, worker_nodes
+        )
+        raise SystemExit(
+            "Insufficient controller (os-infra_hosts) and "
+            "worker hosts (compute etc) defined in OSA Inventory"
+        )
 
-    logger.debug('Controller Nodes: %s', controller_nodes)
-    logger.debug('Worker Nodes: %s', worker_nodes)
+    logger.debug("Controller Nodes: %s", controller_nodes)
+    logger.debug("Worker Nodes: %s", worker_nodes)
 
     """ Constructing all group
     """
     for host in controller_nodes + worker_nodes:
         try:
-            ansible_host = osa_inv['_meta']['hostvars'][host]['ansible_host']
+            ansible_host = osa_inv["_meta"]["hostvars"][host]["ansible_host"]
         except KeyError:
-            ansible_host = osa_inv['_meta']['hostvars'][host]['ansible_ssh_host']
+            ansible_host = osa_inv["_meta"]["hostvars"][host]["ansible_ssh_host"]
 
-        become_user = kwargs['ansible_user']
+        become_user = kwargs["ansible_user"]
 
-        k8s_inv['all']['hosts'][host] = { 'ansible_host': ansible_host,
-                                          'access_ip': ansible_host,
-                                          'become_user': become_user }
+        k8s_inv["all"]["hosts"][host] = {
+            "ansible_host": ansible_host,
+            "access_ip": ansible_host,
+            "become_user": become_user,
+        }
         if become_user != "root":
-          k8s_inv['all']['hosts'][host]['ansible_become'] = 'yes'
+            k8s_inv["all"]["hosts"][host]["ansible_become"] = "yes"
 
-        logger.debug('Adding host (group all): %s %s', host, k8s_inv['all']['hosts'][host])
+        logger.debug(
+            "Adding host (group all): %s %s", host, k8s_inv["all"]["hosts"][host]
+        )
 
     """ Constructing children
     """
-    k8s_inv['all']['children'] = { 'kube-master': {
-                                        'hosts': {}
-                                        },
-                                    'kube-node': {
-                                        'hosts': {}
-                                        },
-                                    'etcd': {
-                                        'hosts': {}
-                                        },
-                                    'openstack_control_plane': {
-                                        'hosts': {}
-                                        },
-                                    'openstack-compute-node': {
-                                        'hosts': {}
-                                        },
-                                    'k8s_cluster': {
-                                        'children': {
-                                            'kube-master': {},
-                                            'kube-node': {},
-                                            'openstack_control_plane': {},
-                                            'openstack_compute_node': {},
-                                            }
-                                        },
-                                    'calico-rr': {
-                                        'hosts': {}
-                                        },
-                                }
+    k8s_inv["all"]["children"] = {
+        "kube-master": {"hosts": {}},
+        "kube-node": {"hosts": {}},
+        "etcd": {"hosts": {}},
+        "openstack_control_plane": {"hosts": {}},
+        "openstack-compute-node": {"hosts": {}},
+        "k8s_cluster": {
+            "children": {
+                "kube-master": {},
+                "kube-node": {},
+                "openstack_control_plane": {},
+                "openstack_compute_node": {},
+            }
+        },
+        "calico-rr": {"hosts": {}},
+    }
 
-    for group in ['kube-master', 'etcd', 'openstack_control_plane']:
+    for group in ["kube-master", "etcd", "openstack_control_plane"]:
         for host in controller_nodes:
-            logger.debug('Adding host (group %s): %s', group, host)
-            k8s_inv['all']['children'][group]['hosts'][host] = {}
+            logger.debug("Adding host (group %s): %s", group, host)
+            k8s_inv["all"]["children"][group]["hosts"][host] = {}
 
-    for group in ['kube-node','openstack-compute-node']:
+    for group in ["kube-node", "openstack-compute-node"]:
         for host in worker_nodes:
-            logger.debug('Adding host (group %s): %s', group, host)
-            k8s_inv['all']['children'][group]['hosts'][host] = {}
+            logger.debug("Adding host (group %s): %s", group, host)
+            k8s_inv["all"]["children"][group]["hosts"][host] = {}
 
     """ Dump dictionary to a human readable inventory
         to stdout. This can be used to create the inventory file
     """
     try:
-        with open(args['hosts_file'], 'w') as hosts_yaml:
+        with open(args["hosts_file"], "w") as hosts_yaml:
             yaml_inv.dump(k8s_inv, hosts_yaml)
 
-        logger.info('Inventory written to: %s', k8s_inv)
+        logger.info("Inventory written to: %s", k8s_inv)
         hosts_yaml.close()
     except Exception as ex:
-        logger.error('Could not dump YAML to file: %s', args['hosts_file'])
+        logger.error("Could not dump YAML to file: %s", args["hosts_file"])
         raise SystemExit
+
 
 if __name__ == "__main__":
     args = parse_args(sys.argv[1:])


### PR DESCRIPTION
The scripts were all using "$*" for user includes but that wasn't working. So this change makes the linter happy and ensures that users are able to extend the flags used within a script by setting $@ at the end.