### PR TITLE
feat: Add volume_id for snapshots

### DIFF
--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -1058,6 +1058,7 @@ conf:
           display_name: resource_metadata.(display_name|name)
           volume_type: resource_metadata.volume_type
           volume_type_id: resource_metadata.volume_type_id
+          volume_id: resource_metadata.volume_id
           image_id: resource_metadata.image_id
           instance_id: resource_metadata.instance_id
         event_create:
@@ -1074,6 +1075,7 @@ conf:
           project_id: project_id
           image_id: image_id
           instance_id: instance_id
+          volume_id: volume_id
 
       - resource_type: volume_provider
         metrics:
@@ -1314,6 +1316,7 @@ conf:
         resource_id: $.payload.snapshot_id
         metadata:
           display_name: $.payload.display_name
+          volume_id: $.payload.volume_id
 
       - name: 'backup.size'
         event_type:


### PR DESCRIPTION
When one is viewing snapshot resources in gnocchi it is useful to know the volume_id.