### PR TITLE
update kubernetes-entrypoint image tag to latest-ubuntu_jammy 

### DIFF
--- a/base-kustomize/ovn/ovn-setup.yaml
+++ b/base-kustomize/ovn/ovn-setup.yaml
@@ -131,7 +131,7 @@ spec:
           emptyDir: {}
       initContainers:
         - name: init
-          image: "quay.io/airshipit/kubernetes-entrypoint:v1.0.0"
+          image: "quay.io/airshipit/kubernetes-entrypoint:latest-ubuntu_jammy"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
update the kubernetes-entrypoint image tag from v1.0.0 to latest-ubuntu_jammy for the ovn-setup daemonset otherwise with latest versions the pods are failing to pull the image