### PR TITLE
fix(ceilometer): Disable the ks_service job

### DIFF
--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -2133,7 +2133,7 @@ manifests:
   job_db_sync: true
   job_image_repo_sync: true
   job_ks_endpoints: false
-  job_ks_service: true
+  job_ks_service: false
   job_ks_user: true
   job_rabbit_init: true
   pdb_api: true


### PR DESCRIPTION
Ceilometer does not actually need this to function properly anymore. It used to have an API but was deprecated a while back. Creating a service in keystone for it is mostly harmless but results in WARNING level logs in other services when they do a service list, find ceilometer in the output, but no related keystone endpoint exists.