### PR TITLE
chore(magnum): convert helm chart from submodule to repo

### DIFF
--- a/base-helm-configs/magnum/magnum-helm-overrides.yaml
+++ b/base-helm-configs/magnum/magnum-helm-overrides.yaml
@@ -1,262 +1,89 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Default values for magnum.
-# This is a YAML-formatted file.
-# Declare name/value pairs to be passed into your templates.
-# name: value
-
 ---
-release_group: null
-
-labels:
-  api:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-  conductor:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-  job:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-
 images:
   tags:
-    bootstrap: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    db_init: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    magnum_db_sync: "quay.io/rackspace/rackerlabs-magnum:2024.1-ubuntu_jammy"
-    db_drop: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    rabbit_init: "quay.io/rackspace/rackerlabs-rabbitmq:3.13-management"
-    ks_user: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    ks_service: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    ks_endpoints: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    magnum_api: "quay.io/rackspace/rackerlabs-magnum:2024.1-ubuntu_jammy"
-    magnum_conductor: "quay.io/rackspace/rackerlabs-magnum:2024.1-ubuntu_jammy"
-    dep_check: "quay.io/rackspace/rackerlabs-kubernetes-entrypoint:v1.0.0"
-    image_repo_sync: "quay.io/rackspace/rackerlabs-docker:17.07.0"
-  pull_policy: "IfNotPresent"
-  local_registry:
-    active: false
-    exclude:
-      - dep_check
-      - image_repo_sync
+    bootstrap: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    db_drop: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    db_init: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    dep_check: 'quay.io/rackspace/rackerlabs-kubernetes-entrypoint:v1.0.0'
+    image_repo_sync: 'quay.io/rackspace/rackerlabs-docker:17.07.0'
+    ks_endpoints: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    ks_service: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    ks_user: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    magnum_api: 'quay.io/rackspace/rackerlabs-magnum:2024.1-ubuntu_jammy'
+    magnum_conductor: 'quay.io/rackspace/rackerlabs-magnum:2024.1-ubuntu_jammy'
+    magnum_db_sync: 'quay.io/rackspace/rackerlabs-magnum:2024.1-ubuntu_jammy'
+    rabbit_init: 'quay.io/rackspace/rackerlabs-rabbitmq:3.13-management'
 
 conf:
-  paste:
-    pipeline:main:
-      pipeline: cors healthcheck request_id authtoken api_v1
-    app:api_v1:
-      paste.app_factory: magnum.api.app:app_factory
-    filter:authtoken:
-      acl_public_routes: /, /v1
-      paste.filter_factory: magnum.api.middleware.auth_token:AuthTokenMiddleware.factory
-    filter:request_id:
-      paste.filter_factory: oslo_middleware:RequestId.factory
-    filter:cors:
-      paste.filter_factory: oslo_middleware.cors:filter_factory
-      oslo_config_project: magnum
-    filter:healthcheck:
-      paste.filter_factory: oslo_middleware:Healthcheck.factory
-      backends: disable_by_file
-      disable_by_file_path: /etc/magnum/healthcheck_disable
-  policy: {}
+  logging:
+    logger_root:
+      handlers:
+        - stdout
+      level: INFO
   magnum:
-    DEFAULT:
-      log_config_append: /etc/magnum/logging.conf
-      transport_url: null
-    glance_client:
-      api_version: 2
-      endpoint_type: publicURL
-      region_name: RegionOne
-    nova_client:
+    barbican_client:
       endpoint_type: publicURL
       region_name: RegionOne
     cinder_client:
       endpoint_type: publicURL
       region_name: RegionOne
-    neutron_client:
-      endpoint_type: publicURL
-      region_name: RegionOne
-    barbican_client:
+    database:
+      idle_timeout: 3600
+      connection_recycle_time: 3600
+      pool_timeout: 60
+    glance_client:
+      api_version: 2
       endpoint_type: publicURL
       region_name: RegionOne
     heat_client:
       endpoint_type: publicURL
       region_name: RegionOne
+    keystone_auth:
+      auth_section: keystone_authtoken
+    keystone_authtoken:
+      auth_type: password
+      auth_version: v3
+      interface: public
+      memcache_security_strategy: ENCRYPT
+      service_token_roles: service
+      service_token_roles_required: true
+      service_type: container-infra
     magnum_client:
+      endpoint_type: publicURL
+      region_name: RegionOne
+    neutron_client:
+      endpoint_type: publicURL
+      region_name: RegionOne
+    nova_client:
       endpoint_type: publicURL
       region_name: RegionOne
     octavia_client:
       endpoint_type: publicURL
       region_name: RegionOne
-    cluster:
-      temp_cache_dir: /var/lib/magnum/certificate-cache
-    oslo_messaging_notifications:
-      driver: messagingv2
     oslo_concurrency:
       lock_path: /tmp/magnum
+    oslo_messaging_notifications:
+      driver: messagingv2
     oslo_messaging_rabbit:
       amqp_durable_queues: false
-      # We define use of quorum queues via kustomize but this was enabling HA queues instead
-      # ha_queues are deprecated, explicitly set to false and set quorum_queue true
-      rabbit_ha_queues: false
-      rabbit_quorum_queue: true
-      # TODO: Not available until 2024.1, but once it is, we want to enable these!
-      # new feature ref; https://docs.openstack.org/releasenotes/oslo.messaging/2024.1.html
-      rabbit_transient_quorum_queue: false
-      use_queue_manager: false
-      # Reconnect after a node outage more quickly
-      rabbit_interval_max: 10
-      # Send more frequent heartbeats and fail unhealthy nodes faster
-      # heartbeat_timeout / heartbeat_rate / 2.0 = 30 / 3 / 2.0 = 5
-      # https://opendev.org/openstack/oslo.messaging/commit/36fb5bceabe08a982ebd52e4a8f005cd26fdf6b8
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 30
-      # Setting lower kombu_reconnect_delay should resolve isssue with HA failing when one node is down
-      # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
-      # https://review.opendev.org/c/openstack/oslo.messaging/+/866617
       kombu_reconnect_delay: 0.5
-    oslo_policy:
-      policy_file: /etc/magnum/policy.yaml
-    certificates:
-      cert_manager_type: barbican
-    database:
-      max_retries: -1
+      rabbit_ha_queues: false
+      rabbit_interval_max: 10
+      rabbit_quorum_queue: true
+      rabbit_transient_quorum_queue: false
+      use_queue_manager: false
     trust:
       cluster_user_trust: true
-      trustee_keystone_interface: public
       trustee_domain_name: magnum
-    keystone_auth:
-      auth_section: keystone_authtoken
-    keystone_authtoken:
-      interface: public
-      service_token_roles: service
-      service_token_roles_required: true
-      auth_type: password
-      auth_version: v3
-      memcache_security_strategy: ENCRYPT
-      service_type: container-infra
-    api:
-      # NOTE(portdirect): the bind port should not be defined, and is manipulated
-      # via the endpoints section.
-      port: null
-      host: 0.0.0.0
-  logging:
-    loggers:
-      keys:
-        - root
-        - magnum
-    handlers:
-      keys:
-        - stdout
-        - stderr
-        - "null"
-    formatters:
-      keys:
-        - context
-        - default
-    logger_root:
-      level: INFO
-      handlers:
-        - stdout
-    logger_magnum:
-      level: INFO
-      handlers:
-        - stdout
-      qualname: magnum
-    logger_amqp:
-      level: WARNING
-      handlers: stderr
-      qualname: amqp
-    logger_amqplib:
-      level: WARNING
-      handlers: stderr
-      qualname: amqplib
-    logger_eventletwsgi:
-      level: WARNING
-      handlers: stderr
-      qualname: eventlet.wsgi.server
-    logger_sqlalchemy:
-      level: WARNING
-      handlers: stderr
-      qualname: sqlalchemy
-    logger_boto:
-      level: WARNING
-      handlers: stderr
-      qualname: boto
-    handler_null:
-      class: logging.NullHandler
-      formatter: default
-      args: ()
-    handler_stdout:
-      class: StreamHandler
-      args: (sys.stdout,)
-      formatter: context
-    handler_stderr:
-      class: StreamHandler
-      args: (sys.stderr,)
-      formatter: context
-    formatter_context:
-      class: oslo_log.formatters.ContextFormatter
-      datefmt: "%Y-%m-%d %H:%M:%S"
-    formatter_default:
-      format: "%(message)s"
-      datefmt: "%Y-%m-%d %H:%M:%S"
+      trustee_keystone_interface: public
   magnum_api_uwsgi:
     uwsgi:
-      add-header: "Connection: close"
-      buffer-size: 65535
-      die-on-term: true
-      enable-threads: true
-      exit-on-reload: false
-      hook-master-start: unix_signal:15 gracefully_kill_them_all
-      lazy-apps: true
-      log-x-forwarded-for: true
-      master: true
-      procname-prefix-spaced: "magnum-api:"
-      route-user-agent: '^kube-probe.* donotlog:'
-      thunder-lock: true
-      worker-reload-mercy: 80
-      wsgi-file: /var/lib/openstack/bin/magnum-api-wsgi
-
-network:
-  api:
-    ingress:
-      public: true
-      classes:
-        namespace: "nginx"
-        cluster: "nginx-openstack"
-      annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: /
-    external_policy_local: false
-    node_port:
-      enabled: false
-      port: 30511
-
-bootstrap:
-  enabled: false
-  ks_user: magnum
-  script: |
-    openstack token issue
+      processes: 4
+      threads: 2
 
 dependencies:
-  dynamic:
-    common:
-      local_image_registry:
-        jobs:
-          - magnum-image-repo-sync
-        services:
-          - endpoint: node
-            service: local_image_registry
   static:
     api:
       jobs:
@@ -264,440 +91,50 @@ dependencies:
         - magnum-ks-user
         - magnum-domain-ks-user
         - magnum-ks-endpoints
-        #- magnum-rabbit-init
-      services:
-        - endpoint: internal
-          service: oslo_db
-        - endpoint: internal
-          service: identity
-        - endpoint: internal
-          service: oslo_messaging
-        - endpoint: internal
-          service: key_manager
-        - endpoint: internal
-          service: orchestration
     conductor:
       jobs:
         - magnum-db-sync
         - magnum-ks-user
         - magnum-domain-ks-user
         - magnum-ks-endpoints
-        #- magnum-rabbit-init
-      services:
-        - endpoint: internal
-          service: oslo_db
-        - endpoint: internal
-          service: identity
-        - endpoint: internal
-          service: oslo_messaging
-        - endpoint: internal
-          service: key_manager
-        - endpoint: internal
-          service: orchestration
-    db_drop:
-      services:
-        - endpoint: internal
-          service: oslo_db
-    db_init:
-      services:
-        - endpoint: internal
-          service: oslo_db
     db_sync:
       jobs: null
-      services:
-        - endpoint: internal
-          service: oslo_db
-    ks_endpoints:
-      jobs:
-        - magnum-ks-service
-      services:
-        - endpoint: internal
-          service: identity
-    ks_service:
-      services:
-        - endpoint: internal
-          service: identity
-    ks_user:
-      services:
-        - endpoint: internal
-          service: identity
-    rabbit_init:
-      services:
-        - endpoint: internal
-          service: oslo_messaging
-    image_repo_sync:
-      services:
-        - endpoint: internal
-          service: local_image_registry
 
-# Names of secrets used by bootstrap and environmental checks
-secrets:
-  identity:
-    admin: magnum-keystone-admin
-    magnum: magnum-keystone-user
-    magnum_stack_user: magnum-keystone-stack-user
-  oslo_db:
-    admin: magnum-db-admin
-    magnum: magnum-db-user
-  oslo_messaging:
-    admin: magnum-rabbitmq-admin
-    magnum: magnum-rabbitmq-user
-  oci_image_registry:
-    magnum: magnum-oci-image-registry
-
-# typically overridden by environmental
-# values, but should include all endpoints
-# required by this chart
 endpoints:
-  cluster_domain_suffix: cluster.local
-  local_image_registry:
-    name: docker-registry
-    namespace: docker-registry
-    hosts:
-      default: localhost
-      internal: docker-registry
-      node: localhost
-    host_fqdn_override:
-      default: null
-    port:
-      registry:
-        node: 5000
-  oci_image_registry:
-    name: oci-image-registry
-    namespace: oci-image-registry
-    auth:
-      enabled: false
-      magnum:
-        username: magnum
-        password: password
-    hosts:
-      default: localhost
-    host_fqdn_override:
-      default: null
-    port:
-      registry:
-        default: null
+  fluentd:
+    namespace: fluentbit
   identity:
-    name: keystone
-    auth:
-      admin:
-        region_name: RegionOne
-        username: admin
-        password: password
-        project_name: admin
-        user_domain_name: default
-        project_domain_name: default
-      magnum:
-        role: admin
-        region_name: RegionOne
-        username: magnum
-        password: password
-        project_name: service
-        user_domain_name: service
-        project_domain_name: service
-      magnum_stack_user:
-        role: admin
-        region_name: RegionOne
-        username: magnum-domain
-        password: password
-        domain_name: magnum
-    hosts:
-      default: keystone
-      internal: keystone-api
-    host_fqdn_override:
-      default: null
-    path:
-      default: /v3
-    scheme:
-      default: http
     port:
       api:
         default: 5000
-        public: 80
         internal: 5000
-        service: 5000
-  container_infra:
-    name: magnum
-    hosts:
-      default: magnum-api
-      public: magnum
-    host_fqdn_override:
-      default: null
-    path:
-      default: /v1
-    scheme:
-      default: http
-    port:
-      api:
-        default: 9511
         public: 80
+        service: 5000
   key_manager:
-    name: barbican
     hosts:
-      default: barbican-api
       public: barbican-api
-    host_fqdn_override:
-      default: null
-    path:
-      default: /v1
-    scheme:
-      default: http
     port:
       api:
         default: 9311
         public: 9311
-  orchestration:
-    name: heat
-    hosts:
-      default: heat-api
-      public: heat
-    host_fqdn_override:
-      default: null
-    path:
-      default: '/v1/%(project_id)s'
-    scheme:
-      default: 'http'
-    port:
-      api:
-        default: 8004
-        public: 80
   oslo_db:
-    auth:
-      admin:
-        username: root
-        password: password
-      magnum:
-        username: magnum
-        password: password
+    host_fqdn_override:
+      default: mariadb-cluster-primary.openstack.svc.cluster.local
     hosts:
       default: mariadb-cluster-primary
-    host_fqdn_override:
-      default: null
-    path: /magnum
-    scheme: mysql+pymysql
-    port:
-      mysql:
-        default: 3306
   oslo_cache:
-    auth:
-      # NOTE(portdirect): this is used to define the value for keystone
-      # authtoken cache encryption key, if not set it will be populated
-      # automatically with a random value, but to take advantage of
-      # this feature all services should be set to use the same key,
-      # and memcache service.
-      memcache_secret_key: null
+    host_fqdn_override:
+      default: memcached.openstack.svc.cluster.local
     hosts:
       default: memcached
-    host_fqdn_override:
-      default: null
-    port:
-      memcache:
-        default: 11211
   oslo_messaging:
-    auth:
-      admin:
-        username: rabbitmq
-        password: password
-      magnum:
-        username: magnum
-        password: password
-    statefulset:
-      replicas: 2
-      name: rabbitmq-server
-    hosts:
-      default: rabbitmq-nodes
     host_fqdn_override:
       default: rabbitmq.openstack.svc.cluster.local
-    path: /magnum
-    scheme: rabbit
-    port:
-      amqp:
-        default: 5672
-      http:
-        default: 15672
-  fluentd:
-    namespace: fluentbit
-    name: fluentd
     hosts:
-      default: fluentd-logging
-    host_fqdn_override:
-      default: null
-    path:
-      default: null
-    scheme: 'http'
-    port:
-      service:
-        default: 24224
-      metrics:
-        default: 24220
-
-pod:
-  user:
-    magnum:
-      uid: 42424
-  affinity:
-    anti:
-      type:
-        default: preferredDuringSchedulingIgnoredDuringExecution
-      topologyKey:
-        default: kubernetes.io/hostname
-      weight:
-        default: 10
-  mounts:
-    magnum_api:
-      init_container: null
-      magnum_api:
-        volumeMounts:
-        volumes:
-    magnum_conductor:
-      init_container: null
-      magnum_conductor:
-        volumeMounts:
-        volumes:
-    magnum_bootstrap:
-      init_container: null
-      magnum_bootstrap:
-        volumeMounts:
-        volumes:
-    magnum_db_sync:
-      magnum_db_sync:
-        volumeMounts:
-        volumes:
-  replicas:
-    api: 1
-    conductor: 1
-  lifecycle:
-    upgrades:
-      deployments:
-        revision_history: 3
-        pod_replacement_strategy: RollingUpdate
-        rolling_update:
-          max_unavailable: 1
-          max_surge: 3
-    disruption_budget:
-      api:
-        min_available: 0
-    termination_grace_period:
-      api:
-        timeout: 30
-  resources:
-    enabled: true
-    api:
-      requests:
-        memory: "128Mi"
-        cpu: "100m"
-      limits:
-        memory: "4096Mi"
-        cpu: "2000m"
-    conductor:
-      requests:
-        memory: "512Mi"
-        cpu: "100m"
-      limits:
-        memory: "4096Mi"
-        cpu: "2000m"
-    jobs:
-      bootstrap:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      db_init:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      db_sync:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      db_drop:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      ks_endpoints:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      ks_service:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      ks_user:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      rabbit_init:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      tests:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      image_repo_sync:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-
-
-network_policy:
-  magnum:
-    ingress:
-      - {}
-    egress:
-      - {}
+      default: rabbitmq-nodes
 
 manifests:
-  configmap_bin: true
-  configmap_etc: true
-  deployment_api: true
   ingress_api: false
-  job_bootstrap: true
   job_db_init: false
-  job_db_sync: true
-  job_db_drop: false
-  job_image_repo_sync: true
-  job_ks_endpoints: true
-  job_ks_service: true
-  job_ks_user_domain: true
-  job_ks_user: true
   job_rabbit_init: false
-  pdb_api: true
-  network_policy: false
-  secret_db: true
-  secret_keystone: true
-  secret_rabbitmq: true
-  secret_registry: true
-  service_api: true
   service_ingress_api: false
-  statefulset_conductor: true
-...

--- a/bin/install-magnum.sh
+++ b/bin/install-magnum.sh
@@ -4,9 +4,7 @@ GLOBAL_OVERRIDES_DIR="/etc/genestack/helm-configs/global_overrides"
 SERVICE_CONFIG_DIR="/etc/genestack/helm-configs/magnum"
 BASE_OVERRIDES="/opt/genestack/base-helm-configs/magnum/magnum-helm-overrides.yaml"
 
-pushd /opt/genestack/submodules/openstack-helm || exit 1
-
-HELM_CMD="helm upgrade --install magnum ./magnum \
+HELM_CMD="helm upgrade --install magnum openstack-helm/magnum --version 2024.2.157+13651f45-628a320c \
     --namespace=openstack \
     --timeout 120m"
 
@@ -35,8 +33,9 @@ HELM_CMD+=" --set conf.magnum.keystone_authtoken.memcache_secret_key=\"\$(kubect
 HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
 HELM_CMD+=" --post-renderer-args magnum/overlay $*"
 
+helm repo add openstack-helm https://tarballs.opendev.org/openstack/openstack-helm
+helm repo update
+
 echo "Executing Helm command:"
 echo "${HELM_CMD}"
 eval "${HELM_CMD}"
-
-popd || exit 1

--- a/releasenotes/notes/magnum-chart-5bcf6c0c706a9ad5.yaml
+++ b/releasenotes/notes/magnum-chart-5bcf6c0c706a9ad5.yaml
@@ -1,0 +1,17 @@
+---
+deprecations:
+  - |
+    The magnum chart will now use the online OSH helm repository. This change
+    will allow the magnum chart to be updated more frequently and will allow
+    the magnum chart to be used with the OpenStack-Helm project. Upgrading to
+    this chart may require changes to the deployment configuration. Simple
+    updates can be made by running the following command:
+
+    .. code-block:: shell
+
+      helm -n openstack uninstall magnum
+      kubectl -n openstack delete -f /etc/genestack/kustomize/magnum/base/magnum-rabbitmq-queue.yaml
+      /opt/genestack/bin/install-magnum.sh
+
+    This operation should have no operational impact on running VMs but should be
+    performed during a maintenance window.


### PR DESCRIPTION
This change removes the need to carry the openstack-helm charts for the purposes of providing a magnum deployment. The base helm files have been updated and simplified, reducing the values we carry to only what we need.

Related Issue: #809
Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>