### PR TITLE
Feat: Adding fields to megaraid_pd_info Prometheus exporter data

### DIFF
--- a/ansible/playbooks/extra/custom_exporters/perccli.py
+++ b/ansible/playbooks/extra/custom_exporters/perccli.py
@@ -213,6 +213,8 @@ metrics = {
             "state",
             "firmware",
             "serial",
+            "manufacturer",
+            "type",
         ],
         namespace=namespace,
         registry=registry,
@@ -394,7 +396,7 @@ def create_metrics_of_physical_drive(
     physical_drive, detailed_info_array, controller_index
 ):
     enclosure, slot = physical_drive.get("EID:Slt").split(":")[:2]
-
+    type_pd = physical_drive.get("Type")
     if enclosure == " ":
         drive_identifier = "Drive /c{0}/s{1}".format(controller_index, slot)
         enclosure = ""
@@ -457,6 +459,8 @@ def create_metrics_of_physical_drive(
             physical_drive["State"],
             attributes["Firmware Revision"].strip(),
             attributes["SN"].strip(),
+            attributes["Manufacturer Id"].strip(),
+            type_pd,
         ).set(1)
 
         if "Drive Temperature" in state and state["Drive Temperature"] != "N/A":


### PR DESCRIPTION
Added to additional keys:
 - manufacturer
 - type (JBOD or "-") This tells us whether the drive is being tracked by the RAID card as part of an array or strictly in pass through mode which is designated for JBOD.

Both of these fields will assist in filters with Prometheus alert rules.