### PR TITLE
doc: Prometheus SNMP exporter documentation

### DIFF
--- a/docs/monitoring-info.md
+++ b/docs/monitoring-info.md
@@ -151,6 +151,13 @@ The [Prometheus Push Gateway](https://github.com/prometheus/pushgateway) is used
 It's not capable of turning Prometheus into a push-based monitoring system and should only be used when there is no other way to collect the desired metrics.
 Currently, in Genestack the push gateway is only being used to gather stats from the OVN-Backup CronJob as noted in the [Pushgateway Deployment Doc](prometheus-pushgateway.md).
 
+* ### SNMP Exporter:
+The [Prometheus SNMP Exporter](https://github.com/prometheus/snmp_exporter) is
+used for gathering SNMP metrics. A default Genestack installation does not make
+use of it, so you do not need to install it unless you plan to do additional
+configuration beyond Genestack defaults and specifically plan to monitor some
+SNMP-enabled devices.
+
 * ### Textfile Collector:
 It's possible to gather node/host metrics that aren't exposed by any of the above exporters by utilizing the [Node Exporter Textfile Collector](https://github.com/prometheus/node_exporter?tab=readme-ov-file#textfile-collector).
 Currently, in Genestack the textfile-collector is used to collect kernel-taint stats. To view more information about the textfile-collector and how to deploy your own custom exporter view the [Custom Metrics Deployment Doc](prometheus-custom-node-metrics.md).

--- a/docs/prometheus-monitoring-overview.md
+++ b/docs/prometheus-monitoring-overview.md
@@ -19,6 +19,7 @@ Prometheus makes use of various metric exporters used to collect monitoring data
 * Memcached Exporter(Memcached metrics)
 * Openstack Exporter(Metrics from various Openstack products)
 * Pushgateway (metrics from short-lived jobs)
+* SNMP exporter (for monitoring with SNMP)
 
 <figure markdown="span">
   ![Prometheus Monitoring Diagram](assets/images/prometheus-monitoring.png){ style="filter:drop-shadow(#3c3c3c 0.5rem 0.5rem 10px);" }

--- a/docs/prometheus-snmp-exporter.md
+++ b/docs/prometheus-snmp-exporter.md
@@ -1,0 +1,20 @@
+# Prometheus SNMP Exporter
+
+You will not generally need the Prometheus SNMP Exporter unless you have
+specific SNMP monitoring needs and take additional steps to configure the
+Prometheus SNMP Exporter. The default Genestack configuration doesn't make
+immediate use of it without site-specific customization, such as writing an
+applicable snmp.conf
+
+Use the Prometheus SNMP exporter for getting metrics from monitoring with SNMP
+into Prometheus.
+
+#### Install the Prometheus SNMP Exporter Helm Chart
+
+
+``` shell
+bin/install-chart.sh prometheus-snmp-exporter
+```
+
+!!! success
+    If the installation is successful, you should see the prometheus-snmp-exporter pod running in the prometheus namespace.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -233,6 +233,7 @@ nav:
               - Openstack Exporter: prometheus-openstack-metrics-exporter.md
               - Blackbox Exporter: prometheus-blackbox-exporter.md
               - Pushgateway: prometheus-pushgateway.md
+              - SNMP Exporter: prometheus-snmp-exporter.md
               - Custom Node Metrics: prometheus-custom-node-metrics.md
               - Alert Manager Examples:
                   - alertmanager-slack.md


### PR DESCRIPTION
JIRA:OSPC-624

This documents the Prometheus SNMP Exporter.

Internally, we configure it for our F5s, but external users would need to plan to configure it on a site and installation specific basis. As it does not monitor anything within Genestack itself, it doesn't have much in the way of default configuration, so I mostly mentioned it exists, how to install it, and that it needs configuration if anyone plans to use it.