### PR TITLE
chore: Update image build for neutron

### DIFF
--- a/.github/workflows/release-neutron-oslodb.yaml
+++ b/.github/workflows/release-neutron-oslodb.yaml
@@ -24,10 +24,10 @@ on:
       NeutronTag:
         description: 'Set Neutron version'
         required: true
-        default: 'sync-add-mode-2024.1'
+        default: 'sync-add-mode'
         type: choice
         options:
-          - 'master'
+          - 'sync-add-mode'
           - 'sync-add-mode-2024.1'
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.


### PR DESCRIPTION
This change will allow us to build the master image of neutron using the fixed sync methods. An upstream review has been created to track these changes and ensure that the fixes we're developing are shared with the community.

Upstream: https://review.opendev.org/c/openstack/neutron/+/941824