### PR TITLE
fix: Use git to derive changed files instead

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -16,12 +16,17 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Get changed files
+      - name: Fetch all branches and tags
+        run: git fetch --prune --unshallow
+      - name: Determine changed files
         id: changed-files
-        uses: tj-actions/changed-files@v23.1
+        run: |
+          CHANGED_FILES=$(git diff --name-only HEAD^ | xargs)
+          echo "Changed files: $CHANGED_FILES"
+          echo "CHANGED_FILES=$CHANGED_FILES" >> $GITHUB_ENV
       - name: Run Check
         uses: pre-commit/action@v3.0.1
         with:
           extra_args: >-
-            --files ${{ steps.changed-files.outputs.all_changed_files }}
+            --files ${{ env.CHANGED_FILES }}
             --hook-stage manual


### PR DESCRIPTION
tj-actions is no longer recommended

CVE-2025-30066