### PR TITLE
chore(gnocchi): convert gnocchi helm chart from submodule to repo

### DIFF
--- a/base-helm-configs/gnocchi/gnocchi-helm-overrides.yaml
+++ b/base-helm-configs/gnocchi/gnocchi-helm-overrides.yaml
@@ -1,691 +1,147 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Default values for gnocchi.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 ---
-labels:
-  api:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-  job:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-  metricd:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-  statsd:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-  test:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-
-release_group: null
-
 images:
   tags:
-    dep_check: "quay.io/rackspace/rackerlabs-kubernetes-entrypoint:v1.0.0"
-    gnocchi_storage_init: "quay.io/rackspace/rackerlabs-ceph-config-helper:latest-ubuntu_jammy"
-    db_init_indexer: "quay.io/rackspace/rackerlabs-postgres:14.5"
-    db_init: "quay.io/rackspace/rackerlabs-gnocchi:2024.1-ubuntu_jammy"
-    db_sync: "quay.io/rackspace/rackerlabs-gnocchi:2024.1-ubuntu_jammy"
-    ks_user: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    ks_service: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    ks_endpoints: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    gnocchi_api: "quay.io/rackspace/rackerlabs-gnocchi:2024.1-ubuntu_jammy"
-    gnocchi_statsd: "quay.io/rackspace/rackerlabs-gnocchi:2024.1-ubuntu_jammy"
-    gnocchi_metricd: "quay.io/rackspace/rackerlabs-gnocchi:2024.1-ubuntu_jammy"
-    gnocchi_resources_cleaner: "quay.io/rackspace/rackerlabs-gnocchi:2024.1-ubuntu_jammy"
-    image_repo_sync: "quay.io/rackspace/rackerlabs-docker:17.07.0"
-  pull_policy: "Always"
-  local_registry:
-    active: false
-    exclude:
-      - dep_check
-      - image_repo_sync
+    db_init: 'quay.io/rackspace/rackerlabs-gnocchi:2024.1-ubuntu_jammy'
+    db_init_indexer: 'quay.io/rackspace/rackerlabs-postgres:14.5'
+    db_sync: 'quay.io/rackspace/rackerlabs-gnocchi:2024.1-ubuntu_jammy'
+    dep_check: 'quay.io/rackspace/rackerlabs-kubernetes-entrypoint:v1.0.0'
+    gnocchi_api: 'quay.io/rackspace/rackerlabs-gnocchi:2024.1-ubuntu_jammy'
+    gnocchi_metricd: 'quay.io/rackspace/rackerlabs-gnocchi:2024.1-ubuntu_jammy'
+    gnocchi_resources_cleaner: 'quay.io/rackspace/rackerlabs-gnocchi:2024.1-ubuntu_jammy'
+    gnocchi_statsd: 'quay.io/rackspace/rackerlabs-gnocchi:2024.1-ubuntu_jammy'
+    gnocchi_storage_init: 'quay.io/rackspace/rackerlabs-ceph-config-helper:latest-ubuntu_jammy'
+    image_repo_sync: 'quay.io/rackspace/rackerlabs-docker:17.07.0'
+    ks_endpoints: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    ks_service: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
+    ks_user: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
 
-jobs:
-  resources_cleaner:
-    # daily
-    cron: "0 */24 * * *"
-    deleted_resources_ttl: '1day'
-    history:
-      success: 3
-      failed: 1
-
-network:
-  api:
-    ingress:
-      public: true
-      classes:
-        namespace: "nginx"
-        cluster: "nginx-openstack"
-      annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: /
-    external_policy_local: false
-    node_port:
-      enabled: false
-      port: 8041
-  statsd:
-    node_port:
-      enabled: false
-      port: 8125
-
-dependencies:
-  dynamic:
-    common:
-      local_image_registry:
-        jobs:
-          - gnocchi-image-repo-sync
-        services:
-          - endpoint: node
-            service: local_image_registry
-  static:
-    api:
-      jobs:
-        - gnocchi-storage-init
-        - gnocchi-db-sync
-        - gnocchi-ks-endpoints
-        - gnocchi-ks-service
-        - gnocchi-ks-user
-      services:
-        - endpoint: internal
-          service: identity
-        - endpoint: internal
-          service: oslo_db
-    clean:
-      services: null
-    db_init:
-      services:
-        - endpoint: internal
-          service: oslo_db
-    db_init_postgresql:
-      jobs: null
-      services:
-        - endpoint: internal
-          service: oslo_db_postgresql
-    db_sync:
-      jobs:
-        - gnocchi-storage-init
-        - gnocchi-db-init
-        - gnocchi-db-init-indexer
-      services:
-        - endpoint: internal
-          service: oslo_db_postgresql
-    ks_endpoints:
-      jobs:
-        - gnocchi-ks-service
-      services:
-        - endpoint: internal
-          service: identity
-    ks_service:
-      services:
-        - endpoint: internal
-          service: identity
-    ks_user:
-      services:
-        - endpoint: internal
-          service: identity
-    metricd:
-      jobs:
-        - gnocchi-storage-init
-        - gnocchi-db-sync
-        - gnocchi-ks-user
-        - gnocchi-ks-service
-        - gnocchi-ks-endpoints
-      services:
-        - endpoint: internal
-          service: oslo_db_postgresql
-        - endpoint: internal
-          service: metric
-    statsd:
-      jobs:
-        - gnocchi-storage-init
-        - gnocchi-db-sync
-        - gnocchi-ks-user
-        - gnocchi-ks-service
-        - gnocchi-ks-endpoints
-      services:
-        - endpoint: internal
-          service: oslo_db_postgresql
-        - endpoint: internal
-          service: metric
-    resources_cleaner:
-      jobs:
-        - gnocchi-storage-init
-        - gnocchi-db-sync
-        - gnocchi-ks-user
-        - gnocchi-ks-endpoints
-      services:
-        - endpoint: internal
-          service: oslo_db
-        - endpoint: internal
-          service: identity
-        - endpoint: internal
-          service: metric
-    storage_init:
-      services: null
-    tests:
-      jobs:
-        - gnocchi-storage-init
-        - gnocchi-db-sync
-      services:
-        - endpoint: internal
-          service: identity
-        - endpoint: internal
-          service: oslo_db_postgresql
-        - endpoint: internal
-          service: metric
-    image_repo_sync:
-      services:
-        - endpoint: internal
-          service: local_image_registry
-
-pod:
-  user:
-    gnocchi:
-      uid: 1000
-  affinity:
-    anti:
-      type:
-        default: preferredDuringSchedulingIgnoredDuringExecution
-      topologyKey:
-        default: kubernetes.io/hostname
-      weight:
-        default: 10
-  tolerations:
-    gnocchi:
-      enabled: false
-      tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
-        - key: node-role.kubernetes.io/control-plane
-          operator: Exists
-          effect: NoSchedule
-  mounts:
-    gnocchi_api:
-      init_container: null
-      gnocchi_api:
-    gnocchi_statsd:
-      init_container: null
-      gnocchi_statsd:
-    gnocchi_metricd:
-      init_container: null
-      gnocchi_metricd:
-    gnocchi_resources_cleaner:
-      init_container: null
-      gnocchi_resources_cleaner:
-    gnocchi_tests:
-      init_container: null
-      gnocchi_tests:
-  replicas:
-    api: 1
-  lifecycle:
-    upgrades:
-      deployments:
-        revision_history: 3
-        pod_replacement_strategy: RollingUpdate
-        rolling_update:
-          max_unavailable: 1
-          max_surge: 3
-      daemonsets:
-        pod_replacement_strategy: RollingUpdate
-        metricd:
-          enabled: true
-          min_ready_seconds: 0
-          max_unavailable: 20%
-        statsd:
-          enabled: true
-          min_ready_seconds: 0
-          max_unavailable: 20%
-    disruption_budget:
-      api:
-        min_available: 0
-    termination_grace_period:
-      api:
-        timeout: 30
-  resources:
-    enabled: true
-    api:
-      requests:
-        memory: "124Mi"
-        cpu: "100m"
-      limits:
-        memory: "4096Mi"
-        cpu: "2000m"
-    statsd:
-      requests:
-        memory: "124Mi"
-        cpu: "100m"
-      limits:
-        memory: "4096Mi"
-        cpu: "2000m"
-    metricd:
-      requests:
-        memory: "124Mi"
-        cpu: "100m"
-      limits:
-        memory: "4096Mi"
-        cpu: "2000m"
-    jobs:
-      clean:
-        requests:
-          memory: "124Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      db_init:
-        requests:
-          memory: "124Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      db_sync:
-        requests:
-          memory: "124Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      ks_endpoints:
-        requests:
-          memory: "124Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      ks_service:
-        requests:
-          memory: "124Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      ks_user:
-        requests:
-          memory: "124Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      resources_cleaner:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      tests:
-        requests:
-          memory: "124Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      image_repo_sync:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
+ceph_client:
+  user_secret_name: gnocchi-temp-keyring
 
 conf:
   apache: |
-    Listen 0.0.0.0:{{ tuple "metric" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}
-
+    Listen 0.0.0.0:{{ tuple "metric" "internal" "api" . | include
+    "helm-toolkit.endpoints.endpoint_port_lookup" }}
     SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
     CustomLog /dev/stdout combined env=!forwarded
     CustomLog /dev/stdout proxy env=forwarded
-
-    <VirtualHost *:{{ tuple "metric" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}>
-        WSGIDaemonProcess gnocchi processes=1 threads=2 user=gnocchi group=gnocchi display-name=%{GROUP}
+    <VirtualHost *:{{ tuple "metric" "internal" "api" . | include
+    "helm-toolkit.endpoints.endpoint_port_lookup" }}>
+        WSGIDaemonProcess gnocchi processes={{ .Values.conf.gnocchi_api_wsgi.wsgi.processes }} threads={{ .Values.conf.gnocchi_api_wsgi.wsgi.threads }} user=gnocchi group=gnocchi display-name=%{GROUP}
         WSGIProcessGroup gnocchi
         WSGIScriptAlias / "/usr/local/lib/python3.10/dist-packages/gnocchi/rest/wsgi.py"
         WSGIApplicationGroup %{GLOBAL}
-
         ErrorLog /dev/stderr
         SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
         CustomLog /dev/stdout combined env=!forwarded
         CustomLog /dev/stdout proxy env=forwarded
-
         <Directory "/usr/local/lib/python3.10/dist-packages/gnocchi/rest">
               Require all granted
         </Directory>
     </VirtualHost>
-  ceph:
-    monitors: []
-    admin_keyring: null
-    override:
-    append:
+  gnocchi:
+    metricd:
+      workers: 2
+  gnocchi_api_wsgi:
+    wsgi:
+      processes: 2
+      threads: 4
   paste:
-    app:gnocchiv1:
-      paste.app_factory: gnocchi.rest.app:app_factory
+    'app:gnocchiv1':
+      paste.app_factory: 'gnocchi.rest.app:app_factory'
       root: gnocchi.rest.api.V1Controller
-    app:gnocchiversions:
-      paste.app_factory: gnocchi.rest.app:app_factory
+    'app:gnocchiversions':
+      paste.app_factory: 'gnocchi.rest.app:app_factory'
       root: gnocchi.rest.api.VersionsController
-    app:healthcheck:
+    'app:healthcheck':
       oslo_config_project: gnocchi
-      use: egg:oslo.middleware#healthcheck
-    composite:gnocchi+basic:
+      use: 'egg:oslo.middleware#healthcheck'
+    'composite:gnocchi+basic':
       /: gnocchiversions_pipeline
       /healthcheck: healthcheck
       /v1: gnocchiv1+noauth
-      use: egg:Paste#urlmap
-    composite:gnocchi+keystone:
+      use: 'egg:Paste#urlmap'
+    'composite:gnocchi+keystone':
       /: gnocchiversions_pipeline
       /healthcheck: healthcheck
       /v1: gnocchiv1+keystone
-      use: egg:Paste#urlmap
-    composite:gnocchi+remoteuser:
+      use: 'egg:Paste#urlmap'
+    'composite:gnocchi+remoteuser':
       /: gnocchiversions_pipeline
       /healthcheck: healthcheck
       /v1: gnocchiv1+noauth
-      use: egg:Paste#urlmap
-    filter:keystone_authtoken:
+      use: 'egg:Paste#urlmap'
+    'filter:keystone_authtoken':
       oslo_config_project: gnocchi
-      use: egg:keystonemiddleware#auth_token
-    pipeline:gnocchiv1+keystone:
+      use: 'egg:keystonemiddleware#auth_token'
+    'pipeline:gnocchiv1+keystone':
       pipeline: keystone_authtoken gnocchiv1
-    pipeline:gnocchiv1+noauth:
+    'pipeline:gnocchiv1+noauth':
       pipeline: gnocchiv1
-    pipeline:gnocchiversions_pipeline:
+    'pipeline:gnocchiversions_pipeline':
       pipeline: gnocchiversions
-    pipeline:main:
+    'pipeline:main':
       pipeline: gnocchi+keystone
   policy:
     admin_or_creator: 'role:admin or project_id:%(created_by_project_id)s'
-    create archive policy rule: 'role:admin'
-    create archive policy: 'role:admin'
-    create metric: ''
-    create resource: ''
-    create resource type: 'role:admin'
-    delete archive policy: 'role:admin'
-    delete archive policy rule: 'role:admin'
-    delete metric: 'rule:admin_or_creator'
-    delete resource: 'rule:admin_or_creator'
-    delete resource type: 'role:admin'
-    delete resources: 'rule:admin_or_creator'
-    get archive policy: ''
-    get archive policy rule: ''
-    get measures: 'rule:admin_or_creator or rule:metric_owner'
-    get metric: 'rule:admin_or_creator or rule:metric_owner'
-    get resource type: ''
-    get resource: 'rule:admin_or_creator or rule:resource_owner'
-    get status: 'role:admin'
-    list all metric: 'role:admin'
-    list archive policy: ''
-    list archive policy rule: ''
-    list metric: ''
-    list resource: 'rule:admin_or_creator or rule:resource_owner'
-    list resource type: ''
-    metric_owner: 'project_id:%(resource.project_id)s'
-    post measures: 'rule:admin_or_creator'
-    resource_owner: 'project_id:%(project_id)s'
-    search metric: 'rule:admin_or_creator or rule:metric_owner'
-    search resource: 'rule:admin_or_creator or rule:resource_owner'
-    update archive policy: 'role:admin'
-    update resource: 'rule:admin_or_creator'
-    update resource type: 'role:admin'
     context_is_admin: 'role:admin'
     update archive policy rule: 'role:admin'
-  gnocchi:
-    DEFAULT:
-      debug: false
-    token:
-      provider: uuid
-    api:
-      auth_mode: keystone
-      # NOTE(portdirect): the bind port should not be defined, and is manipulated
-      # via the endpoints section.
-      port: null
-    statsd:
-      # NOTE(portdirect): the bind port should not be defined, and is manipulated
-      # via the endpoints section.
-      port: null
-    # Increase worker count for production
-    metricd:
-      workers: 8
-    database:
-      max_retries: -1
-    storage:
-      driver: ceph
-      ceph_pool: gnocchi.metrics
-      ceph_username: gnocchi
-      ceph_keyring: /etc/ceph/ceph.client.gnocchi.keyring
-      ceph_conffile: /etc/ceph/ceph.conf
-      file_basepath: /var/lib/gnocchi
-      provided_keyring: null
-    indexer:
-      driver: postgresql
-    keystone_authtoken:
-      auth_type: password
-      auth_version: v3
-      memcache_security_strategy: ENCRYPT
 
-ceph_client:
-  configmap: ceph-etc
-  user_secret_name: gnocchi-temp-keyring
+pod:
+  lifecycle:
+    upgrades:
+      daemonsets:
+        metricd:
+          enabled: true
+          max_unavailable: 20%
+        pod_replacement_strategy: RollingUpdate
+        statsd:
+          enabled: true
+          max_unavailable: 20%
 
-secrets:
-  identity:
-    admin: gnocchi-keystone-admin
-    gnocchi: gnocchi-keystone-user
-  oslo_db:
-    admin: gnocchi-db-admin
-    gnocchi: gnocchi-db-user
-  oslo_db_indexer:
-    admin: gnocchi-db-indexer-admin
-    gnocchi: gnocchi-db-indexer-user
-  rbd: gnocchi-rbd-keyring
-  tls:
-    metric:
-      api:
-        public: gnocchi-tls-public
-
-bootstrap:
-  enabled: false
-  ks_user: gnocchi
-  script: |
-    openstack token issue
-
-# typically overridden by environmental
-# values, but should include all endpoints
-# required by this chart
 endpoints:
-  cluster_domain_suffix: cluster.local
-  local_image_registry:
-    name: docker-registry
-    namespace: docker-registry
-    hosts:
-      default: localhost
-      internal: docker-registry
-      node: localhost
-    host_fqdn_override:
-      default: null
+  fluentd:
+    namespace: fluentbit
     port:
-      registry:
-        node: 5000
+      metrics:
+        default: 24220
+      service:
+        default: 24224
   identity:
-    name: keystone
-    auth:
-      admin:
-        username: "admin"
-        user_domain_name: "default"
-        password: "password"
-        project_name: "admin"
-        project_domain_name: "default"
-        region_name: "RegionOne"
-        os_auth_type: "password"
-        os_tenant_name: "admin"
-      gnocchi:
-        username: "gnocchi"
-        role: "admin"
-        password: "password"
-        project_name: "service"
-        region_name: "RegionOne"
-        os_auth_type: "password"
-        os_tenant_name: "service"
-        user_domain_name: service
-        project_domain_name: service
-    hosts:
-      default: keystone
-      internal: keystone-api
-    host_fqdn_override:
-      default: null
-    path:
-      default: /v3
-    scheme:
-      default: 'http'
     port:
       api:
         default: 5000
-        public: 80
         internal: 5000
+        public: 80
         service: 5000
   metric:
-    name: gnocchi
-    hosts:
-      default: gnocchi-api
-      public: gnocchi
-    host_fqdn_override:
-      default: null
-      # NOTE: this chart supports TLS for fqdn over-ridden public
-      # endpoints using the following format:
-      # public:
-      #   host: null
-      #   tls:
-      #     crt: null
-      #     key: null
-    path:
-      default: null
-    scheme:
-      default: 'http'
     port:
       api:
         default: 8041
-        public: 80
         internal: 8041
+        public: 80
         service: 8041
-  metric_statsd:
-    name: gnocchi-statsd
-    hosts:
-      default: gnocchi-statsd
-    host_fqdn_override:
-      default: null
-    path:
-      default: null
-    scheme:
-      default: null
-    port:
-      statsd:
-        default: 8125
-  oslo_db_postgresql:
-    auth:
-      admin:
-        username: postgres
-        password: password
-      gnocchi:
-        username: gnocchi
-        password: password
-    hosts:
-      default: postgres-cluster
-    host_fqdn_override:
-      default: null
-    path: /gnocchi
-    scheme: postgresql
-    port:
-      postgresql:
-        default: 5432
   oslo_db:
-    auth:
-      admin:
-        username: root
-        password: password
-      gnocchi:
-        username: gnocchi
-        password: password
+    host_fqdn_override:
+      default: mariadb-cluster-primary.openstack.svc.cluster.local
     hosts:
       default: mariadb-cluster-primary
-    host_fqdn_override:
-      default: null
-    path: /gnocchi
-    scheme: mysql+pymysql
-    port:
-      mysql:
-        default: 3306
+  oslo_db_postgresql:
+    hosts:
+      default: postgres-cluster
   oslo_cache:
-    auth:
-      # NOTE(portdirect): this is used to define the value for keystone
-      # authtoken cache encryption key, if not set it will be populated
-      # automatically with a random value, but to take advantage of
-      # this feature all services should be set to use the same key,
-      # and memcache service.
-      memcache_secret_key: null
+    host_fqdn_override:
+      default: memcached.openstack.svc.cluster.local
     hosts:
       default: memcached
+  oslo_messaging:
     host_fqdn_override:
-      default: null
-    port:
-      memcache:
-        default: 11211
-  fluentd:
-    namespace: fluentbit
-    name: fluentd
+      default: rabbitmq.openstack.svc.cluster.local
     hosts:
-      default: fluentd-logging
-    host_fqdn_override:
-      default: null
-    path:
-      default: null
-    scheme: 'http'
-    port:
-      service:
-        default: 24224
-      metrics:
-        default: 24220
+      default: rabbitmq-nodes
+
 manifests:
-  configmap_bin: true
-  configmap_etc: true
-  cron_job_resources_cleaner: true
-  daemonset_metricd: true
-  daemonset_statsd: true
-  deployment_api: true
   ingress_api: false
-  job_bootstrap: true
-  job_clean: true
-  job_db_drop: false
-  job_db_init_indexer: true
-  job_db_init: true
-  job_image_repo_sync: true
-  secret_db_indexer: true
-  job_db_sync: true
-  job_ks_endpoints: true
-  job_ks_service: true
-  job_ks_user: true
-  job_storage_init: true
-  pdb_api: true
   pod_gnocchi_test: false
-  secret_db: true
-  secret_keystone: true
   secret_ingress_tls: false
-  service_api: true
   service_ingress_api: false
-  service_statsd: true
-...

--- a/bin/install-gnocchi.sh
+++ b/bin/install-gnocchi.sh
@@ -4,9 +4,7 @@ GLOBAL_OVERRIDES_DIR="/etc/genestack/helm-configs/global_overrides"
 SERVICE_CONFIG_DIR="/etc/genestack/helm-configs/gnocchi"
 BASE_OVERRIDES="/opt/genestack/base-helm-configs/gnocchi/gnocchi-helm-overrides.yaml"
 
-pushd /opt/genestack/submodules/openstack-helm-infra || exit 1
-
-HELM_CMD="helm upgrade --install gnocchi ./gnocchi \
+HELM_CMD="helm upgrade --install gnocchi openstack-helm-infra/gnocchi  \
     --namespace=openstack \
     --timeout 10m"
 
@@ -33,8 +31,9 @@ HELM_CMD+=" --set endpoints.oslo_db_postgresql.auth.gnocchi.password=\"\$(kubect
 HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
 HELM_CMD+=" --post-renderer-args gnocchi/overlay $*"
 
+helm repo add openstack-helm-infra https://tarballs.opendev.org/openstack/openstack-helm-infra
+helm repo update
+
 echo "Executing Helm command:"
 echo "${HELM_CMD}"
 eval "${HELM_CMD}"
-
-popd || exit 1

--- a/releasenotes/notes/gnocchi-chart-822265ae2b8e6d8b.yaml
+++ b/releasenotes/notes/gnocchi-chart-822265ae2b8e6d8b.yaml
@@ -1,0 +1,14 @@
+---
+deprecations:
+  - |
+    The gnocchi chart will now use the online OSH helm repository. This change
+    will allow the gnocchi chart to be updated more frequently and will allow
+    the gnocchi chart to be used with the OpenStack-Helm project. Upgrading to
+    this chart may require changes to the deployment configuration. Simple
+    updates can be made by running the following command:
+
+    .. code-block:: shell
+
+      helm -n openstack uninstall gnocchi
+      kubectl -n openstack delete -f /etc/genestack/kustomize/gnocchi/base/gnocchi-rabbitmq-queue.yaml
+      /opt/genestack/bin/install-gnocchi.sh


### PR DESCRIPTION
This change removes the need to carry the openstack-helm-infra chart for the purposes of providing a libvirt deployment. The base helm file has been updated and simplified, reducing the values we carry to only what we need.

Related Issue: #809
Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>