### PR TITLE
chore: add envoy affinity rules

### DIFF
--- a/base-kustomize/envoyproxy-gateway/base/envoy-custom-proxy-config.yaml
+++ b/base-kustomize/envoyproxy-gateway/base/envoy-custom-proxy-config.yaml
@@ -8,6 +8,8 @@ spec:
   provider:
     type: Kubernetes
     kubernetes:
+      envoyService:
+        externalTrafficPolicy: Cluster
       envoyHpa:
         minReplicas: 2
         maxReplicas: 9
@@ -24,3 +26,14 @@ spec:
                 type: AverageValue
                 averageValue: 500Mi
             type: Resource
+      envoyDeployment:
+        pod:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                    - key: node-role.kubernetes.io/worker
+                      operator: In
+                      values:
+                        - worker

--- a/manifests/metallb/metallb-openstack-service-lb.yml
+++ b/manifests/metallb/metallb-openstack-service-lb.yml
@@ -17,12 +17,8 @@ metadata:
 spec:
   ipAddressPools:
     - gateway-api-external
-  # nodeSelectors:  # Optional block to limit nodes for a given advertisement
-  #   - matchLabels:
-  #       kubernetes.io/hostname: controller01.your.domain.tld
-  #   - matchLabels:
-  #       kubernetes.io/hostname: controller02.your.domain.tld
-  #   - matchLabels:
-  #       kubernetes.io/hostname: controller03.your.domain.tld
+  nodeSelectors:  # Optional block to limit nodes for a given advertisement
+    - matchLabels:
+        node-role.kubernetes.io/worker: worker
   # interfaces:  # Optional block to limit ifaces used to advertise VIPs
   #   - br-mgmt


### PR DESCRIPTION
This change will ensure that the envoy deployment for the flex gateway is using an affinity rule that matches the

> node-role.kubernetes.io/worker=worker

This value will ensure that gateways are deployed on our k8s workers.