### PR TITLE
fix(keystone): update the keystone image to fix project id hashing

### DIFF
--- a/.original-images.json
+++ b/.original-images.json
@@ -14,6 +14,6 @@
   "ghcr.io/rackerlabs/genestack/nova-efi:2024.1-ubuntu_jammy-1723129048",
   "ghcr.io/rackerlabs/genestack/nova-efi:2024.1-ubuntu_jammy-1737928811",
   "ghcr.io/rackerlabs/genestack/octavia-ovn:2024.1-ubuntu_jammy-1737651745",
-  "ghcr.io/rackerlabs/keystone-rxt:2024.1-ubuntu_jammy-1738429591",
+  "ghcr.io/rackerlabs/keystone-rxt:2024.1-ubuntu_jammy-1739377879",
   "ghcr.io/rackerlabs/skyline-rxt:master-ubuntu_jammy-1738594297"
 ]


### PR DESCRIPTION
There was an issue with the project id hash which had unforseen breakage with services like octavia. While the hash length is allowed by the keystone driver, a hard coded value in the octavia service limits project IDs to only 32 characters.

This change pulls in a new image that will resolve this hashing issue so that new projects don't encounter this issue.