### PR TITLE
chore: ignore line-length and submodules in yamllint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,10 @@ repos:
     rev: v1.29.0
     hooks:
       - id: yamllint
+        args:
+          - >-
+            -d {extends: default, rules: {line-length: disable},
+            ignore: [submodules/]}
   - repo: https://github.com/ansible-community/ansible-lint
     rev: v6.22.2
     hooks:


### PR DESCRIPTION
configure pre_commit yamllint args to ignore line-length and the submodules directory as everything in submodules is owned by others and we dont care about line-length.