### PR TITLE
feat: add yamllint to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,31 +3,35 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
-    - id: end-of-file-fixer
-    - id: trailing-whitespace
-    - id: mixed-line-ending
-    - id: check-byte-order-marker
-    - id: check-executables-have-shebangs
-    - id: check-merge-conflict
-    - id: check-symlinks
-    - id: check-yaml
-      files: .*\.(yaml|yml)$
-      args:
-      - "--allow-multiple-documents"
-      - "--unsafe"
-    - id: debug-statements
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+      - id: check-byte-order-marker
+      - id: check-executables-have-shebangs
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-yaml
+        files: .*\.(yaml|yml)$
+        args:
+          - "--allow-multiple-documents"
+          - "--unsafe"
+      - id: debug-statements
   - repo: https://github.com/psf/black
     rev: 24.1.1
     hooks:
-    - id: black
+      - id: black
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.29.0
+    hooks:
+      - id: yamllint
   - repo: https://github.com/ansible-community/ansible-lint
     rev: v6.22.2
     hooks:
-    - id: ansible-lint
-      additional_dependencies:
-      - ansible
-      - yamllint
+      - id: ansible-lint
+        additional_dependencies:
+          - ansible
+          - yamllint
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 3.0.0
     hooks:
-    - id: shellcheck
+      - id: shellcheck


### PR DESCRIPTION
Add yamllint to pre-commit to ensure that we are enforcing code standards to our yaml files.