### PR TITLE
chore(glance): convert helm chart from submodule to repo

### DIFF
--- a/base-helm-configs/glance/glance-helm-overrides.yaml
+++ b/base-helm-configs/glance/glance-helm-overrides.yaml
@@ -1,18 +1,6 @@
+---
 # radosgw, rbd, swift or pvc
 storage: pvc
-
-labels:
-  api:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-  job:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-  test:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-
-release_group: null
 
 images:
   tags:
@@ -31,12 +19,6 @@ images:
     bootstrap: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
     dep_check: "quay.io/rackspace/rackerlabs-kubernetes-entrypoint:v1.0.0"
     image_repo_sync: "quay.io/rackspace/rackerlabs-docker:17.07.0"
-  pull_policy: "IfNotPresent"
-  local_registry:
-    active: false
-    exclude:
-      - dep_check
-      - image_repo_sync
 
 bootstrap:
   enabled: true
@@ -71,167 +53,9 @@ network_policy:
       - {}
 
 conf:
-  software:
-    rbd:
-      rbd_store_pool_app_name: glance-image
-  rally_tests:
-    run_tempest: false
-    tests:
-      GlanceImages.create_and_delete_image:
-        - args:
-            container_format: bare
-            disk_format: qcow2
-            image_location: http://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
-          runner:
-            concurrency: 1
-            times: 1
-            type: constant
-          sla:
-            failure_rate:
-              max: 0
-      GlanceImages.create_and_list_image:
-        - args:
-            container_format: bare
-            disk_format: qcow2
-            image_location: http://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
-          runner:
-            concurrency: 1
-            times: 1
-            type: constant
-          sla:
-            failure_rate:
-              max: 0
-  ceph:
-    monitors: []
-    admin_keyring: null
-    override:
-    append:
-  ceph_client:
-    override:
-    append:
-  paste:
-    pipeline:glance-api:
-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler unauthenticated-context rootapp
-    pipeline:glance-api-caching:
-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler unauthenticated-context cache rootapp
-    pipeline:glance-api-cachemanagement:
-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler unauthenticated-context cache cachemanage rootapp
-    pipeline:glance-api-keystone:
-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler authtoken audit context  rootapp
-    pipeline:glance-api-keystone+caching:
-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler authtoken audit context cache rootapp
-    pipeline:glance-api-keystone+cachemanagement:
-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler authtoken audit context cache cachemanage rootapp
-    pipeline:glance-api-trusted-auth:
-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler context rootapp
-    pipeline:glance-api-trusted-auth+cachemanagement:
-      pipeline: cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler context cache cachemanage rootapp
-    composite:rootapp:
-      paste.composite_factory: glance.api:root_app_factory
-      /: apiversions
-      /v1: apiv1app
-      /v2: apiv2app
-    app:apiversions:
-      paste.app_factory: glance.api.versions:create_resource
-    app:apiv1app:
-      paste.app_factory: glance.api.v1.router:API.factory
-    app:apiv2app:
-      paste.app_factory: glance.api.v2.router:API.factory
-    filter:healthcheck:
-      paste.filter_factory: oslo_middleware:Healthcheck.factory
-      backends: disable_by_file
-      disable_by_file_path: /etc/glance/healthcheck_disable
-    filter:versionnegotiation:
-      paste.filter_factory: glance.api.middleware.version_negotiation:VersionNegotiationFilter.factory
-    filter:cache:
-      paste.filter_factory: glance.api.middleware.cache:CacheFilter.factory
-    filter:cachemanage:
-      paste.filter_factory: glance.api.middleware.cache_manage:CacheManageFilter.factory
-    filter:context:
-      paste.filter_factory: glance.api.middleware.context:ContextMiddleware.factory
-    filter:unauthenticated-context:
-      paste.filter_factory: glance.api.middleware.context:UnauthenticatedContextMiddleware.factory
-    filter:authtoken:
-      paste.filter_factory: keystonemiddleware.auth_token:filter_factory
-      delay_auth_decision: true
-    filter:audit:
-      paste.filter_factory: keystonemiddleware.audit:filter_factory
-      audit_map_file: /etc/glance/api_audit_map.conf
-    filter:gzip:
-      paste.filter_factory: glance.api.middleware.gzip:GzipMiddleware.factory
-    filter:osprofiler:
-      paste.filter_factory: osprofiler.web:WsgiMiddleware.factory
-      hmac_keys: SECRET_KEY  # DEPRECATED
-      enabled: yes  # DEPRECATED
-    filter:cors:
-      paste.filter_factory: oslo_middleware.cors:filter_factory
-      oslo_config_project: glance
-      oslo_config_program: glance-api
-    filter:http_proxy_to_wsgi:
-      paste.filter_factory: oslo_middleware:HTTPProxyToWSGI.factory
-  policy: {}
-  glance_sudoers: |
-    # This sudoers file supports rootwrap for both Kolla and LOCI Images.
-    Defaults !requiretty
-    Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/var/lib/openstack/bin:/var/lib/kolla/venv/bin"
-    glance ALL = (root) NOPASSWD: /var/lib/kolla/venv/bin/glance-rootwrap /etc/glance/rootwrap.conf *, /var/lib/openstack/bin/glance-rootwrap /etc/glance/rootwrap.conf *
-  rootwrap: |
-    # Configuration for glance-rootwrap
-    # This file should be owned by (and only-writable by) the root user
-
-    [DEFAULT]
-    # List of directories to load filter definitions from (separated by ',').
-    # These directories MUST all be only writeable by root !
-    filters_path=/etc/glance/rootwrap.d,/usr/share/glance/rootwrap
-
-    # List of directories to search executables in, in case filters do not
-    # explicitely specify a full path (separated by ',')
-    # If not specified, defaults to system PATH environment variable.
-    # These directories MUST all be only writeable by root !
-    exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin,/usr/local/bin,/usr/local/sbin,/var/lib/openstack/bin,/var/lib/kolla/venv/bin
-
-    # Enable logging to syslog
-    # Default value is False
-    use_syslog=False
-
-    # Which syslog facility to use.
-    # Valid values include auth, authpriv, syslog, local0, local1...
-    # Default value is 'syslog'
-    syslog_log_facility=syslog
-
-    # Which messages to log.
-    # INFO means log all usage
-    # ERROR means only log unsuccessful attempts
-    syslog_log_level=ERROR
-  rootwrap_filters:
-    glance_cinder_store:
-      pods:
-        - api
-      content: |
-        # glance-rootwrap command filters for glance cinder store
-        # This file should be owned by (and only-writable by) the root user
-
-        [Filters]
-        # cinder store driver
-        disk_chown: RegExpFilter, chown, root, chown, \d+, /dev/(?!.*/\.\.).*
-
-        # os-brick library commands
-        # os_brick.privileged.run_as_root oslo.privsep context
-        # This line ties the superuser privs with the config files, context name,
-        # and (implicitly) the actual python code invoked.
-        privsep-rootwrap: RegExpFilter, privsep-helper, root, privsep-helper, --config-file, /etc/(?!\.\.).*, --privsep_context, os_brick.privileged.default, --privsep_sock_path, /tmp/.*
-
-        chown: CommandFilter, chown, root
-        mount: CommandFilter, mount, root
-        umount: CommandFilter, umount, root
   glance:
     DEFAULT:
-      log_config_append: /etc/glance/logging.conf
-      # NOTE(portdirect): the bind port should not be defined, and is manipulated
-      # via the endpoints section.
-      bind_port: null
-      workers: 8
-      enable_v1_api: False
+      workers: 2
       # NOTE(cloudnull): This option is required when using the new glance multi-backend feature.
       #                  The example below is for the rxt_swift backend, but could easily be used
       #                  for other backends.
@@ -241,54 +65,32 @@ conf:
     oslo_middleware:
       enable_proxy_headers_parsing: true
     keystone_authtoken:
-      service_token_roles: service
-      service_token_roles_required: true
       auth_type: password
       auth_version: v3
       memcache_security_strategy: ENCRYPT
+      service_token_roles: service
+      service_token_roles_required: true
       service_type: image
     glance_store:
       # NOTE(cloudnull): When using the glance multi-backend feature, the default_backend
       #                  option should be set to the name of the default backend section.
       # default_backend: rxt_swift
-      cinder_catalog_info: volumev3::internalURL
-      rbd_store_chunk_size: 8
-      rbd_store_replication: 3
-      rbd_store_crush_rule: replicated_rule
-      rbd_store_pool: glance.images
-      rbd_store_user: glance
-      rbd_store_ceph_conf: /etc/ceph/ceph.conf
       filesystem_store_datadir: /var/lib/glance/images
-      default_swift_reference: ref1
-      swift_store_container: glance
       swift_auth_address: https://swift.cluster.local
       swift_auth_version: 3
       swift_user: glance:glance-store
       swift_password: override_from_your_secrets_files
-      swift_store_create_container_on_put: true
-      swift_store_config_file: /etc/glance/swift-store.conf
-      swift_store_endpoint_type: internalURL
     rxt_swift:
       swift_store_auth_address: http://keystone-api.openstack.svc.cluster.local:5000/v3
       swift_store_create_container_on_put: true
       swift_store_multi_tenant: true
       swift_store_container: glance
       swift_store_admin_tenants: admin,image-services
-    os_glance_tasks_store:
-      filesystem_store_datadir: /var/lib/glance/tmp
-    os_glance_staging_store:
-      filesystem_store_datadir: /var/lib/glance/tmp
-    paste_deploy:
-      flavor: keystone
     database:
       idle_timeout: 3600
       connection_recycle_time: 3600
       pool_timeout: 60
       max_retries: -1
-    oslo_concurrency:
-      lock_path: /tmp/glance
-    oslo_messaging_notifications:
-      driver: messagingv2
     oslo_messaging_rabbit:
       amqp_durable_queues: false
       # We define use of quorum queues via kustomize but this was enabling HA queues instead
@@ -310,70 +112,14 @@ conf:
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617
       kombu_reconnect_delay: 0.5
-    oslo_policy:
-      policy_file: /etc/glance/policy.yaml
-    cors: {}
+  glance_api_uwsgi:
+    uwsgi:
+      processes: 4
   logging:
-    loggers:
-      keys:
-        - root
-        - glance
-    handlers:
-      keys:
-        - stdout
-        - stderr
-        - "null"
-    formatters:
-      keys:
-        - context
-        - default
     logger_root:
       level: INFO
       handlers:
         - stdout
-    logger_glance:
-      level: INFO
-      handlers:
-        - stdout
-      qualname: glance
-    logger_amqp:
-      level: WARNING
-      handlers: stderr
-      qualname: amqp
-    logger_amqplib:
-      level: WARNING
-      handlers: stderr
-      qualname: amqplib
-    logger_eventletwsgi:
-      level: WARNING
-      handlers: stderr
-      qualname: eventlet.wsgi.server
-    logger_sqlalchemy:
-      level: WARNING
-      handlers: stderr
-      qualname: sqlalchemy
-    logger_boto:
-      level: WARNING
-      handlers: stderr
-      qualname: boto
-    handler_null:
-      class: logging.NullHandler
-      formatter: default
-      args: ()
-    handler_stdout:
-      class: StreamHandler
-      args: (sys.stdout,)
-      formatter: context
-    handler_stderr:
-      class: StreamHandler
-      args: (sys.stderr,)
-      formatter: context
-    formatter_context:
-      class: oslo_log.formatters.ContextFormatter
-      datefmt: "%Y-%m-%d %H:%M:%S"
-    formatter_default:
-      format: "%(message)s"
-      datefmt: "%Y-%m-%d %H:%M:%S"
   api_audit_map:
     DEFAULT:
       target_endpoint_type: None
@@ -411,180 +157,26 @@ conf:
   rabbitmq:
     policies: []
 
-network:
-  api:
-    ingress:
-      public: true
-      classes:
-        namespace: "nginx"
-        cluster: "nginx-openstack"
-      annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: /
-        nginx.ingress.kubernetes.io/proxy-body-size: "0"
-    external_policy_local: false
-    node_port:
-      enabled: false
-      port: 30092
-
 volume:
   class_name: general-multi-attach  # This can be changed as needed
   size: 10Gi  # This should be set to 100Gi in production
 
 dependencies:
-  dynamic:
-    common:
-      local_image_registry:
-        jobs:
-          - glance-image-repo-sync
-        services:
-          - endpoint: node
-            service: local_image_registry
   static:
     api:
       jobs:
         - glance-db-sync
         - glance-ks-user
         - glance-ks-endpoints
-      services:
-        - endpoint: internal
-          service: oslo_db
-        - endpoint: internal
-          service: identity
-        - endpoint: internal
-          service: oslo_messaging
     bootstrap:
       jobs: null
-      services:
-        - endpoint: internal
-          service: identity
-        - endpoint: internal
-          service: image
     clean:
       jobs: null
-    db_drop:
-      services:
-        - endpoint: internal
-          service: oslo_db
-    db_init:
-      services:
-        - endpoint: internal
-          service: oslo_db
     db_sync:
       jobs: null
-      services:
-        - endpoint: internal
-          service: oslo_db
-    ks_endpoints:
-      jobs:
-        - glance-ks-service
-      services:
-        - endpoint: internal
-          service: identity
-    ks_service:
-      services:
-        - endpoint: internal
-          service: identity
-    ks_user:
-      services:
-        - endpoint: internal
-          service: identity
-    rabbit_init:
-      services:
-        - endpoint: internal
-          service: oslo_messaging
-    storage_init:
-      jobs:
-        - glance-ks-user
-      services: null
-    metadefs_load:
-      jobs:
-        - glance-db-sync
-      services: null
-    image_repo_sync:
-      services:
-        - endpoint: internal
-          service: local_image_registry
 
-# Names of secrets used by bootstrap and environmental checks
-secrets:
-  identity:
-    admin: glance-keystone-admin
-    glance: glance-keystone-user
-    test: glance-keystone-test
-  oslo_db:
-    admin: glance-db-admin
-    glance: glance-db-user
-  rbd: images-rbd-keyring
-  oslo_messaging:
-    admin: glance-rabbitmq-admin
-    glance: glance-rabbitmq-user
-  tls:
-    image:
-      api:
-        public: glance-tls-public
-        internal: glance-tls-api
-  oci_image_registry:
-    glance: glance-oci-image-registry
-
-# typically overridden by environmental
-# values, but should include all endpoints
-# required by this chart
 endpoints:
-  cluster_domain_suffix: cluster.local
-  local_image_registry:
-    name: docker-registry
-    namespace: docker-registry
-    hosts:
-      default: localhost
-      internal: docker-registry
-      node: localhost
-    host_fqdn_override:
-      default: null
-    port:
-      registry:
-        node: 5000
-  oci_image_registry:
-    name: oci-image-registry
-    namespace: oci-image-registry
-    auth:
-      enabled: false
-      glance:
-        username: glance
-        password: password
-    hosts:
-      default: localhost
-    host_fqdn_override:
-      default: null
-    port:
-      registry:
-        default: null
   identity:
-    name: keystone
-    auth:
-      admin:
-        region_name: RegionOne
-        username: admin
-        password: password
-        project_name: admin
-        user_domain_name: default
-        project_domain_name: default
-      glance:
-        role: admin
-        region_name: RegionOne
-        username: glance
-        password: password
-        project_name: service
-        user_domain_name: service
-        project_domain_name: service
-    hosts:
-      default: keystone
-      internal: keystone-api
-    host_fqdn_override:
-      default: null
-    path:
-      default: /v3
-    scheme:
-      default: http
     port:
       api:
         default: 5000
@@ -592,24 +184,6 @@ endpoints:
         internal: 5000
         service: 5000
   image:
-    name: glance
-    hosts:
-      default: glance-api
-      public: glance
-    host_fqdn_override:
-      default: null
-      # NOTE(portdirect): this chart supports TLS for fqdn over-ridden public
-      # endpoints using the following format:
-      # public:
-      #   host: null
-      #   tls:
-      #     crt: null
-      #     key: null
-    path:
-      default: null
-    scheme:
-      default: http
-      service: http
     port:
       api:
         default: 9292
@@ -617,80 +191,21 @@ endpoints:
         internal: 9292
         service: 9292
   oslo_db:
-    auth:
-      admin:
-        username: root
-        password: password
-        secret:
-          tls:
-            internal: mariadb-tls-direct
-      glance:
-        username: glance
-        password: password
+    host_fqdn_override:
+      default: mariadb-cluster-primary.openstack.svc.cluster.local
     hosts:
       default: mariadb-cluster-primary
-    host_fqdn_override:
-      default: null
-    path: /glance
-    scheme: mysql+pymysql
-    port:
-      mysql:
-        default: 3306
   oslo_cache:
-    auth:
-      # NOTE(portdirect): this is used to define the value for keystone
-      # authtoken cache encryption key, if not set it will be populated
-      # automatically with a random value, but to take advantage of
-      # this feature all services should be set to use the same key,
-      # and memcache service.
-      memcache_secret_key: null
+    host_fqdn_override:
+      default: memcached.openstack.svc.cluster.local
     hosts:
       default: memcached
-    host_fqdn_override:
-      default: null
-    port:
-      memcache:
-        default: 11211
   oslo_messaging:
-    auth:
-      admin:
-        username: rabbitmq
-        password: password
-        secret:
-          tls:
-            internal: rabbitmq-tls-direct
-      glance:
-        username: glance
-        password: password
-    statefulset:
-      replicas: 3
-      name: rabbitmq-server
-    hosts:
-      default: rabbitmq-nodes
     host_fqdn_override:
       default: rabbitmq.openstack.svc.cluster.local
-    path: /glance
-    scheme: rabbit
-    port:
-      amqp:
-        default: 5672
-      http:
-        default: 15672
-  object_store:
-    name: swift
-    namespace: ceph
-    auth:
-      glance:
-        tmpurlkey: supersecret
     hosts:
-      default: ceph-rgw
-      public: radosgw
-    host_fqdn_override:
-      default: null
-    path:
-      default: /swift/v1/KEY_$(tenant_id)s
-    scheme:
-      default: http
+      default: rabbitmq-nodes
+  object_store:
     port:
       api:
         default: 8088
@@ -698,22 +213,6 @@ endpoints:
         internal: 8088
         service: 8088
   ceph_object_store:
-    name: radosgw
-    namespace: ceph
-    auth:
-      glance:
-        username: glance
-        password: password
-        tmpurlkey: supersecret
-    hosts:
-      default: ceph-rgw
-      public: radosgw
-    host_fqdn_override:
-      default: null
-    path:
-      default: /auth/v1.0
-    scheme:
-      default: http
     port:
       api:
         default: 8088
@@ -722,159 +221,17 @@ endpoints:
         service: 8088
   fluentd:
     namespace: fluentbit
-    name: fluentd
-    hosts:
-      default: fluentd-logging
-    host_fqdn_override:
-      default: null
-    path:
-      default: null
-    scheme: 'http'
-    port:
-      service:
-        default: 24224
-      metrics:
-        default: 24220
   dashboard:
-    name: horizon
-    hosts:
-      default: horizon-int
-      public: horizon
-    host_fqdn_override:
-      default: null
-      # NOTE(portdirect): this chart supports TLS for fqdn over-ridden public
-      # endpoints using the following format:
-      # public:
-      #   host: null
-      #   tls:
-      #     crt: null
-      #     key: null
-    path:
-      default: null
-    scheme:
-      default: http
-      public: https
     port:
       web:
         default: 80
         public: 443
         internal: 80
         service: 80
-  # NOTE(tp6510): these endpoints allow for things like DNS lookups and ingress
-  # They are using to enable the Egress K8s network policy.
-  kube_dns:
-    namespace: kube-system
-    name: kubernetes-dns
-    hosts:
-      default: kube-dns
-    host_fqdn_override:
-      default: null
-    path:
-      default: null
-    scheme: http
-    port:
-      dns:
-        default: 53
-        protocol: UDP
-  ingress:
-    namespace: null
-    name: ingress
-    hosts:
-      default: ingress
-    port:
-      ingress:
-        default: 80
 
 pod:
-  security_context:
-    glance:
-      pod:
-        runAsUser: 42424
-      container:
-        glance_perms:
-          readOnlyRootFilesystem: true
-          runAsUser: 0
-        ceph_keyring_placement:
-          readOnlyRootFilesystem: true
-          runAsUser: 0
-        glance_api:
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-        nginx:
-          readOnlyRootFilesystem: false
-          runAsUser: 0
-    clean:
-      pod:
-        runAsUser: 42424
-      container:
-        glance_secret_clean:
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-    metadefs_load:
-      pod:
-        runAsUser: 42424
-      container:
-        glance_metadefs_load:
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-    storage_init:
-      pod:
-        runAsUser: 42424
-      container:
-        ceph_keyring_placement:
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-        glance_storage_init:
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-    test:
-      pod:
-        runAsUser: 42424
-      container:
-        glance_test_ks_user:
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-        glance_test:
-          runAsUser: 65500
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-  affinity:
-    anti:
-      type:
-        default: preferredDuringSchedulingIgnoredDuringExecution
-      topologyKey:
-        default: kubernetes.io/hostname
-      weight:
-        default: 10
-  tolerations:
-    glance:
-      enabled: false
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
-  useHostNetwork:
-    api: false
-  mounts:
-    glance_api:
-      init_container: null
-      glance_api:
-        volumeMounts:
-        volumes:
-    glance_tests:
-      init_container: null
-      glance_tests:
-        volumeMounts:
-        volumes:
-    glance_db_sync:
-      glance_db_sync:
-        volumeMounts:
-        volumes:
   replicas:
-    api: 1  # Set to 3 in production when attached to shared storage.
+    api: 1
   lifecycle:
     upgrades:
       deployments:
@@ -904,130 +261,13 @@ pod:
             periodSeconds: 15
             timeoutSeconds: 10
   resources:
-    enabled: true
-    api:
-      requests:
-        memory: "128Mi"
-        cpu: "100m"
-      limits:
-        memory: "4096Mi"
-        cpu: "2000m"
-    jobs:
-      storage_init:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      metadefs_load:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      db_sync:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      db_init:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      db_drop:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      ks_user:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      ks_service:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      ks_endpoints:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      rabbit_init:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      bootstrap:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      tests:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      image_repo_sync:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-
-# NOTE(helm_hook): helm_hook might break for helm2 binary.
-# set helm3_hook: false when using the helm2 binary.
-helm3_hook: true
-
-tls:
-  identity: false
-  oslo_messaging: false
-  oslo_db: false
+    enabled: false
 
 manifests:
-  certificates: false
-  configmap_bin: true
-  configmap_etc: true
-  deployment_api: true
   ingress_api: false
-  job_bootstrap: true
-  job_clean: true
   job_db_init: false
-  job_db_sync: true
-  job_db_drop: false
-  job_image_repo_sync: true
-  job_ks_endpoints: true
-  job_ks_service: true
-  job_ks_user: true
-  job_storage_init: false  # This is set to false because we're using PVC storage.
-  job_metadefs_load: true
+  job_storage_init: false
   job_rabbit_init: false
-  pdb_api: true
   pod_rally_test: false
-  pvc_images: true
-  network_policy: false
-  secret_db: true
   secret_ingress_tls: false
-  secret_keystone: true
-  secret_rabbitmq: true
-  secret_registry: true
   service_ingress_api: false
-  service_api: true
-
-# NOTE: This is for enable helm resource-policy to keep glance-images PVC.
-# set keep_pvc: true when allow helm resource-policy to keep for PVC.
-# This will requires mannual delete for PVC.
-# set keep_pvc: false when disallow helm resource-policy to keep for PVC.
-# This will allow helm to delete the PVC.
-keep_pvc: true

--- a/bin/install-glance.sh
+++ b/bin/install-glance.sh
@@ -4,9 +4,7 @@ GLOBAL_OVERRIDES_DIR="/etc/genestack/helm-configs/global_overrides"
 SERVICE_CONFIG_DIR="/etc/genestack/helm-configs/glance"
 BASE_OVERRIDES="/opt/genestack/base-helm-configs/glance/glance-helm-overrides.yaml"
 
-pushd /opt/genestack/submodules/openstack-helm || exit 1
-
-HELM_CMD="helm upgrade --install glance ./glance \
+HELM_CMD="helm upgrade --install glance openstack-helm/glance --version 2024.2.396+13651f45-628a320c \
     --namespace=openstack \
     --timeout 120m"
 
@@ -33,8 +31,9 @@ HELM_CMD+=" --set endpoints.oslo_messaging.auth.glance.password=\"\$(kubectl --n
 HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
 HELM_CMD+=" --post-renderer-args glance/overlay $*"
 
+helm repo add openstack-helm https://tarballs.opendev.org/openstack/openstack-helm
+helm repo update
+
 echo "Executing Helm command:"
 echo "${HELM_CMD}"
 eval "${HELM_CMD}"
-
-popd || exit 1

--- a/releasenotes/notes/glance-chart-d355eaa64eb4b89c.yaml
+++ b/releasenotes/notes/glance-chart-d355eaa64eb4b89c.yaml
@@ -1,0 +1,17 @@
+---
+deprecations:
+  - |
+    The glance chart will now use the online OSH helm repository. This change
+    will allow the glance chart to be updated more frequently and will allow
+    the glance chart to be used with the OpenStack-Helm project. Upgrading to
+    this chart may require changes to the deployment configuration. Simple
+    updates can be made by running the following command:
+
+    .. code-block:: shell
+
+      helm -n openstack uninstall glance
+      kubectl -n openstack delete -f /etc/genestack/kustomize/glance/base/glance-rabbitmq-queue.yaml
+      /opt/genestack/bin/install-glance.sh
+
+    This operation should have no operational impact on running VMs but should be
+    performed during a maintenance window.


### PR DESCRIPTION
This change removes the need to carry the openstack-helm charts for the purposes of providing a glance deployment. The base helm files have been updated and simplified, reducing the values we carry to only what we need.

Related Issue: https://github.com/rackerlabs/genestack/issues/809
Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>