### PR TITLE
chore(placement): convert helm chart from submodule to repo

### DIFF
--- a/base-helm-configs/placement/placement-helm-overrides.yaml
+++ b/base-helm-configs/placement/placement-helm-overrides.yaml
@@ -1,513 +1,88 @@
-release_group: null
-
-labels:
-  api:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-  job:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-
+---
 images:
-  pull_policy: IfNotPresent
   tags:
-    placement: "quay.io/rackspace/rackerlabs-placement:2024.1-ubuntu_jammy"
-    ks_user: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    ks_service: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    ks_endpoints: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    db_init: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    db_drop: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    placement_db_sync: "quay.io/rackspace/rackerlabs-placement:2024.1-ubuntu_jammy"
-    dep_check: "quay.io/rackspace/rackerlabs-kubernetes-entrypoint:v1.0.0"
-    image_repo_sync: "quay.io/rackspace/rackerlabs-docker:17.07.0"
-  local_registry:
-    active: false
-    exclude:
-      - dep_check
-      - image_repo_sync
-
-network:
-  api:
-    port: 8778
-    ingress:
-      public: true
-      classes:
-        namespace: "nginx"
-        cluster: "nginx-openstack"
-      annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: /
-    external_policy_local: false
-    node_port:
-      enabled: false
-      port: 30778
+    db_drop: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    db_init: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    dep_check: 'quay.io/rackspace/rackerlabs-kubernetes-entrypoint:v1.0.0'
+    image_repo_sync: 'quay.io/rackspace/rackerlabs-docker:17.07.0'
+    ks_endpoints: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    ks_service: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    ks_user: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    placement: 'quay.io/rackspace/rackerlabs-placement:2024.1-ubuntu_jammy'
+    placement_db_sync: 'quay.io/rackspace/rackerlabs-placement:2024.1-ubuntu_jammy'
 
 conf:
-  software:
-    apache2:
-      binary: apache2
-      start_parameters: -DFOREGROUND
-      # Enable/Disable modules
-      # a2enmod:
-      #   - headers
-      #   - rewrite
-      # a2dismod:
-      #   - status
-      a2enmod: null
-      a2dismod: null
-  policy: {}
+  logging:
+    logger_root:
+      handlers:
+        - stdout
+      level: INFO
   placement:
-    DEFAULT:
-      debug: false
-      use_syslog: false
-      log_config_append: /etc/placement/logging.conf
+    keystone_authtoken:
+      auth_type: password
+      auth_version: v3
+      memcache_security_strategy: ENCRYPT
+      service_token_roles: service
+      service_token_roles_required: true
+      service_type: placement
+    oslo_concurrency:
+      lock_path: /tmp/octavia
+    oslo_messaging_notifications:
+      driver: messagingv2
+    oslo_messaging_rabbit:
+      amqp_durable_queues: false
+      heartbeat_rate: 3
+      heartbeat_timeout_threshold: 30
+      kombu_reconnect_delay: 0.5
+      rabbit_ha_queues: false
+      rabbit_interval_max: 10
+      rabbit_quorum_queue: true
+      rabbit_transient_quorum_queue: false
+      use_queue_manager: false
     placement:
       randomize_allocation_candidates: true
     placement_database:
-      connection: null
-      max_retries: -1
-    keystone_authtoken:
-      service_token_roles: service
-      service_token_roles_required: true
-      auth_version: v3
-      auth_type: password
-      memcache_security_strategy: ENCRYPT
-      service_type: placement
-    oslo_messaging_notifications:
-      driver: messagingv2
-    oslo_concurrency:
-      lock_path: /tmp/octavia
-    oslo_messaging_rabbit:
-      amqp_durable_queues: false
-      # We define use of quorum queues via kustomize but this was enabling HA queues instead
-      # ha_queues are deprecated, explicitly set to false and set quorum_queue true
-      rabbit_ha_queues: false
-      rabbit_quorum_queue: true
-      # TODO: Not available until 2024.1, but once it is, we want to enable these!
-      # new feature ref; https://docs.openstack.org/releasenotes/oslo.messaging/2024.1.html
-      rabbit_transient_quorum_queue: false
-      use_queue_manager: false
-      # Reconnect after a node outage more quickly
-      rabbit_interval_max: 10
-      # Send more frequent heartbeats and fail unhealthy nodes faster
-      # heartbeat_timeout / heartbeat_rate / 2.0 = 30 / 3 / 2.0 = 5
-      # https://opendev.org/openstack/oslo.messaging/commit/36fb5bceabe08a982ebd52e4a8f005cd26fdf6b8
-      heartbeat_rate: 3
-      heartbeat_timeout_threshold: 30
-      # Setting lower kombu_reconnect_delay should resolve isssue with HA failing when one node is down
-      # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
-      # https://review.opendev.org/c/openstack/oslo.messaging/+/866617
-      kombu_reconnect_delay: 0.5
-  logging:
-    loggers:
-      keys:
-        - root
-        - placement
-    handlers:
-      keys:
-        - stdout
-        - stderr
-        - "null"
-    formatters:
-      keys:
-        - context
-        - default
-    logger_root:
-      level: INFO
-      handlers:
-        - stdout
-    logger_placement:
-      level: INFO
-      handlers:
-        - stdout
-      qualname: placement
-    logger_amqp:
-      level: WARNING
-      handlers: stderr
-      qualname: amqp
-    logger_amqplib:
-      level: WARNING
-      handlers: stderr
-      qualname: amqplib
-    logger_eventletwsgi:
-      level: WARNING
-      handlers: stderr
-      qualname: eventlet.wsgi.server
-    logger_sqlalchemy:
-      level: WARNING
-      handlers: stderr
-      qualname: sqlalchemy
-    logger_boto:
-      level: WARNING
-      handlers: stderr
-      qualname: boto
-    handler_null:
-      class: logging.NullHandler
-      formatter: default
-      args: ()
-    handler_stdout:
-      class: StreamHandler
-      args: (sys.stdout,)
-      formatter: context
-    handler_stderr:
-      class: StreamHandler
-      args: (sys.stderr,)
-      formatter: context
-    formatter_context:
-      class: oslo_log.formatters.ContextFormatter
-      datefmt: "%Y-%m-%d %H:%M:%S"
-    formatter_default:
-      format: "%(message)s"
-      datefmt: "%Y-%m-%d %H:%M:%S"
-  wsgi_placement: |
-    Listen 0.0.0.0:{{ tuple "placement" "service" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}
-    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
-    LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy
-    SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
-    CustomLog /dev/stdout combined env=!forwarded
-    CustomLog /dev/stdout proxy env=forwarded
-    <VirtualHost *:{{ tuple "placement" "service" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}>
-        WSGIDaemonProcess placement-api processes=4 threads=1 user=placement group=placement display-name=%{GROUP}
-        WSGIProcessGroup placement-api
-        WSGIScriptAlias / /var/www/cgi-bin/placement/placement-api
-        WSGIApplicationGroup %{GLOBAL}
-        WSGIPassAuthorization On
-        <IfVersion >= 2.4>
-          ErrorLogFormat "%{cu}t %M"
-        </IfVersion>
-        ErrorLog /dev/stdout
-        SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
-        CustomLog /dev/stdout combined env=!forwarded
-        CustomLog /dev/stdout proxy env=forwarded
-    </VirtualHost>
-    Alias /placement /var/www/cgi-bin/placement/placement-api
-    <Location /placement>
-        SetHandler wsgi-script
-        Options +ExecCGI
-        WSGIProcessGroup placement-api
-        WSGIApplicationGroup %{GLOBAL}
-        WSGIPassAuthorization On
-    </Location>
+      idle_timeout: 3600
+      connection_recycle_time: 3600
+      pool_timeout: 60
+  placement_api_uwsgi:
+    uwsgi:
+      processes: 4
+      threads: 2
 
 endpoints:
-  cluster_domain_suffix: cluster.local
-  local_image_registry:
-    name: docker-registry
-    namespace: docker-registry
-    hosts:
-      default: localhost
-      internal: docker-registry
-      node: localhost
-    host_fqdn_override:
-      default: null
-    port:
-      registry:
-        node: 5000
-  oci_image_registry:
-    name: oci-image-registry
-    namespace: oci-image-registry
-    auth:
-      enabled: false
-      placement:
-        username: placement
-        password: password
-    hosts:
-      default: localhost
-    host_fqdn_override:
-      default: null
-    port:
-      registry:
-        default: null
-  oslo_db:
-    auth:
-      admin:
-        username: root
-        password: password
-        secret:
-          tls:
-            internal: mariadb-tls-direct
-      placement:
-        username: placement
-        password: password
-      # NOTE: This should be the username/password used to access the nova_api
-      # database. This is required only if database migration from nova to
-      # placement is desired.
-      nova_api:
-        username: nova
-        password: password
-    hosts:
-      default: mariadb-cluster-primary
-    host_fqdn_override:
-      default: null
-    path: /placement
-    scheme: mysql+pymysql
-    port:
-      mysql:
-        default: 3306
-  oslo_cache:
-    auth:
-      # NOTE(portdirect): this is used to define the value for keystone
-      # authtoken cache encryption key, if not set it will be populated
-      # automatically with a random value, but to take advantage of
-      # this feature all services should be set to use the same key,
-      # and memcache service.
-      memcache_secret_key: null
-    hosts:
-      default: memcached
-    host_fqdn_override:
-      default: null
-    port:
-      memcache:
-        default: 11211
+  fluentd:
+    namespace: fluentbit
   identity:
-    name: keystone
-    auth:
-      admin:
-        region_name: RegionOne
-        username: admin
-        password: password
-        project_name: admin
-        user_domain_name: default
-        project_domain_name: default
-      placement:
-        role: admin
-        region_name: RegionOne
-        username: placement
-        password: password
-        project_name: service
-        user_domain_name: service
-        project_domain_name: service
-    hosts:
-      default: keystone
-      internal: keystone-api
-    host_fqdn_override:
-      default: null
-    path:
-      default: /v3
-    scheme:
-      default: http
     port:
       api:
         default: 5000
         internal: 5000
         public: 80
         service: 5000
-  placement:
-    name: placement
-    hosts:
-      default: placement-api
-      public: placement
-    host_fqdn_override:
-      default: null
-    path:
-      default: /
-    scheme:
-      default: 'http'
-      service: 'http'
-    port:
-      api:
-        default: 8778
-        public: 80
-        internal: 8778
-        service: 8778
-  fluentd:
-    namespace: fluentbit
-    name: fluentd
-    hosts:
-      default: fluentd-logging
-    host_fqdn_override:
-      default: null
-    path:
-      default: null
-    scheme: 'http'
-    port:
-      service:
-        default: 24224
-      metrics:
-        default: 24220
-
-pod:
-  security_context:
-    placement:
-      pod:
-        runAsUser: 42424
-      container:
-        placement_api:
-          readOnlyRootFilesystem: false
-          runAsUser: 0
-        placement_mysql_migration:
-          readOnlyRootFilesystem: false
-          runAsUser: 0
-  affinity:
-    anti:
-      type:
-        default: preferredDuringSchedulingIgnoredDuringExecution
-      topologyKey:
-        default: kubernetes.io/hostname
-  tolerations:
-    placement:
-      enabled: false
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
-  mounts:
-    placement:
-      init_container: null
-      placement:
-        volumeMounts:
-        volumes:
-  replicas:
-    api: 1
-  lifecycle:
-    upgrades:
-      deployments:
-        revision_history: 3
-        pod_replacement_strategy: RollingUpdate
-        rolling_update:
-          max_unavailable: 1
-          max_surge: 3
-    disruption_budget:
-      api:
-        min_available: 0
-    termination_grace_period:
-      api:
-        timeout: 30
-  resources:
-    enabled: true
-    api:
-      requests:
-        memory: "128Mi"
-        cpu: "100m"
-      limits:
-        memory: "2048Mi"
-        cpu: "2000m"
-    jobs:
-      db_init:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      db_sync:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      db_drop:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      ks_endpoints:
-        requests:
-          memory: "64Mi"
-        limits:
-          memory: "4096Mi"
-      ks_service:
-        requests:
-          memory: "64Mi"
-        limits:
-          memory: "4096Mi"
-      ks_user:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-
-secrets:
-  identity:
-    admin: placement-keystone-admin
-    placement: placement-keystone-user
   oslo_db:
-    admin: placement-db-admin
-    placement: placement-db-user
-  tls:
-    placement:
-      api:
-        public: placement-tls-public
-        internal: placement-tls-api
-  oci_image_registry:
-    placement: placement-oci-image-registry
+    host_fqdn_override:
+      default: mariadb-cluster-primary.openstack.svc.cluster.local
+    hosts:
+      default: mariadb-cluster-primary
+  oslo_cache:
+    host_fqdn_override:
+      default: memcached.openstack.svc.cluster.local
+    hosts:
+      default: memcached
+  oslo_messaging:
+    host_fqdn_override:
+      default: rabbitmq.openstack.svc.cluster.local
+    hosts:
+      default: rabbitmq-nodes
 
 dependencies:
-  dynamic:
-    common:
-      local_image_registry:
-        jobs:
-          - image-repo-sync
-        services:
-          - endpoint: node
-            service: local_image_registry
   static:
-    api:
-      jobs:
-        - placement-db-sync
-        - placement-ks-service
-        - placement-ks-user
-        - placement-ks-endpoints
-    ks_endpoints:
-      jobs:
-        - placement-ks-user
-        - placement-ks-service
-      services:
-        - endpoint: internal
-          service: identity
-    ks_service:
-      services:
-        - endpoint: internal
-          service: identity
-    ks_user:
-      services:
-        - endpoint: internal
-          service: identity
-    db_drop:
-      services:
-        - endpoint: internal
-          service: oslo_db
-    db_init:
-      services:
-        - endpoint: internal
-          service: oslo_db
     db_sync:
       jobs: []
-      #   - placement-db-init
-      services:
-        - endpoint: internal
-          service: oslo_db
-
-# NOTE(helm_hook): helm_hook might break for helm2 binary.
-# set helm3_hook: false when using the helm2 binary.
-helm3_hook: true
-
-tls:
-  identity: false
-  oslo_messaging: false
-  oslo_db: false
 
 manifests:
-  certificates: false
-  configmap_bin: true
-  configmap_etc: true
-  deployment: true
-  job_image_repo_sync: true
-  job_db_init: false
-  job_db_sync: true
-  job_db_drop: false
-  job_ks_endpoints: true
-  job_ks_service: true
-  job_ks_user: true
-  network_policy: false
-  secret_db: true
-  secret_ingress_tls: false
-  secret_registry: true
-  pdb: true
   ingress: false
-  secret_keystone: true
+  job_db_init: false
+  secret_ingress_tls: false
   service_ingress: false
-  service: true

--- a/bin/install-placement.sh
+++ b/bin/install-placement.sh
@@ -4,9 +4,7 @@ GLOBAL_OVERRIDES_DIR="/etc/genestack/helm-configs/global_overrides"
 SERVICE_CONFIG_DIR="/etc/genestack/helm-configs/placement"
 BASE_OVERRIDES="/opt/genestack/base-helm-configs/placement/placement-helm-overrides.yaml"
 
-pushd /opt/genestack/submodules/openstack-helm || exit 1
-
-HELM_CMD="helm upgrade --install placement ./placement \
+HELM_CMD="helm upgrade --install placement openstack-helm/placement --version 2024.2.62+13651f45-628a320c \
     --namespace=openstack \
     --timeout 120m"
 
@@ -38,5 +36,3 @@ HELM_CMD+=" --post-renderer-args placement/overlay $*"
 echo "Executing Helm command:"
 echo "${HELM_CMD}"
 eval "${HELM_CMD}"
-
-popd || exit 1

--- a/releasenotes/notes/placement-chart-2b02ca15631a0af1.yaml
+++ b/releasenotes/notes/placement-chart-2b02ca15631a0af1.yaml
@@ -1,0 +1,16 @@
+---
+deprecations:
+  - |
+    The placement chart will now use the online OSH helm repository. This change
+    will allow the placement chart to be updated more frequently and will allow
+    the placement chart to be used with the OpenStack-Helm project. Upgrading to
+    this chart may require changes to the deployment configuration. Simple
+    updates can be made by running the following command:
+
+    .. code-block:: shell
+
+      helm -n openstack uninstall placement
+      /opt/genestack/bin/install-placement.sh
+
+    This operation should have no operational impact on running VMs but should be
+    performed during a maintenance window.


### PR DESCRIPTION
This change removes the need to carry the openstack-helm charts for the purposes of providing a placement deployment. The base helm files have been updated and simplified, reducing the values we carry to only what we need.

Related Issue: #809
Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>