### PR TITLE
fix: resolve deprecated keystone options

### DIFF
--- a/base-helm-configs/barbican/barbican-helm-overrides.yaml
+++ b/base-helm-configs/barbican/barbican-helm-overrides.yaml
@@ -379,10 +379,11 @@ conf:
       transport_url: null
       log_config_append: /etc/barbican/logging.conf
     keystone_authtoken:
-      auth_type: password
+      service_token_roles: service
+      service_token_roles_required: true
       auth_version: v3
+      auth_type: password
       memcache_security_strategy: ENCRYPT
-      memcache_secret_key: null
       service_type: key-manager
     database:
       max_retries: -1

--- a/base-helm-configs/heat/heat-helm-overrides.yaml
+++ b/base-helm-configs/heat/heat-helm-overrides.yaml
@@ -332,6 +332,8 @@ conf:
       trusts_delegated_roles: ""
       host: heat-engine
     keystone_authtoken:
+      service_token_roles: service
+      service_token_roles_required: true
       auth_type: password
       auth_version: v3
       memcache_security_strategy: ENCRYPT

--- a/base-helm-configs/octavia/octavia-helm-overrides.yaml
+++ b/base-helm-configs/octavia/octavia-helm-overrides.yaml
@@ -201,6 +201,8 @@ conf:
       controller_ip_port_list: 0.0.0.0:5555
       heartbeat_key: insecure
     keystone_authtoken:
+      service_token_roles: service
+      service_token_roles_required: true
       auth_type: password
       auth_version: v3
       memcache_security_strategy: ENCRYPT


### PR DESCRIPTION
This change resolves a keytsone lib warning that is within many of our services.

> 2025-02-11 00:49:34.772 9 WARNING keystonemiddleware.auth_token [-] AuthToken middleware is set with keystone_authtoken.service_token_roles_required set to False. This is backwards compatible but deprecated behaviour. Please set this to True.

With this change the error is resolved and no longer part of our system.