### PR TITLE
fix: Update the use of managed-by Helm

### DIFF
--- a/base-kustomize/barbican/base/barbican-mariadb-database.yaml
+++ b/base-kustomize/barbican/base/barbican-mariadb-database.yaml
@@ -4,9 +4,10 @@ kind: Database
 metadata:
   name: barbican
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "barbican"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -23,9 +24,10 @@ kind: User
 metadata:
   name: barbican
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "barbican"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -46,9 +48,10 @@ kind: Grant
 metadata:
   name: barbican-grant
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "barbican"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/barbican/base/barbican-rabbitmq-queue.yaml
+++ b/base-kustomize/barbican/base/barbican-rabbitmq-queue.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: openstack
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "barbican"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -24,9 +23,10 @@ kind: Vhost
 metadata:
   name: barbican-vhost
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "barbican"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -48,9 +48,10 @@ kind: Queue
 metadata:
   name: barbican-queue
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "barbican"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -68,9 +69,10 @@ kind: Permission
 metadata:
   name: barbican-permission
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "barbican"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/ceilometer/base/ceilometer-rabbitmq-queue.yaml
+++ b/base-kustomize/ceilometer/base/ceilometer-rabbitmq-queue.yaml
@@ -4,9 +4,10 @@ kind: User
 metadata:
   name: ceilometer
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "ceilometer"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -24,9 +25,10 @@ kind: Vhost
 metadata:
   name: ceilometer-vhost
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "ceilometer"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -48,9 +50,10 @@ kind: Queue
 metadata:
   name: ceilometer-queue
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "ceilometer"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -68,9 +71,10 @@ kind: Permission
 metadata:
   name: ceilometer-permission
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "ceilometer"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/cinder/base/cinder-mariadb-database.yaml
+++ b/base-kustomize/cinder/base/cinder-mariadb-database.yaml
@@ -4,9 +4,10 @@ kind: Database
 metadata:
   name: cinder
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "cinder"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -23,9 +24,10 @@ kind: User
 metadata:
   name: cinder
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "cinder"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -46,9 +48,10 @@ kind: Grant
 metadata:
   name: cinder-grant
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "cinder"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/cinder/base/cinder-rabbitmq-queue.yaml
+++ b/base-kustomize/cinder/base/cinder-rabbitmq-queue.yaml
@@ -4,9 +4,10 @@ kind: User
 metadata:
   name: cinder
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "cinder"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -24,9 +25,10 @@ kind: Vhost
 metadata:
   name: cinder-vhost
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "cinder"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -48,9 +50,10 @@ kind: Queue
 metadata:
   name: cinder-queue
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "cinder"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -68,9 +71,10 @@ kind: Permission
 metadata:
   name: cinder-permission
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "cinder"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/designate/base/designate-mariadb-database.yaml
+++ b/base-kustomize/designate/base/designate-mariadb-database.yaml
@@ -4,9 +4,10 @@ kind: Database
 metadata:
   name: designate
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "designate"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -23,9 +24,10 @@ kind: User
 metadata:
   name: designate
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "designate"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -46,9 +48,10 @@ kind: Grant
 metadata:
   name: designate-grant
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "designate"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/designate/base/designate-rabbitmq-queue.yaml
+++ b/base-kustomize/designate/base/designate-rabbitmq-queue.yaml
@@ -4,9 +4,10 @@ kind: User
 metadata:
   name: designate
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "designate"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -24,9 +25,10 @@ kind: Vhost
 metadata:
   name: designate-vhost
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "designate"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -48,9 +50,10 @@ kind: Queue
 metadata:
   name: designate-queue
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "designate"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -68,9 +71,10 @@ kind: Permission
 metadata:
   name: designate-permission
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "designate"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/glance/base/glance-mariadb-database.yaml
+++ b/base-kustomize/glance/base/glance-mariadb-database.yaml
@@ -4,9 +4,10 @@ kind: Database
 metadata:
   name: glance
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "glance"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -23,9 +24,10 @@ kind: User
 metadata:
   name: glance
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "glance"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -46,9 +48,10 @@ kind: Grant
 metadata:
   name: glance-grant
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "glance"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/glance/base/glance-rabbitmq-queue.yaml
+++ b/base-kustomize/glance/base/glance-rabbitmq-queue.yaml
@@ -24,9 +24,10 @@ kind: Vhost
 metadata:
   name: glance-vhost
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "glance"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -48,9 +49,10 @@ kind: Queue
 metadata:
   name: glance-queue
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "glance"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -68,9 +70,10 @@ kind: Permission
 metadata:
   name: glance-permission
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "glance"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/grafana/base/grafana-database.yaml
+++ b/base-kustomize/grafana/base/grafana-database.yaml
@@ -5,7 +5,6 @@ metadata:
   name: mariadb-cluster
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "grafana"
     meta.helm.sh/release-namespace: "openstack"
   labels:
@@ -21,7 +20,6 @@ metadata:
   namespace: grafana
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "grafana"
     meta.helm.sh/release-namespace: "openstack"
   labels:
@@ -142,7 +140,6 @@ metadata:
   namespace: grafana
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "grafana"
     meta.helm.sh/release-namespace: "openstack"
   labels:
@@ -183,7 +180,6 @@ metadata:
   namespace: grafana
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "grafana"
     meta.helm.sh/release-namespace: "openstack"
   labels:
@@ -205,7 +201,6 @@ metadata:
   namespace: grafana
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "grafana"
     meta.helm.sh/release-namespace: "openstack"
   labels:
@@ -231,7 +226,6 @@ metadata:
   namespace: grafana
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "grafana"
     meta.helm.sh/release-namespace: "openstack"
   labels:

--- a/base-kustomize/heat/base/heat-mariadb-database.yaml
+++ b/base-kustomize/heat/base/heat-mariadb-database.yaml
@@ -4,9 +4,10 @@ kind: Database
 metadata:
   name: heat
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "heat"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -23,9 +24,10 @@ kind: User
 metadata:
   name: heat
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "heat"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -46,9 +48,10 @@ kind: Grant
 metadata:
   name: heat-grant
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "heat"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/horizon/base/horizon-mariadb-database.yaml
+++ b/base-kustomize/horizon/base/horizon-mariadb-database.yaml
@@ -4,9 +4,10 @@ kind: Database
 metadata:
   name: horizon
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "horizon"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -23,9 +24,10 @@ kind: User
 metadata:
   name: horizon
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "horizon"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -46,9 +48,10 @@ kind: Grant
 metadata:
   name: horizon-grant
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "horizon"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/keystone/base/keystone-mariadb-database.yaml
+++ b/base-kustomize/keystone/base/keystone-mariadb-database.yaml
@@ -4,9 +4,10 @@ kind: Database
 metadata:
   name: keystone
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "keystone"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -23,9 +24,10 @@ kind: User
 metadata:
   name: keystone
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "keystone"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -46,9 +48,10 @@ kind: Grant
 metadata:
   name: keystone-grant
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "keystone"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/keystone/base/keystone-rabbitmq-queue.yaml
+++ b/base-kustomize/keystone/base/keystone-rabbitmq-queue.yaml
@@ -24,9 +24,10 @@ kind: Vhost
 metadata:
   name: keystone-vhost
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "keystone"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -48,9 +49,10 @@ kind: Queue
 metadata:
   name: keystone-queue
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "keystone"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -68,9 +70,10 @@ kind: Permission
 metadata:
   name: keystone-permission
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "keystone"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/magnum/base/magnum-mariadb-database.yaml
+++ b/base-kustomize/magnum/base/magnum-mariadb-database.yaml
@@ -4,9 +4,10 @@ kind: Database
 metadata:
   name: magnum
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "magnum"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -23,9 +24,10 @@ kind: User
 metadata:
   name: magnum
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "magnum"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -46,9 +48,10 @@ kind: Grant
 metadata:
   name: magnum-grant
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "magnum"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/magnum/base/magnum-rabbitmq-queue.yaml
+++ b/base-kustomize/magnum/base/magnum-rabbitmq-queue.yaml
@@ -4,9 +4,10 @@ kind: User
 metadata:
   name: magnum
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "magnum"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -24,9 +25,10 @@ kind: Vhost
 metadata:
   name: magnum-vhost
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "magnum"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -41,9 +43,10 @@ kind: Queue
 metadata:
   name: magnum-queue
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "magnum"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -61,9 +64,10 @@ kind: Permission
 metadata:
   name: magnum-permission
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "magnum"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/neutron/base/neutron-mariadb-database.yaml
+++ b/base-kustomize/neutron/base/neutron-mariadb-database.yaml
@@ -4,9 +4,10 @@ kind: Database
 metadata:
   name: neutron
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "neutron"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -23,9 +24,10 @@ kind: User
 metadata:
   name: neutron
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "neutron"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -46,9 +48,10 @@ kind: Grant
 metadata:
   name: neutron-grant
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "neutron"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/neutron/base/neutron-rabbitmq-queue.yaml
+++ b/base-kustomize/neutron/base/neutron-rabbitmq-queue.yaml
@@ -4,9 +4,10 @@ kind: User
 metadata:
   name: neutron
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "neutron"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -24,9 +25,10 @@ kind: Vhost
 metadata:
   name: neutron-vhost
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "neutron"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -48,9 +50,10 @@ kind: Queue
 metadata:
   name: neutron-queue
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "neutron"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -68,9 +71,10 @@ kind: Permission
 metadata:
   name: neutron-permission
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "neutron"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/nova/base/nova-mariadb-database.yaml
+++ b/base-kustomize/nova/base/nova-mariadb-database.yaml
@@ -4,9 +4,10 @@ kind: Database
 metadata:
   name: nova
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "nova"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -23,9 +24,10 @@ kind: Database
 metadata:
   name: nova-api
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "nova"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -43,9 +45,10 @@ kind: Database
 metadata:
   name: nova-cell0
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "nova"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -63,9 +66,10 @@ kind: User
 metadata:
   name: nova
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "nova"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -86,9 +90,10 @@ kind: Grant
 metadata:
   name: nova-grant
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "nova"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -108,9 +113,10 @@ kind: Grant
 metadata:
   name: nova-api-grant
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "nova"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -130,9 +136,10 @@ kind: Grant
 metadata:
   name: nova-cell0-grant
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "nova"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/nova/base/nova-rabbitmq-queue.yaml
+++ b/base-kustomize/nova/base/nova-rabbitmq-queue.yaml
@@ -4,9 +4,10 @@ kind: User
 metadata:
   name: nova
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "nova"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -24,9 +25,10 @@ kind: Vhost
 metadata:
   name: nova-vhost
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "nova"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -48,9 +50,10 @@ kind: Queue
 metadata:
   name: nova-queue
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "nova"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -68,9 +71,10 @@ kind: Permission
 metadata:
   name: nova-permission
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "nova"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/octavia/base/octavia-mariadb-database.yaml
+++ b/base-kustomize/octavia/base/octavia-mariadb-database.yaml
@@ -4,9 +4,10 @@ kind: Database
 metadata:
   name: octavia
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "octavia"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -23,9 +24,10 @@ kind: User
 metadata:
   name: octavia
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "octavia"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -46,9 +48,10 @@ kind: Grant
 metadata:
   name: octavia-grant
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "octavia"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/octavia/base/octavia-rabbitmq-queue.yaml
+++ b/base-kustomize/octavia/base/octavia-rabbitmq-queue.yaml
@@ -4,9 +4,10 @@ kind: User
 metadata:
   name: octavia
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "octavia"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -24,9 +25,10 @@ kind: Vhost
 metadata:
   name: octavia-vhost
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "octavia"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -48,9 +50,10 @@ kind: Queue
 metadata:
   name: octavia-queue
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "octavia"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -68,9 +71,10 @@ kind: Permission
 metadata:
   name: octavia-permission
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "octavia"
     meta.helm.sh/release-namespace: "openstack"
 spec:

--- a/base-kustomize/placement/base/placement-mariadb-database.yaml
+++ b/base-kustomize/placement/base/placement-mariadb-database.yaml
@@ -4,9 +4,10 @@ kind: Database
 metadata:
   name: placement
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "placement"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -23,9 +24,10 @@ kind: User
 metadata:
   name: placement
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "placement"
     meta.helm.sh/release-namespace: "openstack"
 spec:
@@ -46,9 +48,10 @@ kind: Grant
 metadata:
   name: placement-grant
   namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
   annotations:
     helm.sh/resource-policy: keep
-    app.kubernetes.io/managed-by: "Helm"
     meta.helm.sh/release-name: "placement"
     meta.helm.sh/release-namespace: "openstack"
 spec:


### PR DESCRIPTION
Our use of app.kubernetes.io/managed-by: "Helm" was set in an annotation but it needed to be in a label. This fixes the glitch.