### PR TITLE
Increase net.netfilter.nf_conntrack_max

### DIFF
--- a/ansible/roles/host_setup/defaults/main.yml
+++ b/ansible/roles/host_setup/defaults/main.yml
@@ -42,7 +42,8 @@ host_rp_filter_all: 0
 host_rp_filter_default: 0
 
 # Set the maximum size of the connection tracking table.
-host_nf_conntrack_max: 262144
+host_nf_conntrack_max: 1048576
+host_nf_conntrack_buckets: 262144
 
 # System control kernel tuning
 kernel_options:
@@ -106,6 +107,8 @@ kernel_options:
     value: "{{ set_gc_val | int * 2 }}"
   - key: 'net.netfilter.nf_conntrack_max'
     value: "{{ host_nf_conntrack_max }}"
+  - key: 'net.netfilter.nf_conntrack_buckets'
+    value: "{{ host_nf_conntrack_buckets }}"
   - key: 'vm.dirty_background_ratio'
     value: 5
   - key: 'vm.dirty_ratio'


### PR DESCRIPTION
Increasing net.netfilter.nf_conntrack_max to 1 million along with adding host_nf_conntrack_buckets