### PR TITLE
chore(heat): convert helm chart from submodule to repo

### DIFF
--- a/base-helm-configs/heat/heat-helm-overrides.yaml
+++ b/base-helm-configs/heat/heat-helm-overrides.yaml
@@ -1,551 +1,78 @@
 ---
-release_group: null
-
-labels:
-  api:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-  cfn:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-  cloudwatch:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-  engine:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-  job:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-  test:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-
 images:
   tags:
-    bootstrap: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    db_init: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    db_drop: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    ks_user: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    ks_service: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    ks_endpoints: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    heat_db_sync: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    heat_api: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    heat_cfn: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    heat_cloudwatch: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    heat_engine: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    heat_engine_cleaner: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    heat_purge_deleted: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    test: "quay.io/rackspace/rackerlabs-xrally-openstack:2.0.0"
-    rabbit_init: "quay.io/rackspace/rackerlabs-rabbitmq:3.13-management"
-    dep_check: "quay.io/rackspace/rackerlabs-kubernetes-entrypoint:v1.0.0"
-    image_repo_sync: "quay.io/rackspace/rackerlabs-docker:17.07.0"
-  pull_policy: "IfNotPresent"
-  local_registry:
-    active: false
-    exclude:
-      - dep_check
-      - image_repo_sync
-
-jobs:
-  engine_cleaner:
-    cron: "*/5 * * * *"
-    starting_deadline: 600
-    history:
-      success: 3
-      failed: 1
-
-  purge_deleted:
-    cron: "20 */24 * * *"
-    purge_age: 60
-    history:
-      success: 3
-      failed: 1
+    bootstrap: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    db_drop: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    db_init: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    dep_check: 'quay.io/rackspace/rackerlabs-kubernetes-entrypoint:v1.0.0'
+    heat_api: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    heat_cfn: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    heat_cloudwatch: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    heat_db_sync: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    heat_engine: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    heat_engine_cleaner: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    heat_purge_deleted: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    image_repo_sync: 'quay.io/rackspace/rackerlabs-docker:17.07.0'
+    ks_endpoints: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    ks_service: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    ks_user: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    rabbit_init: 'quay.io/rackspace/rackerlabs-rabbitmq:3.13-management'
+    test: 'quay.io/rackspace/rackerlabs-xrally-openstack:2.0.0'
 
 conf:
-  rally_tests:
-    run_tempest: false
-    tests:
-      HeatStacks.create_update_delete_stack:
-        - args:
-            template_path: /tmp/rally-jobs/random_strings.yaml
-            updated_template_path: /tmp/rally-jobs/updated_random_strings_replace.yaml
-          runner:
-            concurrency: 1
-            times: 1
-            type: constant
-          sla:
-            failure_rate:
-              max: 0
-      HeatStacks.create_check_delete_stack:
-        - args:
-            template_path: /tmp/rally-jobs/random_strings.yaml
-          runner:
-            concurrency: 1
-            times: 1
-            type: constant
-          sla:
-            failure_rate:
-              max: 0
-      HeatStacks.create_and_delete_stack:
-        - args:
-            template_path: /tmp/rally-jobs/resource_group_with_constraint.yaml
-          runner:
-            concurrency: 1
-            times: 1
-            type: constant
-          sla:
-            failure_rate:
-              max: 0
-      HeatStacks.create_and_list_stack:
-        - args:
-            template_path: /tmp/rally-jobs/default.yaml
-          runner:
-            concurrency: 1
-            times: 1
-            type: constant
-          sla:
-            failure_rate:
-              max: 0
-      HeatStacks.create_snapshot_restore_delete_stack:
-        - args:
-            template_path: /tmp/rally-jobs/random_strings.yaml
-          runner:
-            concurrency: 1
-            times: 1
-            type: constant
-          sla:
-            failure_rate:
-              max: 0
-      HeatStacks.create_stack_and_list_output:
-        - args:
-            template_path: /tmp/rally-jobs/resource_group_with_outputs.yaml
-          runner:
-            concurrency: 1
-            times: 1
-            type: constant
-          sla:
-            failure_rate:
-              max: 0
-      HeatStacks.create_stack_and_list_output_via_API:
-        - args:
-            template_path: /tmp/rally-jobs/resource_group_with_outputs.yaml
-          runner:
-            concurrency: 1
-            times: 1
-            type: constant
-          sla:
-            failure_rate:
-              max: 0
-    templates:
-      - name: /tmp/rally-jobs/default.yaml
-        template: |
-          heat_template_version: 2014-10-16
-      - name: /tmp/rally-jobs/random_strings.yaml
-        template: |
-          heat_template_version: 2014-10-16
-          description: Test template for rally create-update-delete scenario
-          resources:
-            test_string_one:
-              type: OS::Heat::RandomString
-              properties:
-                length: 20
-            test_string_two:
-              type: OS::Heat::RandomString
-              properties:
-                length: 20
-      - name: /tmp/rally-jobs/resource_group_with_constraint.yaml
-        template: |
-          heat_template_version: 2013-05-23
-          description: Template for testing caching.
-          parameters:
-            count:
-              type: number
-              default: 40
-            delay:
-              type: number
-              default: 0.1
-          resources:
-            rg:
-              type: OS::Heat::ResourceGroup
-              properties:
-                count:
-                  get_param: count
-                resource_def:
-                    type: OS::Heat::TestResource
-                    properties:
-                      constraint_prop_secs:
-                        get_param: delay
-      - name: /tmp/rally-jobs/resource_group_with_outputs.yaml
-        template: |
-          heat_template_version: 2013-05-23
-          parameters:
-            attr_wait_secs:
-              type: number
-              default: 0.5
-          resources:
-            rg:
-              type: OS::Heat::ResourceGroup
-              properties:
-                count: 10
-                resource_def:
-                  type: OS::Heat::TestResource
-                  properties:
-                    attr_wait_secs:
-                      get_param: attr_wait_secs
-          outputs:
-            val1:
-              value:
-                get_attr:
-                  - rg
-                  - resource.0.output
-            val2:
-              value:
-                get_attr:
-                  - rg
-                  - resource.1.output
-            val3:
-              value:
-                get_attr:
-                  - rg
-                  - resource.2.output
-            val4:
-              value:
-                get_attr:
-                  - rg
-                  - resource.3.output
-            val5:
-              value:
-                get_attr:
-                  - rg
-                  - resource.4.output
-            val6:
-              value:
-                get_attr:
-                  - rg
-                  - resource.5.output
-            val7:
-              value:
-                get_attr:
-                  - rg
-                  - resource.6.output
-            val8:
-              value:
-                get_attr:
-                  - rg
-                  - resource.7.output
-            val9:
-              value:
-                get_attr:
-                  - rg
-                  - resource.8.output
-            val10:
-              value:
-                get_attr:
-                  - rg
-                  - resource.9.output
-      - name: /tmp/rally-jobs/updated_random_strings_replace.yaml
-        template: |
-          heat_template_version: 2014-10-16
-          description: |
-            Test template for create-update-delete-stack scenario in rally.
-            The template deletes one resource from the stack defined by
-            random-strings.yaml.template and re-creates it with the updated parameters
-            (so-called update-replace). That happens because some parameters cannot be
-            changed without resource re-creation. The template allows to measure performance
-            of update-replace operation.
-          resources:
-            test_string_one:
-              type: OS::Heat::RandomString
-              properties:
-                length: 20
-            test_string_two:
-              type: OS::Heat::RandomString
-              properties:
-                length: 40
-  paste:
-    pipeline:heat-api:
-      pipeline: cors request_id faultwrap http_proxy_to_wsgi versionnegotiation osprofiler authurl authtoken audit context apiv1app
-    pipeline:heat-api-standalone:
-      pipeline: cors request_id faultwrap http_proxy_to_wsgi versionnegotiation authurl authpassword context apiv1app
-    pipeline:heat-api-custombackend:
-      pipeline: cors request_id faultwrap versionnegotiation context custombackendauth apiv1app
-    pipeline:heat-api-cfn:
-      pipeline: cors http_proxy_to_wsgi cfnversionnegotiation osprofiler ec2authtoken authtoken audit context apicfnv1app
-    pipeline:heat-api-cfn-standalone:
-      pipeline: cors http_proxy_to_wsgi cfnversionnegotiation ec2authtoken context apicfnv1app
-    pipeline:heat-api-cloudwatch:
-      pipeline: cors versionnegotiation osprofiler ec2authtoken authtoken audit context apicwapp
-    pipeline:heat-api-cloudwatch-standalone:
-      pipeline: cors versionnegotiation ec2authtoken context apicwapp
-    app:apiv1app:
-      paste.app_factory: heat.common.wsgi:app_factory
-      heat.app_factory: heat.api.openstack.v1:API
-    app:apicfnv1app:
-      paste.app_factory: heat.common.wsgi:app_factory
-      heat.app_factory: heat.api.cfn.v1:API
-    app:apicwapp:
-      paste.app_factory: heat.common.wsgi:app_factory
-      heat.app_factory: heat.api.cloudwatch:API
-    filter:versionnegotiation:
-      paste.filter_factory: heat.common.wsgi:filter_factory
-      heat.filter_factory: heat.api.openstack:version_negotiation_filter
-    filter:cors:
-      paste.filter_factory: oslo_middleware.cors:filter_factory
-      oslo_config_project: heat
-    filter:faultwrap:
-      paste.filter_factory: heat.common.wsgi:filter_factory
-      heat.filter_factory: heat.api.openstack:faultwrap_filter
-    filter:cfnversionnegotiation:
-      paste.filter_factory: heat.common.wsgi:filter_factory
-      heat.filter_factory: heat.api.cfn:version_negotiation_filter
-    filter:cwversionnegotiation:
-      paste.filter_factory: heat.common.wsgi:filter_factory
-      heat.filter_factory: heat.api.cloudwatch:version_negotiation_filter
-    filter:context:
-      paste.filter_factory: heat.common.context:ContextMiddleware_filter_factory
-    filter:ec2authtoken:
-      paste.filter_factory: heat.api.aws.ec2token:EC2Token_filter_factory
-    filter:http_proxy_to_wsgi:
-      paste.filter_factory: oslo_middleware:HTTPProxyToWSGI.factory
-    filter:authurl:
-      paste.filter_factory: heat.common.auth_url:filter_factory
-    filter:authtoken:
-      paste.filter_factory: keystonemiddleware.auth_token:filter_factory
-    filter:authpassword:
-      paste.filter_factory: heat.common.auth_password:filter_factory
-    filter:custombackendauth:
-      paste.filter_factory: heat.common.custom_backend_auth:filter_factory
-    filter:audit:
-      paste.filter_factory: keystonemiddleware.audit:filter_factory
-      audit_map_file: /etc/heat/api_audit_map.conf
-    filter:request_id:
-      paste.filter_factory: oslo_middleware.request_id:RequestId.factory
-    filter:osprofiler:
-      paste.filter_factory: osprofiler.web:WsgiMiddleware.factory
-  policy: {}
   heat:
     DEFAULT:
+      num_engine_workers: 4
       server_keystone_endpoint_type: public
-      log_config_append: /etc/heat/logging.conf
-      num_engine_workers: 8
-      trusts_delegated_roles: ""
-      host: heat-engine
-    keystone_authtoken:
-      service_token_roles: service
-      service_token_roles_required: true
-      auth_type: password
-      auth_version: v3
-      memcache_security_strategy: ENCRYPT
-      service_type: orchestration
-      interface: public
-    database:
-      idle_timeout: 3600
-      connection_recycle_time: 3600
-      pool_timeout: 60
-      max_retries: -1
-    trustee:
-      auth_type: password
-      auth_version: v3
-    heat_api:
-      # NOTE(portdirect): the bind port should not be defined, and is manipulated
-      # via the endpoints section.
-      bind_port: null
-      workers: 8
-    heat_api_cloudwatch:
-      # NOTE(portdirect): the bind port should not be defined, and is manipulated
-      # via the endpoints section.
-      bind_port: null
-      workers: 8
-    heat_api_cfn:
-      # NOTE(portdirect): the bind port should not be defined, and is manipulated
-      # via the endpoints section.
-      bind_port: null
-      workers: 8
-    paste_deploy:
-      api_paste_config: /etc/heat/api-paste.ini
-    clients:
-      endpoint_type: internalURL
-    clients_heat:
-      endpoint_type: publicURL
     clients_keystone:
       endpoint_type: publicURL
-    oslo_messaging_notifications:
-      driver: messagingv2
-    oslo_middleware:
-      enable_proxy_headers_parsing: true
+    database:
+      connection_recycle_time: 3600
+      idle_timeout: 3600
+      pool_timeout: 60
+    heat_api:
+      workers: 1
+    heat_api_cfn:
+      workers: 1
+    heat_api_cloudwatch:
+      workers: 1
+    keystone_authtoken:
+      auth_type: password
+      auth_version: v3
+      interface: public
+      memcache_security_strategy: ENCRYPT
+      service_token_roles: service
+      service_token_roles_required: true
+      service_type: orchestration
     oslo_concurrency:
       lock_path: /tmp/heat
     oslo_messaging_rabbit:
       amqp_durable_queues: false
-      # We define use of quorum queues via kustomize but this was enabling HA queues instead
-      # ha_queues are deprecated, explicitly set to false and set quorum_queue true
-      rabbit_ha_queues: false
-      rabbit_quorum_queue: true
-      # TODO: Not available until 2024.1, but once it is, we want to enable these!
-      # new feature ref; https://docs.openstack.org/releasenotes/oslo.messaging/2024.1.html
-      rabbit_transient_quorum_queue: false
-      use_queue_manager: false
-      # Reconnect after a node outage more quickly
-      rabbit_interval_max: 10
-      # Send more frequent heartbeats and fail unhealthy nodes faster
-      # heartbeat_timeout / heartbeat_rate / 2.0 = 30 / 3 / 2.0 = 5
-      # https://opendev.org/openstack/oslo.messaging/commit/36fb5bceabe08a982ebd52e4a8f005cd26fdf6b8
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 30
-      # Setting lower kombu_reconnect_delay should resolve isssue with HA failing when one node is down
-      # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
-      # https://review.opendev.org/c/openstack/oslo.messaging/+/866617
       kombu_reconnect_delay: 0.5
-    oslo_policy:
-      policy_file: /etc/heat/policy.yaml
-  api_audit_map:
-    DEFAULT:
-      target_endpoint_type: None
-    path_keywords:
-      stacks: stack
-      resources: resource
-      preview: None
-      detail: None
-      abandon: None
-      snapshots: snapshot
-      restore: None
-      outputs: output
-      metadata: server
-      signal: None
-      events: event
-      template: None
-      template_versions: template_version
-      functions: None
-      validate: None
-      resource_types: resource_type
-      build_info: None
-      actions: None
-      software_configs: software_config
-      software_deployments: software_deployment
-      services: None
-    service_endpoints:
-      orchestration:service/orchestration
+      rabbit_ha_queues: false
+      rabbit_interval_max: 10
+      rabbit_quorum_queue: true
+      rabbit_transient_quorum_queue: false
+      use_queue_manager: false
+  heat_api_cfn_uwsgi:
+    uwsgi:
+      processes: 4
+      threads: 2
+  heat_api_uwsgi:
+    uwsgi:
+      processes: 4
+      threads: 2
   logging:
-    loggers:
-      keys:
-        - root
-        - heat
-    handlers:
-      keys:
-        - stdout
-        - stderr
-        - "null"
-    formatters:
-      keys:
-        - context
-        - default
     logger_root:
-      level: INFO
       handlers:
         - stdout
-    logger_heat:
       level: INFO
-      handlers:
-        - stdout
-      qualname: heat
-    logger_amqp:
-      level: WARNING
-      handlers: stderr
-      qualname: amqp
-    logger_amqplib:
-      level: WARNING
-      handlers: stderr
-      qualname: amqplib
-    logger_eventletwsgi:
-      level: WARNING
-      handlers: stderr
-      qualname: eventlet.wsgi.server
-    logger_sqlalchemy:
-      level: WARNING
-      handlers: stderr
-      qualname: sqlalchemy
-    logger_boto:
-      level: WARNING
-      handlers: stderr
-      qualname: boto
-    handler_null:
-      class: logging.NullHandler
-      formatter: default
-      args: ()
-    handler_stdout:
-      class: StreamHandler
-      args: (sys.stdout,)
-      formatter: context
-    handler_stderr:
-      class: StreamHandler
-      args: (sys.stderr,)
-      formatter: context
-    formatter_context:
-      class: oslo_log.formatters.ContextFormatter
-      datefmt: "%Y-%m-%d %H:%M:%S"
-    formatter_default:
-      format: "%(message)s"
-      datefmt: "%Y-%m-%d %H:%M:%S"
-
   rabbitmq:
     policies: []
 
-network:
-  api:
-    ingress:
-      public: true
-      classes:
-        namespace: "nginx"
-        cluster: "nginx-openstack"
-      annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: /
-    external_policy_local: false
-    node_port:
-      enabled: false
-      port: 30004
-  cfn:
-    ingress:
-      public: true
-      classes:
-        namespace: "nginx"
-        cluster: "nginx-openstack"
-      annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: /
-    node_port:
-      enabled: false
-      port: 30800
-  cloudwatch:
-    ingress:
-      public: true
-      classes:
-        namespace: "nginx"
-        cluster: "nginx-openstack"
-      annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: /
-    node_port:
-      enabled: false
-      port: 30003
-
-bootstrap:
-  enabled: true
-  ks_user: admin
-  script: |
-    #NOTE(portdirect): The Orchestration service automatically assigns the
-    # 'heat_stack_user' role to users that it creates during stack deployment.
-    # By default, this role restricts API operations. To avoid conflicts, do
-    # not add this role to actual users.
-    openstack role create --or-show heat_stack_user
-
 dependencies:
-  dynamic:
-    common:
-      local_image_registry:
-        jobs:
-          - heat-image-repo-sync
-        services:
-          - endpoint: node
-            service: local_image_registry
   static:
     api:
       jobs:
@@ -555,13 +82,6 @@ dependencies:
         - heat-domain-ks-user
         - heat-ks-endpoints
         - heat-bootstrap
-      services:
-        - endpoint: internal
-          service: oslo_db
-        - endpoint: internal
-          service: oslo_messaging
-        - endpoint: internal
-          service: identity
     cfn:
       jobs:
         - heat-db-sync
@@ -570,13 +90,6 @@ dependencies:
         - heat-domain-ks-user
         - heat-ks-endpoints
         - heat-bootstrap
-      services:
-        - endpoint: internal
-          service: oslo_db
-        - endpoint: internal
-          service: oslo_messaging
-        - endpoint: internal
-          service: identity
     cloudwatch:
       jobs:
         - heat-db-sync
@@ -585,30 +98,8 @@ dependencies:
         - heat-domain-ks-user
         - heat-ks-endpoints
         - heat-bootstrap
-      services:
-        - endpoint: internal
-          service: oslo_db
-        - endpoint: internal
-          service: oslo_messaging
-        - endpoint: internal
-          service: identity
-    db_drop:
-      services:
-        - endpoint: internal
-          service: oslo_db
-    db_init:
-      services:
-        - endpoint: internal
-          service: oslo_db
     db_sync:
       jobs: []
-      services:
-        - endpoint: internal
-          service: oslo_db
-    bootstrap:
-      services:
-        - endpoint: internal
-          service: identity
     engine:
       jobs:
         - heat-db-sync
@@ -617,653 +108,61 @@ dependencies:
         - heat-domain-ks-user
         - heat-ks-endpoints
         - heat-bootstrap
-      services:
-        - endpoint: internal
-          service: oslo_db
-        - endpoint: internal
-          service: oslo_messaging
-        - endpoint: internal
-          service: identity
-    engine_cleaner:
-      jobs:
-        - heat-db-sync
-        - heat-ks-user
-        - heat-trustee-ks-user
-        - heat-domain-ks-user
-        - heat-ks-endpoints
-      services:
-        - endpoint: internal
-          service: oslo_db
-        - endpoint: internal
-          service: oslo_messaging
-        - endpoint: internal
-          service: identity
-    purge_deleted:
-      jobs:
-        - heat-db-sync
-        - heat-ks-user
-        - heat-trustee-ks-user
-        - heat-domain-ks-user
-        - heat-ks-endpoints
-      services:
-        - endpoint: internal
-          service: oslo_db
-        - endpoint: internal
-          service: oslo_messaging
-        - endpoint: internal
-          service: identity
-    ks_endpoints:
-      jobs:
-        - heat-ks-service
-      services:
-        - endpoint: internal
-          service: identity
-    ks_service:
-      services:
-        - endpoint: internal
-          service: identity
-    ks_user:
-      services:
-        - endpoint: internal
-          service: identity
-    rabbit_init:
-      services:
-        - endpoint: internal
-          service: oslo_messaging
-    trusts:
-      jobs:
-        - heat-ks-user
-        - heat-trustee-ks-user
-        - heat-domain-ks-user
-      services:
-        - endpoint: internal
-          service: identity
-    image_repo_sync:
-      services:
-        - endpoint: internal
-          service: local_image_registry
-    tests:
-      services:
-        - endpoint: internal
-          service: identity
-        - endpoint: internal
-          service: orchestration
 
-# Names of secrets used by bootstrap and environmental checks
-secrets:
-  identity:
-    admin: heat-keystone-admin
-    heat: heat-keystone-user
-    heat_trustee: heat-keystone-trustee
-    heat_stack_user: heat-keystone-stack-user
-    test: heat-keystone-test
-  oslo_db:
-    admin: heat-db-admin
-    heat: heat-db-user
-  oslo_messaging:
-    admin: heat-rabbitmq-admin
-    heat: heat-rabbitmq-user
-  tls:
-    orchestration:
-      api:
-        public: heat-tls-public
-        internal: heat-tls-api
-    cloudformation:
-      cfn:
-        public: cloudformation-tls-public
-        internal: heat-tls-cfn
-  oci_image_registry:
-    heat: heat-oci-image-registry
-
-# typically overridden by environmental
-# values, but should include all endpoints
-# required by this chart
 endpoints:
-  cluster_domain_suffix: cluster.local
-  local_image_registry:
-    name: docker-registry
-    namespace: docker-registry
-    hosts:
-      default: localhost
-      internal: docker-registry
-      node: localhost
-    host_fqdn_override:
-      default: null
-    port:
-      registry:
-        node: 5000
-  oci_image_registry:
-    name: oci-image-registry
-    namespace: oci-image-registry
-    auth:
-      enabled: false
-      heat:
-        username: heat
-        password: password
-    hosts:
-      default: localhost
-    host_fqdn_override:
-      default: null
-    port:
-      registry:
-        default: null
-  identity:
-    name: keystone
-    auth:
-      admin:
-        region_name: RegionOne
-        username: admin
-        password: password
-        project_name: admin
-        user_domain_name: default
-        project_domain_name: default
-      heat:
-        role: admin
-        region_name: RegionOne
-        username: heat
-        password: password
-        project_name: service
-        user_domain_name: service
-        project_domain_name: service
-      heat_trustee:
-        role: admin
-        region_name: RegionOne
-        username: heat-trust
-        password: password
-        project_name: service
-        user_domain_name: service
-        project_domain_name: service
-      heat_stack_user:
-        role: admin
-        region_name: RegionOne
-        username: heat-domain
-        password: password
-        domain_name: heat
-    hosts:
-      default: keystone
-      internal: keystone-api
-    host_fqdn_override:
-      default: null
-    path:
-      default: /v3
-    scheme:
-      default: 'http'
-    port:
-      api:
-        default: 5000
-        public: 80
-        internal: 5000
-        service: 5000
-  orchestration:
-    name: heat
-    hosts:
-      default: heat-api
-      public: heat
-    host_fqdn_override:
-      default: null
-      # NOTE(portdirect): this chart supports TLS for fqdn over-ridden public
-      # endpoints using the following format:
-      # public:
-      #   host: null
-      #   tls:
-      #     crt: null
-      #     key: null
-    path:
-      default: '/v1/%(project_id)s'
-    scheme:
-      default: 'http'
-      service: 'http'
-    port:
-      api:
-        default: 8004
-        public: 80
-        internal: 8004
-        service: 8004
   cloudformation:
-    name: heat-cfn
-    hosts:
-      default: heat-cfn
-      public: cloudformation
-    host_fqdn_override:
-      default: null
-      # NOTE(portdirect): this chart supports TLS for fqdn over-ridden public
-      # endpoints using the following format:
-      # public:
-      #   host: null
-      #   tls:
-      #     crt: null
-      #     key: null
-    path:
-      default: /v1
-    scheme:
-      default: 'http'
-      service: 'http'
     port:
       api:
         default: 8000
-        public: 80
         internal: 8000
+        public: 80
         service: 8000
-  # Cloudwatch does not get an entry in the keystone service catalog
   cloudwatch:
-    name: heat-cloudwatch
-    hosts:
-      default: heat-cloudwatch
-      public: cloudwatch
-    host_fqdn_override:
-      default: null
-    path:
-      default: null
-    type: null
-    scheme:
-      default: 'http'
-      service: 'http'
     port:
       api:
         default: 8003
-        public: 80
         internal: 8003
+        public: 80
         service: 8003
-  oslo_db:
-    auth:
-      admin:
-        username: root
-        password: password
-        secret:
-          tls:
-            internal: mariadb-tls-direct
-      heat:
-        username: heat
-        password: password
-    hosts:
-      default: mariadb-cluster-primary
-    host_fqdn_override:
-      default: null
-    path: /heat
-    scheme: mysql+pymysql
-    port:
-      mysql:
-        default: 3306
-  oslo_cache:
-    auth:
-      # NOTE(portdirect): this is used to define the value for keystone
-      # authtoken cache encryption key, if not set it will be populated
-      # automatically with a random value, but to take advantage of
-      # this feature all services should be set to use the same key,
-      # and memcache service.
-      memcache_secret_key: null
-    hosts:
-      default: memcached
-    host_fqdn_override:
-      default: null
-    port:
-      memcache:
-        default: 11211
-  oslo_messaging:
-    auth:
-      admin:
-        username: rabbitmq
-        password: password
-        secret:
-          tls:
-            internal: rabbitmq-tls-direct
-      heat:
-        username: heat
-        password: password
-    statefulset:
-      replicas: 3
-      name: rabbitmq-server
-    hosts:
-      default: rabbitmq-nodes
-    host_fqdn_override:
-      default: rabbitmq.openstack.svc.cluster.local
-    path: /heat
-    scheme: rabbit
-    port:
-      amqp:
-        default: 5672
-      http:
-        default: 15672
   fluentd:
     namespace: fluentbit
-    name: fluentd
-    hosts:
-      default: fluentd-logging
-    host_fqdn_override:
-      default: null
-    path:
-      default: null
-    scheme: 'http'
+  identity:
     port:
-      service:
-        default: 24224
-      metrics:
-        default: 24220
-  # NOTE(tp6510): these endpoints allow for things like DNS lookups and ingress
-  # They are using to enable the Egress K8s network policy.
-  kube_dns:
-    namespace: kube-system
-    name: kubernetes-dns
-    hosts:
-      default: kube-dns
-    host_fqdn_override:
-      default: null
-    path:
-      default: null
-    scheme: http
-    port:
-      dns:
-        default: 53
-        protocol: UDP
-  ingress:
-    namespace: null
-    name: ingress
-    hosts:
-      default: ingress
-    port:
-      ingress:
-        default: 80
-
-pod:
-  security_context:
-    heat:
-      pod:
-        runAsUser: 42424
-      container:
-        heat_api:
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-        heat_cfn:
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-        heat_cloudwatch:
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-        heat_engine:
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-    trusts:
-      pod:
-        runAsUser: 42424
-      container:
-        heat_trusts:
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-    ks_user:
-      pod:
-        runAsUser: 42424
-      container:
-        heat_ks_domain_user:
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-    engine_cleaner:
-      pod:
-        runAsUser: 42424
-      container:
-        heat_engine_cleaner:
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-  affinity:
-    anti:
-      type:
-        default: preferredDuringSchedulingIgnoredDuringExecution
-      topologyKey:
-        default: kubernetes.io/hostname
-      weight:
-        default: 10
-  tolerations:
-    heat:
-      enabled: false
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
-  mounts:
-    heat_api:
-      init_container: null
-      heat_api:
-        volumeMounts:
-        volumes:
-    heat_cfn:
-      init_container: null
-      heat_cfn:
-        volumeMounts:
-        volumes:
-    heat_cloudwatch:
-      init_container: null
-      heat_cloudwatch:
-        volumeMounts:
-        volumes:
-    heat_engine:
-      init_container: null
-      heat_engine:
-        volumeMounts:
-        volumes:
-    heat_bootstrap:
-      init_container: null
-      heat_bootstrap:
-        volumeMounts:
-        volumes:
-    heat_trusts:
-      init_container: null
-      heat_trusts:
-        volumeMounts:
-        volumes:
-    heat_engine_cleaner:
-      init_container: null
-      heat_engine_cleaner:
-        volumeMounts:
-        volumes:
-    heat_purge_deleted:
-      init_container: null
-      heat_purge_deleted:
-        volumeMounts:
-        volumes:
-    heat_tests:
-      init_container: null
-      heat_tests:
-        volumeMounts:
-        volumes:
-    heat_db_sync:
-      heat_db_sync:
-        volumeMounts:
-        volumes:
-  replicas:
-    api: 1
-    cfn: 1
-    cloudwatch: 1
-    engine: 1
-  lifecycle:
-    upgrades:
-      deployments:
-        revision_history: 3
-        pod_replacement_strategy: RollingUpdate
-        rolling_update:
-          max_unavailable: 1
-          max_surge: 3
-    disruption_budget:
       api:
-        min_available: 0
-      cfn:
-        min_available: 0
-      cloudwatch:
-        min_available: 0
-    termination_grace_period:
+        default: 5000
+        internal: 5000
+        public: 80
+        service: 5000
+  orchestration:
+    port:
       api:
-        timeout: 30
-      cfn:
-        timeout: 30
-      cloudwatch:
-        timeout: 30
-      engine:
-        timeout: 30
-  resources:
-    enabled: true
-    api:
-      requests:
-        memory: "64Mi"
-        cpu: "100m"
-      limits:
-        memory: "4096Mi"
-        cpu: "2000m"
-    cfn:
-      requests:
-        memory: "64Mi"
-        cpu: "100m"
-      limits:
-        memory: "4096Mi"
-        cpu: "2000m"
-    cloudwatch:
-      requests:
-        memory: "64Mi"
-        cpu: "100m"
-      limits:
-        memory: "4096Mi"
-        cpu: "2000m"
-    engine:
-      requests:
-        memory: "128Mi"
-        cpu: "100m"
-      limits:
-        memory: "4096Mi"
-        cpu: "2000m"
-    jobs:
-      bootstrap:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      db_init:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      db_sync:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      db_drop:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      ks_endpoints:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      ks_service:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      ks_user:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      rabbit_init:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      tests:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      trusts:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      engine_cleaner:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      purge_deleted:
-        requests:
-          memory: "124Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      image_repo_sync:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-
-network_policy:
-  heat:
-    ingress:
-      - {}
-    egress:
-      - {}
-
-# NOTE(helm_hook): helm_hook might break for helm2 binary.
-# set helm3_hook: false when using the helm2 binary.
-helm3_hook: true
-
-tls:
-  identity: false
-  oslo_messaging: false
-  oslo_db: false
+        default: 8004
+        internal: 8004
+        public: 80
+        service: 8004
+  oslo_db:
+    host_fqdn_override:
+      default: mariadb-cluster-primary.openstack.svc.cluster.local
+    hosts:
+      default: mariadb-cluster-primary
+  oslo_cache:
+    host_fqdn_override:
+      default: memcached.openstack.svc.cluster.local
+    hosts:
+      default: memcached
+  oslo_messaging:
+    host_fqdn_override:
+      default: rabbitmq.openstack.svc.cluster.local
+    hosts:
+      default: rabbitmq-nodes
 
 manifests:
-  certificates: false
-  configmap_bin: true
-  configmap_etc: true
-  cron_job_engine_cleaner: true
-  cron_job_purge_deleted: true
-  deployment_api: true
-  deployment_cfn: true
-  deployment_cloudwatch: false
-  deployment_engine: true
   ingress_api: false
   ingress_cfn: false
-  ingress_cloudwatch: false
-  job_bootstrap: true
   job_db_init: false
-  job_db_sync: true
-  job_db_drop: false
-  job_image_repo_sync: true
-  job_ks_endpoints: true
-  job_ks_service: true
-  job_ks_user_domain: true
-  job_ks_user_trustee: true
-  job_ks_user: true
   job_rabbit_init: false
-  pdb_api: true
-  pdb_cfn: true
-  pdb_cloudwatch: false
   pod_rally_test: false
-  network_policy: false
-  secret_db: true
   secret_ingress_tls: false
-  secret_keystone: true
-  secret_rabbitmq: true
-  secret_registry: true
-  service_api: true
-  service_cfn: true
-  service_cloudwatch: false
   service_ingress_api: false
   service_ingress_cfn: false
   service_ingress_cloudwatch: false
-  statefulset_engine: false

--- a/bin/install-heat.sh
+++ b/bin/install-heat.sh
@@ -4,9 +4,7 @@ GLOBAL_OVERRIDES_DIR="/etc/genestack/helm-configs/global_overrides"
 SERVICE_CONFIG_DIR="/etc/genestack/helm-configs/heat"
 BASE_OVERRIDES="/opt/genestack/base-helm-configs/heat/heat-helm-overrides.yaml"
 
-pushd /opt/genestack/submodules/openstack-helm || exit 1
-
-HELM_CMD="helm upgrade --install heat ./heat \
+HELM_CMD="helm upgrade --install heat openstack-helm/heat --version 2024.2.294+13651f45-628a320c \
     --namespace=openstack \
     --timeout 120m"
 
@@ -35,8 +33,9 @@ HELM_CMD+=" --set endpoints.oslo_messaging.auth.heat.password=\"\$(kubectl --nam
 HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
 HELM_CMD+=" --post-renderer-args heat/overlay $*"
 
+helm repo add openstack-helm https://tarballs.opendev.org/openstack/openstack-helm
+helm repo update
+
 echo "Executing Helm command:"
 echo "${HELM_CMD}"
 eval "${HELM_CMD}"
-
-popd || exit 1

--- a/releasenotes/notes/heat-chart-e469c7543a21ad8e.yaml
+++ b/releasenotes/notes/heat-chart-e469c7543a21ad8e.yaml
@@ -1,0 +1,17 @@
+---
+deprecations:
+  - |
+    The heat chart will now use the online OSH helm repository. This change
+    will allow the heat chart to be updated more frequently and will allow
+    the heat chart to be used with the OpenStack-Helm project. Upgrading to
+    this chart may require changes to the deployment configuration. Simple
+    updates can be made by running the following command:
+
+    .. code-block:: shell
+
+      helm -n openstack uninstall heat
+      kubectl -n openstack delete -f /etc/genestack/kustomize/heat/base/heat-rabbitmq-queue.yaml
+      /opt/genestack/bin/install-heat.sh
+
+    This operation should have no operational impact on running VMs but should be
+    performed during a maintenance window.


### PR DESCRIPTION
This change removes the need to carry the openstack-helm charts for the purposes of providing a heat deployment. The base helm files have been updated and simplified, reducing the values we carry to only what we need.

Related Issue: #809
Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>