### PR TITLE
chore: update pandoc version in our job so our converted docs look pretty

### DIFF
--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install -r doc-requirements.txt
-      - run: sudo apt update && sudo apt install -y pandoc
+      - run: wget https://github.com/jgm/pandoc/releases/download/3.6.3/pandoc-3.6.3-1-amd64.deb && apt install -y ./pandoc-3.6.3-1-amd64.deb
       - run: reno report -o /tmp/reno.rst
       - run: pandoc /tmp/reno.rst -f rst -t markdown -o docs/release-notes.md
       - run: mkdocs build --strict


### PR DESCRIPTION
pandoc from apt makes our reno docs look sad, pandoc from upstrream make our docs look pretty. so lets make our docs look pretty.