### PR TITLE
chore: rename OPS sections

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -295,9 +295,9 @@ nav:
               - Keystone Readonly Users: openstack-keystone-readonly.md
           - Networking:
               - Creating Networks: openstack-neutron-networks.md
-          - Magnum:
+          - Containers:
               - Creating kubernetes clusters: magnum-kubernetes-cluster-setup-guide.md
-          - Octavia:
+          - Loadbalancers:
               - Creating Flavor Profiles and Flavors: octavia-flavor-and-flavorprofile-guide.md
               - Creating Cloud Load Balancers: octavia-loadbalancer-setup-guide.md
           - Object Storage:


### PR DESCRIPTION
Within the ops docs we were using openstack project names for sections instead of their purpose. This change updates the ops docs so that they style matches.