### PR TITLE
Envoy lb policy

### DIFF
--- a/base-kustomize/envoyproxy-gateway/base/envoy-endpoint-policies.yaml
+++ b/base-kustomize/envoyproxy-gateway/base/envoy-endpoint-policies.yaml
@@ -70,16 +70,6 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: internal-loki-gateway-route
-  loadBalancer:
-    type: LeastRequest
----
-apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: BackendTrafficPolicy
-metadata:
-  name: source-ip-policy
-  namespace: envoy-gateway
-spec:
-  targetRefs:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: grafana-gateway-route
@@ -87,6 +77,4 @@ spec:
       kind: HTTPRoute
       name: custom-skyline-gateway-route
   loadBalancer:
-    type: ConsistentHash
-    consistentHash:
-      type: SourceIP
+    type: LeastRequest


### PR DESCRIPTION
this change simplified the BackendTrafficPolicy so that all endpoints are using the same least connections policy.

While we can enhance our system with additional policies, we should start simple.