### PR TITLE
fix(ceilometer): Add volume_type_id to metric meta

### DIFF
--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -231,7 +231,7 @@ conf:
         size:
           type: int
           fields: payload.size
-        type:
+        volume_type_id:
           fields: payload.volume_type
         replication_status:
           fields: payload.replication_status
@@ -1057,6 +1057,7 @@ conf:
         attributes:
           display_name: resource_metadata.(display_name|name)
           volume_type: resource_metadata.volume_type
+          volume_type_id: resource_metadata.volume_type_id
           image_id: resource_metadata.image_id
           instance_id: resource_metadata.instance_id
         event_create:
@@ -1295,7 +1296,7 @@ conf:
         resource_id: $.payload.volume_id
         metadata:
           display_name: $.payload.display_name
-          volume_type: $.payload.volume_type
+          volume_type_id: $.payload.volume_type
           image_id: $.payload.glance_metadata[?key=image_id].value
           instance_id: $.payload.volume_attachment[0].instance_uuid
 


### PR DESCRIPTION
Cinder volume notifications emit only payload.volume_type as an id, but the API pollster in Ceilometer gets back a name value from Cinder. Cinder should emit the volume_type_name in its notification payloads but sadly it does not at this time. This change will simply re-route payload volume_type to a new field we will add in gnocchi for volume_type_id, preventing flip-flopping of volume_type on the gnocchi volume_type resources.

LPBug: https://bugs.launchpad.net/cinder/+bug/2097328
Change-Id: I71e7fca4a6d303462fa6d0ed69245b79cb28d646