### PR TITLE
fix: update the glance store service

### DIFF
--- a/Containerfiles/Glance-Containerfile
+++ b/Containerfiles/Glance-Containerfile
@@ -6,7 +6,10 @@ RUN apt update && apt install -y git
 RUN export ORIG_PLUGIN_VERSION="${PLUGIN_VERSION}"; \
 if [ "${PLUGIN_VERSION}" != 'master' ]; then export PLUGIN_VERSION=stable/${PLUGIN_VERSION}; fi; \
 . /var/lib/openstack/bin/activate; \
-/var/lib/openstack/bin/pip install boto3 git+https://github.com/openstack/oslo.db@${PLUGIN_VERSION}#egg=oslo_db
+/var/lib/openstack/bin/pip install boto3 os-brick \
+                                         git+https://github.com/openstack/python-cinderclient@${PLUGIN_VERSION}#egg=python-cinderclient \
+                                         git+https://github.com/openstack/oslo.db@${PLUGIN_VERSION}#egg=oslo_db \
+                                         git+https://github.com/openstack/glance@${PLUGIN_VERSION}#egg=glance
 
 FROM openstackhelm/glance:${VERSION}
 COPY --from=build /var/lib/openstack/. /var/lib/openstack/


### PR DESCRIPTION
This change ensures that our glance image so that it resolves errors in the logs with unsupported stores and ensures
we're running an up to date, stable version of glance.