### PR TITLE
chore: cleanup longhorn docs

### DIFF
--- a/base-helm-configs/longhorn/longhorn-helm-overrides.yaml
+++ b/base-helm-configs/longhorn/longhorn-helm-overrides.yaml
@@ -1,0 +1,16 @@
+---
+longhornDriver:
+  nodeSelector:
+    longhorn.io/storage-node: "enabled"
+longhornUI:
+  nodeSelector:
+    longhorn.io/storage-node: "enabled"
+longhornConversionWebhook:
+  nodeSelector:
+    longhorn.io/storage-node: "enabled"
+longhornAdmissionWebhook:
+  nodeSelector:
+    longhorn.io/storage-node: "enabled"
+longhornRecoveryBackend:
+  nodeSelector:
+    longhorn.io/storage-node: "enabled"

--- a/bin/install-longhorn.sh
+++ b/bin/install-longhorn.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# shellcheck disable=SC2124,SC2145,SC2294
+
+GLOBAL_OVERRIDES_DIR="/etc/genestack/helm-configs/global_overrides"
+SERVICE_CONFIG_DIR="/etc/genestack/helm-configs/longhorn"
+
+HELM_CMD="helm upgrade --install longhorn longhorn/longhorn --namespace longhorn-system --create-namespace"
+
+HELM_CMD+=" --set persistence.defaultClass=false --version 1.8.0"
+
+for dir in "$GLOBAL_OVERRIDES_DIR" "$SERVICE_CONFIG_DIR"; do
+    if compgen -G "${dir}/*.yaml" > /dev/null; then
+        for yaml_file in "${dir}"/*.yaml; do
+            HELM_CMD+=" -f ${yaml_file}"
+        done
+    fi
+done
+
+HELM_CMD+=" $@"
+
+helm repo add longhorn https://charts.longhorn.io
+helm repo update
+
+echo "Executing Helm command:"
+echo "${HELM_CMD}"
+eval "${HELM_CMD}"

--- a/docs/storage-ceph-rook-internal.md
+++ b/docs/storage-ceph-rook-internal.md
@@ -22,12 +22,11 @@ kubectl apply -k /etc/genestack/kustomize/rook-operator/
 
 ### Label the Storage Nodes
 
-
 | <div style="width:220px">key</div> | type | <div style="width:128px">value</div>  | notes |
 |:-----|--|:----------------:|:------|
 | **role** | str | `storage-node` | When set to "storage-node" the node will be used for Ceph OSDs |
 
-Use the following command to label a node to be part of the Longhorn storage cluster:
+Use the following command to label a node to be part of the Ceph storage cluster:
 
 ``` shell
 kubectl label node ${NODE_NAME} role=storage-node

--- a/docs/storage-longhorn.md
+++ b/docs/storage-longhorn.md
@@ -13,47 +13,11 @@ This guide walks through installing and configuring Longhorn, a lightweight, rel
 By following these steps, you'll set up the necessary host prerequisites, configure the Helm chart values, deploy Longhorn via Helm, and optionally
 create an encrypted StorageClass.
 
-### Node Pre-Work
+### Storage Node Setup
 
-Longhorn requires that every node participating in storage has certain system packages installed to enable iSCSI and encryption features. Specifically,
-the `iscsiadm` (iSCSI initiator utilities) and `cryptsetup` (encryption utilities) packages must be installed on every Kubernetes node that will provide
-storage to the Longhorn cluster.
-
-**Why these packages?**
-
-- **iscsiadm**: Longhorn uses iSCSI under the hood to expose block devices to pods. Without iSCSI, the block devices cannot be properly mounted.
-- **cryptsetup**: If you later choose to enable volume encryption, you will need `cryptsetup` to handle the encryption operations.
-
-#### Example Installation on Debian-based Systems
-
-If your nodes are running a Debian-based distribution such as Ubuntu or Debian itself, you can install `iscsiadm` and `cryptsetup` with:
-
-``` shell
-apt update
-apt -y install open-iscsi cryptsetup
-```
-
-!!! note
-
-    Adjust the package installation command for your specific Linux distribution if you are not using a Debian-based system.
-
-#### Storage Node Setup
-
-Longhorn will create volumes under the `/var/lib/longhorn` directory on each node. Ensure that this directory has enough space to accommodate the volumes
-you plan to create. If you have a separate disk or partition that you want to use for Longhorn volumes, you can mount it at `/var/lib/longhorn` before
-installing Longhorn.
-
-### Helm Setup
-
-Helm is a popular package manager for Kubernetes that allows you to install applications from “charts.” Longhorn is distributed via an official Helm chart,
-so the first step is to add the Longhorn chart repository to Helm and update your local repo index to retrieve the latest chart information.
-
-``` shell
-helm repo add longhorn https://charts.longhorn.io
-helm repo update
-```
-
-This ensures that Helm knows about the Longhorn chart and can install or upgrade to the correct version.
+Longhorn will create volumes under the `/var/lib/longhorn` directory on each node. Ensure that this directory has
+enough space to accommodate the volumes you plan to create. If you have a separate disk or partition that you want
+to use for Longhorn volumes, you can mount it at `/var/lib/longhorn` before installing Longhorn.
 
 ### Label the Storage Nodes
 
@@ -77,27 +41,13 @@ Replace `${NODE_NAME}` with the name of your node. If you have multiple storage 
 Before deploying Longhorn, it’s best practice to customize the chart’s values to suit your environment. One of the most common customizations is telling Longhorn where to run
 its services and components—in this case, on nodes that have the label `longhorn.io/storage-node=enabled`.
 
-1. Create the override file at `/etc/genestack/helm-configs/longhorn.yaml`.
+1. Create the override file at `/etc/genestack/helm-configs/longhorn/longhorn.yaml`.
 2. Copy the following YAML content into that file. (Adapt as needed.)
 
 !!! example "longhorn.yaml"
 
     ``` yaml
-    longhornDriver:
-      nodeSelector:
-        longhorn.io/storage-node: "enabled"
-    longhornUI:
-      nodeSelector:
-        longhorn.io/storage-node: "enabled"
-    longhornConversionWebhook:
-      nodeSelector:
-        longhorn.io/storage-node: "enabled"
-    longhornAdmissionWebhook:
-      nodeSelector:
-        longhorn.io/storage-node: "enabled"
-    longhornRecoveryBackend:
-      nodeSelector:
-        longhorn.io/storage-node: "enabled"
+    --8<-- "base-helm-configs/longhorn/longhorn-helm-overrides.yaml"
     ```
 
     - `nodeSelector` ensures that the respective component is only scheduled onto nodes labeled `longhorn.io/storage-node=enabled`.
@@ -112,43 +62,27 @@ For additional customization, you can review the full list of supported values i
 
 ### Create The Longhorn Namespace
 
-``` shell
-kubectl create namespace longhorn-system
-```
+!!! example "longhorn-namespace.yaml"
 
-Set the namespace security policy.
+    ``` yaml
+    --8<-- "manifests/longhorn/longhorn-namespace.yaml"
+    ```
 
 ``` shell
-kubectl label --overwrite namespace longhorn-system \
-        pod-security.kubernetes.io/enforce=privileged \
-        pod-security.kubernetes.io/enforce-version=latest \
-        pod-security.kubernetes.io/warn=privileged \
-        pod-security.kubernetes.io/warn-version=latest \
-        pod-security.kubernetes.io/audit=privileged \
-        pod-security.kubernetes.io/audit-version=latest
+kubectl apply -f /etc/genestack/manifests/longhorn/longhorn-namespace.yaml
 ```
 
 ### Run the Deployment
 
-With your values file in place, you can now deploy Longhorn using the `helm upgrade --install` command. This command will install Longhorn if it is not
-installed yet, or upgrade it if an older version is already present. The `--create-namespace` flag ensures the namespace is created if it does not exist.
-The --set persistence.defaultClass=false ensures that the lognhorn storage class is not set as the default.
+With your values file in place, you can now deploy Longhorn using the `/opt/genestack/bin/install-longhorn.sh`
+command. This command will install Longhorn if it is not installed yet, or upgrade it if an older version is
+already present.
 
-``` shell
-helm upgrade --install longhorn longhorn/longhorn \
-             --namespace longhorn-system \
-             --create-namespace \
-             --set persistence.defaultClass=false \
-             -f /etc/genestack/helm-configs/longhorn.yaml
-```
+??? example "Run the Longhorn deployment Script `/opt/genestack/bin/install-longhorn.sh`"
 
-!!! note "Common helm upgrade arguments"
-
-    - **`upgrade --install`**: Installs or upgrades your release.
-    - **`--namespace longhorn-system`**: Puts all the Longhorn resources into the `longhorn-system` namespace.
-    - **`--create-namespace`**: Creates the namespace if it does not exist already.
-    - **`--version 1.8.0`**: Installs a specific version (1.8.0).
-    - **`-f /etc/genestack/helm-configs/longhorn.yaml`**: Applies your custom values file.
+    ``` shell
+    --8<-- "bin/install-longhorn.sh"
+    ```
 
 ## Validate the Deployment
 
@@ -159,6 +93,7 @@ After the Helm deployment finishes, you’ll want to verify that everything is r
    ``` shell
    kubectl -n longhorn-system get pod
    ```
+
    This should show multiple pods such as `longhorn-manager`, `longhorn-driver`, `longhorn-ui`, etc. They should eventually report a `Running` or `Ready` status.
 
 2. **Check the Longhorn Nodes**
@@ -166,13 +101,15 @@ After the Helm deployment finishes, you’ll want to verify that everything is r
    ``` shell
    kubectl -n longhorn-system get nodes.longhorn.io
    ```
+
    This will show the nodes known to the Longhorn system, verifying that Longhorn has recognized and is managing them.
 
 3. **Run a test Pod with a Longhorn Persistent Volume**
 
    ``` shell
-   kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v1.7.2/examples/pod_with_pvc.yaml
+   kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v1.8.0/examples/pod_with_pvc.yaml
    ```
+
    This sample manifest creates a test Pod that uses a PersistentVolumeClaim (PVC) managed by Longhorn. It helps confirm that Longhorn can successfully provision and attach storage.
 
 4. **Validate the Volume State**
@@ -185,7 +122,7 @@ You should see an entry for the newly created volume, and it should be in an att
 
 !!! example "Example Output"
 
-    ```
+    ``` shell
     NAME                                       DATA ENGINE   STATE      ROBUSTNESS   SCHEDULED   SIZE         NODE                                  AGE
     pvc-42c89b53-f08e-4d69-9d4d-cd2297f2c280   v1            attached   healthy                  2147483648   compute-0.cloud.cloudnull.dev.local   54s
     ```
@@ -194,11 +131,15 @@ Once you verify the test deployment, you can remove the Pod and related resource
 
 ## StorageClass Configuration
 
-The Longhorn StorageClass is a Kubernetes resource that defines how PersistentVolumeClaims (PVCs) are provisioned. By creating a StorageClass, you can
-specify the default settings for Longhorn volumes, such as the number of replicas, data locality, and more. This section will guide you through creating
-a general-purpose StorageClass and an optional encrypted StorageClass.
+The Longhorn StorageClass is a Kubernetes resource that defines how PersistentVolumeClaims (PVCs) are provisioned.
+By creating a StorageClass, you can specify the default settings for Longhorn volumes, such as the number of
+replicas, data locality, and more. This section will guide you through creating a general-purpose StorageClass and
+an optional encrypted StorageClass.
 
-For a generic StorageClass and an overview of common properties, review the upstream [example](https://github.com/longhorn/longhorn/blob/master/examples/storageclass.yaml). You can also review the Longhorn [documentation](https://longhorn.io/docs/1.7.2/references/storage-class-parameters/#longhorn-specific-parameters) for more information on StorageClasses.
+For a generic StorageClass and an overview of common properties, review the upstream
+[example](https://github.com/longhorn/longhorn/blob/master/examples/storageclass.yaml). You can also review the Longhorn
+[documentation](https://longhorn.io/docs/1.7.2/references/storage-class-parameters/#longhorn-specific-parameters)
+for more information on StorageClasses.
 
 !!! note
 
@@ -225,37 +166,16 @@ For the purposes of Genestack, it is recommended that you create the `general` S
 !!! example "longhorn-general-storageclass.yaml"
 
     ``` yaml
-    kind: StorageClass
-    apiVersion: storage.k8s.io/v1
-    metadata:
-        name: general
-    provisioner: driver.longhorn.io
-    allowVolumeExpansion: true
-    reclaimPolicy: Delete
-    volumeBindingMode: Immediate
-    parameters:
-        numberOfReplicas: "1"  # This example uses a single replica, but you can adjust this value as needed
-        dataLocality: "best-effort"
-        staleReplicaTimeout: "2880"
-        fromBackup: ""
-        fsType: "ext4"
+    --8<-- "manifests/longhorn/longhorn-general-storageclass.yaml"
     ```
 
-!!! tip "Reuse the Longhorn StorageClass"
-
-    The Longhorn StorageClass values can be dumped and used to recreate the new class.
-
-    ``` shell
-    kubectl get storageclass longhorn -o yaml > /etc/genestack/manifests/longhorn-general-storageclass.yaml
-    ```
-
-    Edit the file and change the `name` fields to `general`. Then apply the manifest to create the `general` StorageClass.
-
-With the `general` StorageClass in place, you can now create PVCs that reference it to dynamically provision Longhorn volumes with the desired settings.
+Apply the general storage class manifest to create the StorageClass.
 
 ``` shell
-kubectl apply -f /etc/genestack/manifests/longhorn-general-storageclass.yaml
+kubectl apply -f /etc/genestack/manifests/longhorn/longhorn-general-storageclass.yaml
 ```
+
+With the `general` StorageClass in place, you can now create PVCs that reference it to dynamically provision Longhorn volumes with the desired settings.
 
 ### (Optional) Create an Encrypted StorageClass
 
@@ -272,40 +192,7 @@ Below is an example combined manifest. Save this content to `/etc/genestack/mani
 !!! example "longhorn-encrypted-storageclass.yaml"
 
     ``` yaml
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: longhorn-crypto
-      namespace: longhorn-system
-    stringData:
-      CRYPTO_KEY_VALUE: "Your encryption passphrase"  # Be sure to replace this with your own passphrase
-      CRYPTO_KEY_PROVIDER: "secret"
-      CRYPTO_KEY_CIPHER: "aes-xts-plain64"
-      CRYPTO_KEY_HASH: "sha256"
-      CRYPTO_KEY_SIZE: "256"
-      CRYPTO_PBKDF: "argon2i"
-    ---
-    kind: StorageClass
-    apiVersion: storage.k8s.io/v1
-    metadata:
-      name: general-encrypted
-    provisioner: driver.longhorn.io
-    allowVolumeExpansion: true
-    reclaimPolicy: Delete
-    volumeBindingMode: Immediate
-    parameters:
-      numberOfReplicas: "3"
-      dataLocality: "best-effort"
-      staleReplicaTimeout: "2880"
-      fromBackup: ""
-      fsType: "ext4"
-      encrypted: "true"
-      csi.storage.k8s.io/provisioner-secret-name: "longhorn-crypto"
-      csi.storage.k8s.io/provisioner-secret-namespace: "longhorn-system"
-      csi.storage.k8s.io/node-publish-secret-name: "longhorn-crypto"
-      csi.storage.k8s.io/node-publish-secret-namespace: "longhorn-system"
-      csi.storage.k8s.io/node-stage-secret-name: "longhorn-crypto"
-      csi.storage.k8s.io/node-stage-secret-namespace: "longhorn-system"
+    --8<-- "manifests/longhorn/longhorn-encrypted-storageclass.yaml"
     ```
 
 !!! info "Explanation of Key Fields"
@@ -326,6 +213,12 @@ Below is an example combined manifest. Save this content to `/etc/genestack/mani
     - `allowVolumeExpansion: true`: Allows you to resize volumes after creation.
     - `reclaimPolicy: Delete`: Automatically deletes the underlying volume when the PVC is deleted.
     - `encrypted: "true"`: Ensures volumes are encrypted.
+
+Apply the encrypted storage class manifest to create the StorageClass.
+
+``` shell
+kubectl apply -f /etc/genestack/manifests/longhorn/longhorn-encrypted-storageclass.yaml
+```
 
 After applying this manifest, a new `StorageClass` named `general-encrypted` will be available. Any PVC you create referencing this StorageClass will
 automatically generate an encrypted Longhorn volume.

--- a/manifests/longhorn/longhorn-encrypted-storageclass.yaml
+++ b/manifests/longhorn/longhorn-encrypted-storageclass.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: longhorn-crypto
+  namespace: longhorn-system
+stringData:
+  CRYPTO_KEY_VALUE: "Your encryption passphrase"  # Be sure to replace this with your own passphrase
+  CRYPTO_KEY_PROVIDER: "secret"
+  CRYPTO_KEY_CIPHER: "aes-xts-plain64"
+  CRYPTO_KEY_HASH: "sha256"
+  CRYPTO_KEY_SIZE: "256"
+  CRYPTO_PBKDF: "argon2i"
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: general-encrypted
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "3"
+  dataLocality: "best-effort"
+  staleReplicaTimeout: "2880"
+  fromBackup: ""
+  fsType: "ext4"
+  encrypted: "true"
+  csi.storage.k8s.io/provisioner-secret-name: "longhorn-crypto"
+  csi.storage.k8s.io/provisioner-secret-namespace: "longhorn-system"
+  csi.storage.k8s.io/node-publish-secret-name: "longhorn-crypto"
+  csi.storage.k8s.io/node-publish-secret-namespace: "longhorn-system"
+  csi.storage.k8s.io/node-stage-secret-name: "longhorn-crypto"
+  csi.storage.k8s.io/node-stage-secret-namespace: "longhorn-system"

--- a/manifests/longhorn/longhorn-general-storageclass.yaml
+++ b/manifests/longhorn/longhorn-general-storageclass.yaml
@@ -1,0 +1,17 @@
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: general
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "2"  # This example uses a single replica, but you can adjust this value as needed
+  dataLocality: "best-effort"
+  staleReplicaTimeout: "2880"
+  fromBackup: ""
+  fsType: "ext4"

--- a/manifests/longhorn/longhorn-namespace.yaml
+++ b/manifests/longhorn/longhorn-namespace.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+metadata:
+  labels:
+    kubernetes.io/metadata.name: longhorn-system
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest
+  name: longhorn-system


### PR DESCRIPTION
This change moves a lot of the longhorn examples into files so that they can be used without having to copy and paste.

Additionally, the node pre work section was removed because all required steps are now covered by our host-setup playbook.