### PR TITLE
FIX: HIGH PRIORITY multipath blacklist

### DIFF
--- a/ansible/playbooks/templates/genestack-multipath.conf
+++ b/ansible/playbooks/templates/genestack-multipath.conf
@@ -9,8 +9,7 @@ blacklist {
     devnode    "scini*"
     devnode    "^rbd[0-9]*"
     devnode    "^nbd[0-9]*"
-    devnode    "^sda[0-9]*"
-    devnode    "^sdb[0-9]*"
+    devnode    "sd[a-b]$"
     devnode    "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
     devnode    "^(td|ha)d[a-z]"
 }


### PR DESCRIPTION
Our current regexp pattern ^sda[0-9]* and ^sdb[0-9]* blacklists sda and sdb which is what we want. Unfortunately, it also blocks /dev/sda[a-x], /dev/sdb[a-x] which is NOT what we want Guarav's Rally testing revealed that with a high number of multipath devices, they naming convention starts to add the additional alphabet letter as it scales up.

The correction: "sd[a-b]$" per
https://www.suse.com/support/kb/doc/?id=000016563