### PR TITLE
fix: bootstrap script will fail if ran twice

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -118,7 +118,7 @@ done
 
 # Symlink /opt/genestack/base-kustomize/kustomize.sh to
 # /etc/genestack/kustomize/kustomize.sh
-ln -s $base_source_dir/kustomize.sh $base_target_dir/kustomize.sh
+ln -sf $base_source_dir/kustomize.sh $base_target_dir/kustomize.sh
 
 # Ensure kustomization.yaml exists in each
 # service base/overlay directory


### PR DESCRIPTION
If the bootstrap script is run twice it will fail due to the kustomize symlink already existing. This change updates the bootstrap script so that the symlink create will force the recreation as needed.