### PR TITLE
fix(skyline): Correct HPA deployment name

### DIFF
--- a/base-kustomize/skyline/base/hpa-skyline-apiserver.yaml
+++ b/base-kustomize/skyline/base/hpa-skyline-apiserver.yaml
@@ -16,4 +16,4 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: skyline-apiserver
+    name: skyline


### PR DESCRIPTION
The HPA deployment name was wrong, which was leading to hpa not managing the deployment.