### PR TITLE
chore(horizon): convert helm chart from submodule to repo

### DIFF
--- a/base-helm-configs/horizon/horizon-helm-overrides.yaml
+++ b/base-helm-configs/horizon/horizon-helm-overrides.yaml
@@ -1,20 +1,3 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Default values for horizon.
-# This is a YAML-formatted file.
-# Declare name/value pairs to be passed into your templates.
-# name: value
-
 ---
 images:
   tags:
@@ -25,63 +8,8 @@ images:
     test: "quay.io/rackspace/rackerlabs-osh-selenium:latest-ubuntu_jammy"
     dep_check: "quay.io/rackspace/rackerlabs-kubernetes-entrypoint:v1.0.0"
     image_repo_sync: "quay.io/rackspace/rackerlabs-docker:17.07.0"
-  pull_policy: "IfNotPresent"
-  local_registry:
-    active: false
-    exclude:
-      - dep_check
-      - image_repo_sync
-
-# Use selenium v4 syntax
-selenium_v4: true
-
-release_group: null
-
-labels:
-  dashboard:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-  job:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-  test:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-
-network:
-  dashboard:
-    ingress:
-      public: true
-      classes:
-        namespace: "nginx"
-        cluster: "nginx-openstack"
-      annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: /
-        nginx.ingress.kubernetes.io/affinity: cookie
-        nginx.ingress.kubernetes.io/affinity-mode: persistent
-        nginx.ingress.kubernetes.io/session-cookie-name: GENESTACKCOOKIE
-        nginx.ingress.kubernetes.io/session-cookie-secure: "true"
-        nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
-        nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
-        nginx.ingress.kubernetes.io/session-cookie-hash: sha1
-  external_policy_local: false
-  node_port:
-    enabled: false
-    port: 31000
 
 conf:
-  software:
-    apache2:
-      binary: apache2
-      start_parameters: -DFOREGROUND
-      site_dir: /etc/apache2/sites-available
-      conf_dir: /etc/apache2/conf-available
-      mods_dir: /etc/apache2/mods-available
-      a2enmod:
-        - headers
-        - rewrite
-      a2dismod:
-        - status
   horizon:
     branding:
       logo_splash: |-
@@ -6087,62 +6015,13 @@ conf:
 
     local_settings:
       config:
-        # Use "True" and "False" as Titlecase strings with quotes, boolean
-        # values will not work
-        horizon_secret_key: 9aee62c0-5253-4a86-b189-e0fb71fa503c
-        debug: "False"
-        use_ssl: "True"
-        endpoint_type: "internalURL"
-        keystone_multidomain_support: "True"
-        keystone_default_domain: Default
-        disable_password_reveal: "True"
-        show_openrc_file: "True"
-        csrf_cookie_secure: "True"
-        csrf_cookie_httponly: "True"
-        enforce_password_check: "True"
-        # Set enable_pwd_validator to true to enforce password validator settings.
-        enable_pwd_validator: false
-        pwd_validator_regex: '(?=.*[a-zA-Z])(?=.*\d).{8,}|(?=.*\d)(?=.*\W).{8,}|(?=.*\W)(?=.*[a-zA-Z]).{8,}'
-        pwd_validator_help_text: '_("Your password must be at least eight (8) characters in length and must include characters from at least two (2) of these groupings: alpha, numeric, and special characters.")'
-        session_cookie_secure: "True"
-        session_cookie_httponly: "True"
+        csrf_cookie_httponly: 'True'
+        csrf_cookie_secure: 'True'
+        disallow_iframe_embed: 'True'
         secure_proxy_ssl_header: true
-        password_autocomplete: "False"
-        disallow_iframe_embed: "True"
-        allowed_hosts:
-          - '*'
-        horizon_images_upload_mode: 'legacy'
-        openstack_cinder_features:
-          enable_backup: "True"
-        openstack_neutron_network:
-          enable_router: "True"
-          enable_quotas: "True"
-          enable_ipv6: "True"
-          enable_distributed_router: "False"
-          enable_ha_router: "False"
-          enable_lb: "True"
-          enable_firewall: "True"
-          enable_vpn: "True"
-          enable_fip_topology_check: "True"
-        openstack_enable_password_retrieve: "False"
-        auth:
-          sso:
-            enabled: False
-            initial_choice: "credentials"
-          idp_mapping:
-            - name: "acme_oidc"
-              label: "Acme Corporation - OpenID Connect"
-              idp: "myidp1"
-              protocol: "oidc"
-            - name: "acme_saml2"
-              label: "Acme Corporation - SAML2"
-              idp: "myidp2"
-              protocol: "saml2"
-        log_level: "DEBUG"
-        # Pass any settings to the end of local_settings.py
-        raw: {}
-        openstack_api_versions:
-          container_infra: "1.10"
+        session_cookie_httponly: 'True'
+        session_cookie_secure: 'True'
+        use_ssl: 'True'
       template: |
         import os
 
@@ -6194,6 +6073,10 @@ conf:
 
         SESSION_COOKIE_HTTPONLY = {{ .Values.conf.horizon.local_settings.config.session_cookie_httponly }}
 
+        # https://docs.djangoproject.com/en/dev/ref/settings/#csrf-trusted-origins
+
+        CSRF_TRUSTED_ORIGINS = [{{ include "helm-toolkit.utils.joinListWithCommaAndSingleQuotes" .Values.conf.horizon.local_settings.config.csrf_trusted_origins }}]
+
         # Overrides for OpenStack API versions. Use this setting to force the
         # OpenStack dashboard to use a specific API version for a given service API.
         # Versions specified here should be integers or floats, not strings.
@@ -6219,6 +6102,8 @@ conf:
             ('Default', _('Default')),
             ('rackspace_cloud_domain', _('Rackspace')),
         )
+        OPENSTACK_KEYSTONE_DEFAULT_DOMAIN = '{{ .Values.conf.horizon.local_settings.config.keystone_default_domain }}'
+
         # Set Console type:
         # valid options are "AUTO"(default), "VNC", "SPICE", "RDP", "SERIAL" or None
         # Set to None explicitly if you want to deactivate the console.
@@ -6338,6 +6223,12 @@ conf:
 
         # Determines which authentication choice to show as default.
         WEBSSO_INITIAL_CHOICE = "{{ .Values.conf.horizon.local_settings.config.auth.sso.initial_choice }}"
+
+        {{- if .Values.conf.horizon.local_settings.config.auth.sso.websso_keystone_url }}
+        # The full auth URL for the Keystone endpoint used for web
+        single-sign-on authentication.
+        WEBSSO_KEYSTONE_URL = "{{ .Values.conf.horizon.local_settings.config.auth.sso.websso_keystone_url }}"
+        {{- end }}
 
         # The list of authentication mechanisms
         # which include keystone federation protocols.
@@ -6855,470 +6746,49 @@ conf:
         {{- range $option, $value := .Values.conf.horizon.local_settings.config.raw }}
         {{ $option }} = {{ toJson $value }}
         {{- end }}
-    policy:
-      ceilometer:
-        context_is_admin: 'role:admin'
-        context_is_owner: 'user_id:%(target.user_id)s'
-        context_is_project: 'project_id:%(target.project_id)s'
-        segregation: 'rule:context_is_admin'
-      heat:
-        'actions:action': 'rule:deny_stack_user'
-        'build_info:build_info': 'rule:deny_stack_user'
-        'cloudformation:CancelUpdateStack': 'rule:deny_stack_user'
-        'cloudformation:CreateStack': 'rule:deny_stack_user'
-        'cloudformation:DeleteStack': 'rule:deny_stack_user'
-        'cloudformation:DescribeStackEvents': 'rule:deny_stack_user'
-        'cloudformation:DescribeStackResource': ''
-        'cloudformation:DescribeStackResources': 'rule:deny_stack_user'
-        'cloudformation:DescribeStacks': 'rule:deny_stack_user'
-        'cloudformation:EstimateTemplateCost': 'rule:deny_stack_user'
-        'cloudformation:GetTemplate': 'rule:deny_stack_user'
-        'cloudformation:ListStackResources': 'rule:deny_stack_user'
-        'cloudformation:ListStacks': 'rule:deny_stack_user'
-        'cloudformation:UpdateStack': 'rule:deny_stack_user'
-        'cloudformation:ValidateTemplate': 'rule:deny_stack_user'
-        'cloudwatch:DeleteAlarms': 'rule:deny_stack_user'
-        'cloudwatch:DescribeAlarmHistory': 'rule:deny_stack_user'
-        'cloudwatch:DescribeAlarms': 'rule:deny_stack_user'
-        'cloudwatch:DescribeAlarmsForMetric': 'rule:deny_stack_user'
-        'cloudwatch:DisableAlarmActions': 'rule:deny_stack_user'
-        'cloudwatch:EnableAlarmActions': 'rule:deny_stack_user'
-        'cloudwatch:GetMetricStatistics': 'rule:deny_stack_user'
-        'cloudwatch:ListMetrics': 'rule:deny_stack_user'
-        'cloudwatch:PutMetricAlarm': 'rule:deny_stack_user'
-        'cloudwatch:PutMetricData': ''
-        'cloudwatch:SetAlarmState': 'rule:deny_stack_user'
-        'context_is_admin': 'role:admin'
-        'deny_everybody': '!'
-        'deny_stack_user': 'not role:heat_stack_user'
-        'events:index': 'rule:deny_stack_user'
-        'events:show': 'rule:deny_stack_user'
-        'resource:index': 'rule:deny_stack_user'
-        'resource:mark_unhealthy': 'rule:deny_stack_user'
-        'resource:metadata': ''
-        'resource:show': 'rule:deny_stack_user'
-        'resource:signal': ''
-        'resource_types:OS::Cinder::EncryptedVolumeType': 'rule:context_is_admin'
-        'resource_types:OS::Cinder::VolumeType': 'rule:context_is_admin'
-        'resource_types:OS::Manila::ShareType': 'rule:context_is_admin'
-        'resource_types:OS::Neutron::QoSBandwidthLimitRule': 'rule:context_is_admin'
-        'resource_types:OS::Neutron::QoSPolicy': 'rule:context_is_admin'
-        'resource_types:OS::Nova::Flavor': 'rule:context_is_admin'
-        'resource_types:OS::Nova::HostAggregate': 'rule:context_is_admin'
-        'service:index': 'rule:context_is_admin'
-        'software_configs:create': 'rule:deny_stack_user'
-        'software_configs:delete': 'rule:deny_stack_user'
-        'software_configs:global_index': 'rule:deny_everybody'
-        'software_configs:index': 'rule:deny_stack_user'
-        'software_configs:show': 'rule:deny_stack_user'
-        'software_deployments:create': 'rule:deny_stack_user'
-        'software_deployments:delete': 'rule:deny_stack_user'
-        'software_deployments:index': 'rule:deny_stack_user'
-        'software_deployments:metadata': ''
-        'software_deployments:show': 'rule:deny_stack_user'
-        'software_deployments:update': 'rule:deny_stack_user'
-        'stacks:abandon': 'rule:deny_stack_user'
-        'stacks:create': 'rule:deny_stack_user'
-        'stacks:delete': 'rule:deny_stack_user'
-        'stacks:delete_snapshot': 'rule:deny_stack_user'
-        'stacks:detail': 'rule:deny_stack_user'
-        'stacks:environment': 'rule:deny_stack_user'
-        'stacks:export': 'rule:deny_stack_user'
-        'stacks:generate_template': 'rule:deny_stack_user'
-        'stacks:global_index': 'rule:deny_everybody'
-        'stacks:index': 'rule:deny_stack_user'
-        'stacks:list_outputs': 'rule:deny_stack_user'
-        'stacks:list_resource_types': 'rule:deny_stack_user'
-        'stacks:list_snapshots': 'rule:deny_stack_user'
-        'stacks:list_template_functions': 'rule:deny_stack_user'
-        'stacks:list_template_versions': 'rule:deny_stack_user'
-        'stacks:lookup': ''
-        'stacks:preview': 'rule:deny_stack_user'
-        'stacks:preview_update': 'rule:deny_stack_user'
-        'stacks:preview_update_patch': 'rule:deny_stack_user'
-        'stacks:resource_schema': 'rule:deny_stack_user'
-        'stacks:restore_snapshot': 'rule:deny_stack_user'
-        'stacks:show': 'rule:deny_stack_user'
-        'stacks:show_output': 'rule:deny_stack_user'
-        'stacks:show_snapshot': 'rule:deny_stack_user'
-        'stacks:snapshot': 'rule:deny_stack_user'
-        'stacks:template': 'rule:deny_stack_user'
-        'stacks:update': 'rule:deny_stack_user'
-        'stacks:update_patch': 'rule:deny_stack_user'
-        'stacks:validate_template': 'rule:deny_stack_user'
-    # list of panels to enable for horizon
-    # this requires that the panels are already installed in the horizon image, if they are not
-    # nothing will be added
-    # the name of the panel should be the name of the dir where the panel is installed
-    # for example heat_dashboard, cloudkittydashboard or neutron_taas_dashboard
-    extra_panels:
-      - heat_dashboard
-      - octavia_dashboard
 
 dependencies:
-  dynamic:
-    common:
-      local_image_registry:
-        jobs:
-          - horizon-image-repo-sync
-        services:
-          - endpoint: node
-            service: local_image_registry
   static:
-    dashboard:
-      jobs:
-        - horizon-db-sync
-      services:
-        - endpoint: internal
-          service: oslo_cache
-        - endpoint: internal
-          service: oslo_db
-        - endpoint: internal
-          service: identity
-    db_drop:
-      services:
-        - endpoint: internal
-          service: oslo_db
-    db_init:
-      services:
-        - endpoint: internal
-          service: oslo_db
     db_sync:
       jobs: []
-      services:
-        - endpoint: internal
-          service: oslo_db
-    image_repo_sync:
-      services:
-        - endpoint: internal
-          service: local_image_registry
-    tests:
-      services:
-        - endpoint: internal
-          service: dashboard
 
-pod:
-  security_context:
-    horizon:
-      pod:
-        runAsUser: 42424
-      container:
-        horizon:
-          readOnlyRootFilesystem: false
-          allowPrivilegeEscalation: false
-          runAsUser: 0
-    db_sync:
-      pod:
-        runAsUser: 42424
-      container:
-        horizon_db_sync:
-          readOnlyRootFilesystem: false
-          allowPrivilegeEscalation: false
-          runAsUser: 0
-    test:
-      pod:
-        runAsUser: 42424
-      container:
-        horizon_test:
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-  affinity:
-    anti:
-      type:
-        default: preferredDuringSchedulingIgnoredDuringExecution
-      topologyKey:
-        default: kubernetes.io/hostname
-      weight:
-        default: 10
-  tolerations:
-    horizon:
-      enabled: false
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
-  mounts:
-    horizon_db_init:
-      init_container: null
-      horizon_db_init:
-        volumeMounts:
-        volumes:
-    horizon_db_sync:
-      init_container: null
-      horizon_db_sync:
-        volumeMounts:
-        volumes:
-    horizon:
-      init_container: null
-      horizon:
-        volumeMounts:
-        volumes:
-    horizon_tests:
-      init_container: null
-      horizon_tests:
-        volumeMounts:
-        volumes:
-  replicas:
-    server: 1
-  lifecycle:
-    upgrades:
-      deployments:
-        revision_history: 3
-        pod_replacement_strategy: RollingUpdate
-        rolling_update:
-          max_unavailable: 1
-          max_surge: 3
-    disruption_budget:
-      horizon:
-        min_available: 0
-    termination_grace_period:
-      horizon:
-        timeout: 30
-  resources:
-    enabled: true
-    server:
-      requests:
-        memory: "64Mi"
-        cpu: "100m"
-      limits:
-        memory: "4096Mi"
-        cpu: "2000m"
-    jobs:
-      db_init:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      db_sync:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      db_drop:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      image_repo_sync:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-      tests:
-        requests:
-          memory: "64Mi"
-          cpu: "100m"
-        limits:
-          memory: "4096Mi"
-# Names of secrets used by bootstrap and environmental checks
-secrets:
-  identity:
-    admin: horizon-keystone-admin
-  oslo_db:
-    admin: horizon-db-admin
-    horizon: horizon-db-user
-  tls:
-    dashboard:
-      dashboard:
-        public: horizon-tls-public
-        internal: horizon-tls-web
-  oci_image_registry:
-    horizon: horizon-oci-image-registry
-
-tls:
-  identity: false
-
-# typically overridden by environmental
-# values, but should include all endpoints
-# required by this chart
 endpoints:
-  cluster_domain_suffix: cluster.local
-  local_image_registry:
-    name: docker-registry
-    namespace: docker-registry
-    hosts:
-      default: localhost
-      internal: docker-registry
-      node: localhost
-    host_fqdn_override:
-      default: null
-    port:
-      registry:
-        node: 5000
-  oci_image_registry:
-    name: oci-image-registry
-    namespace: oci-image-registry
-    auth:
-      enabled: false
-      horizon:
-        username: horizon
-        password: password
-    hosts:
-      default: localhost
-    host_fqdn_override:
-      default: null
-    port:
-      registry:
-        default: null
-  identity:
-    name: keystone
-    auth:
-      admin:
-        region_name: RegionOne
-        username: admin
-        password: password
-        project_name: admin
-        user_domain_name: default
-        project_domain_name: default
-    hosts:
-      default: keystone
-      internal: keystone-api
-    host_fqdn_override:
-      default: null
-    path:
-      default: /v3
-    scheme:
-      default: http
-    port:
-      api:
-        default: 5000
-        public: 80
-        internal: 5000
-        service: 5000
-  oslo_cache:
-    auth:
-      # NOTE(portdirect): this is used to define the value for keystone
-      # authtoken cache encryption key, if not set it will be populated
-      # automatically with a random value, but to take advantage of
-      # this feature all services should be set to use the same key,
-      # and memcache service.
-      memcache_secret_key: null
-    hosts:
-      default: memcached
-    host_fqdn_override:
-      default: null
-    port:
-      memcache:
-        default: 11211
   dashboard:
-    name: horizon
-    hosts:
-      default: horizon-int
-      public: horizon
-    host_fqdn_override:
-      default: null
-      # NOTE(portdirect): this chart supports TLS for fqdn over-ridden public
-      # endpoints using the following format:
-      # public:
-      #   host: null
-      #   tls:
-      #     crt: null
-      #     key: null
-    path:
-      default: null
-    scheme:
-      default: http
     port:
       web:
         default: 80
-        public: 443
         internal: 80
+        public: 443
         service: 80
-  oslo_db:
-    auth:
-      admin:
-        username: root
-        password: password
-        secret:
-          tls:
-            internal: mariadb-tls-direct
-      horizon:
-        username: horizon
-        password: password
-    hosts:
-      default: mariadb-cluster-primary
-    host_fqdn_override:
-      default: null
-    path: /horizon
-    scheme: mysql+pymysql
-    port:
-      mysql:
-        default: 3306
-  # NOTE(tp6510): these endpoints allow for things like DNS lookups and ingress
-  # They are using to enable the Egress K8s network policy.
-  kube_dns:
-    namespace: kube-system
-    name: kubernetes-dns
-    hosts:
-      default: kube-dns
-    host_fqdn_override:
-      default: null
-    path:
-      default: null
-    scheme: http
-    port:
-      dns:
-        default: 53
-        protocol: UDP
-  ingress:
-    namespace: null
-    name: ingress
-    hosts:
-      default: ingress
-    port:
-      ingress:
-        default: 80
   fluentd:
     namespace: fluentbit
-    name: fluentd
-    hosts:
-      default: fluentd-logging
-    host_fqdn_override:
-      default: null
-    path:
-      default: null
-    scheme: 'http'
+  identity:
     port:
-      service:
-        default: 24224
-      metrics:
-        default: 24220
-
-network_policy:
-  horizon:
-    ingress:
-      - {}
-    egress:
-      - {}
-
-# NOTE(helm_hook): helm_hook might break for helm2 binary.
-# set helm3_hook: false when using the helm2 binary.
-helm3_hook: true
+      api:
+        default: 5000
+        internal: 5000
+        public: 80
+        service: 5000
+  oslo_db:
+    host_fqdn_override:
+      default: mariadb-cluster-primary.openstack.svc.cluster.local
+    hosts:
+      default: mariadb-cluster-primary
+  oslo_cache:
+    host_fqdn_override:
+      default: memcached.openstack.svc.cluster.local
+    hosts:
+      default: memcached
+  oslo_messaging:
+    host_fqdn_override:
+      default: rabbitmq.openstack.svc.cluster.local
+    hosts:
+      default: rabbitmq-nodes
 
 manifests:
-  certificates: false
-  configmap_bin: true
-  configmap_etc: true
   configmap_logo: true
-  deployment: true
   ingress_api: false
   job_db_init: false
-  job_db_sync: true
-  job_db_drop: false
-  job_image_repo_sync: true
-  pdb: true
   pod_helm_test: false
-  network_policy: false
-  secret_db: true
   secret_ingress_tls: false
-  secret_keystone: true
-  secret_registry: true
   service_ingress: false
-  service: true

--- a/bin/install-horizon.sh
+++ b/bin/install-horizon.sh
@@ -4,9 +4,7 @@ GLOBAL_OVERRIDES_DIR="/etc/genestack/helm-configs/global_overrides"
 SERVICE_CONFIG_DIR="/etc/genestack/helm-configs/horizon"
 BASE_OVERRIDES="/opt/genestack/base-helm-configs/horizon/horizon-helm-overrides.yaml"
 
-pushd /opt/genestack/submodules/openstack-helm || exit 1
-
-HELM_CMD="helm upgrade --install horizon ./horizon \
+HELM_CMD="helm upgrade --install horizon openstack-helm/horizon --version 2024.2.264+13651f45-628a320c \
     --namespace=openstack \
     --timeout 120m"
 
@@ -32,8 +30,9 @@ HELM_CMD+=" --set endpoints.oslo_db.auth.horizon.password=\"\$(kubectl --namespa
 HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
 HELM_CMD+=" --post-renderer-args horizon/overlay $*"
 
+helm repo add openstack-helm https://tarballs.opendev.org/openstack/openstack-helm
+helm repo update
+
 echo "Executing Helm command:"
 echo "${HELM_CMD}"
 eval "${HELM_CMD}"
-
-popd || exit 1

--- a/releasenotes/notes/horizon-chart-dab65a869cc84de3.yaml
+++ b/releasenotes/notes/horizon-chart-dab65a869cc84de3.yaml
@@ -1,0 +1,16 @@
+---
+deprecations:
+  - |
+    The horizon chart will now use the online OSH helm repository. This change
+    will allow the horizon chart to be updated more frequently and will allow
+    the horizon chart to be used with the OpenStack-Helm project. Upgrading to
+    this chart may require changes to the deployment configuration. Simple
+    updates can be made by running the following command:
+
+    .. code-block:: shell
+
+      helm -n openstack uninstall horizon
+      /opt/genestack/bin/install-horizon.sh
+
+    This operation should have no operational impact on running VMs but should be
+    performed during a maintenance window.


### PR DESCRIPTION
This change removes the need to carry the openstack-helm charts for the purposes of providing a horizon deployment. The base helm files have been updated and simplified, reducing the values we carry to only what we need.

Related Issue: #809
Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>