### PR TITLE
chore: Tuning Octavia API HPA

### DIFF
--- a/base-kustomize/octavia/base/hpa-octavia-api.yaml
+++ b/base-kustomize/octavia/base/hpa-octavia-api.yaml
@@ -10,7 +10,7 @@ spec:
     - resource:
         name: memory
         target:
-          averageValue: 500Mi
+          averageValue: 2200Mi
           type: Value
       type: Resource
   scaleTargetRef:


### PR DESCRIPTION
current memory value is too low forcing max pods to be created