### PR TITLE
chore: move the helm repo update/add to scripts

### DIFF
--- a/bin/install-fluentbit.sh
+++ b/bin/install-fluentbit.sh
@@ -18,6 +18,9 @@ done
 
 HELM_CMD+=" $@"
 
+helm repo add fluent https://fluent.github.io/helm-charts
+helm repo update
+
 echo "Executing Helm command:"
 echo "${HELM_CMD}"
 eval "${HELM_CMD}"

--- a/bin/install-grafana.sh
+++ b/bin/install-grafana.sh
@@ -24,6 +24,9 @@ done
 
 HELM_CMD+=" $@"
 
+helm repo add grafana https://grafana.github.io/helm-charts
+helm repo update
+
 echo "Executing Helm command:"
 echo "${HELM_CMD}"
 eval "${HELM_CMD}"

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -67,16 +67,9 @@ Listeners and Routes should have been configureed when you installed the Gateway
 
 ### Deployment
 
-Add your grafana helm repository and update it.
+Run the Grafana deployment Script `/opt/genestack/bin/install-grafana.sh`
 
-``` shell
-helm repo add grafana https://grafana.github.io/helm-charts
-helm repo update
-```
-
-Run the Grafana deployment Script `bin/install-grafana.sh`
-
-??? example "Run the Grafana deployment Script `bin/install-grafana.sh`"
+??? example "Run the Grafana deployment Script `/opt/genestack/bin/install-grafana.sh`"
 
     ``` shell
     --8<-- "bin/install-grafana.sh"

--- a/docs/infrastructure-fluentbit.md
+++ b/docs/infrastructure-fluentbit.md
@@ -2,18 +2,11 @@
 
 This guide will help you deploy fluentbit to your kubernetes cluster. Fluentbit is a lightweight log shipper that can be used to send logs to loki.
 
-## Install the fluentbit helm repository
+## Deployment
 
-``` shell
-helm repo add fluent https://fluent.github.io/helm-charts
-helm repo update
-```
+Run the Fluent-Bit deployment Script `/opt/genestack/bin/install-fluentbit.sh`
 
-### Deployment
-
-Run the Fluent-Bit deployment Script `bin/install-fluentbit.sh`
-
-??? example "Run the Fluent-Bit deployment Script `bin/install-fluentbit.sh`"
+??? example "Run the Fluent-Bit deployment Script `/opt/genestack/bin/install-fluentbit.sh`"
 
     ``` shell
     --8<-- "bin/install-fluentbit.sh"


### PR DESCRIPTION
The helm repo update / add functions were documented but not part of our install sciprts. This change ensures that the repos are now part of the scripts and not a specific documentation step for FluentBit and Grafana.