### PR TITLE
fix: add iterator for IPS

### DIFF
--- a/ansible/roles/octavia_preconf/files/create_health_mgr_ports.sh
+++ b/ansible/roles/octavia_preconf/files/create_health_mgr_ports.sh
@@ -16,19 +16,24 @@ export OS_CLOUD=$CLOUD_NAME
 
 # Obtain the list of kubernetes nodes with
 # "openstack-control-plane=enabled" label
-CONTROLLER_IP_PORT_LIST=''
+CONTROLLER_IP_PORT_LIST=()
 CTRLS=$(kubectl get nodes -l openstack-control-plane=enabled -o name | awk -F"/" '{print $2}')
 for node in $CTRLS
 do
   node_short=$(echo "$node" | awk -F"." '{print $1}')
   PORTNAME=octavia-health-manager-port-$node_short
-  PORT_ID=$(openstack port create "$PORTNAME" --security-group "$SECGRP_ID" --device-owner Octavia:health-mgr --host="$node" -c id -f value --network "$NET_ID")
-  IP=$(openstack port show "$PORT_ID" -c fixed_ips -f yaml | grep ip_address | awk -F':' '{print $2}')
-  if [ -z "$CONTROLLER_IP_PORT_LIST" ]; then
-    CONTROLLER_IP_PORT_LIST=$IP:5555
-  else
-    CONTROLLER_IP_PORT_LIST=$CONTROLLER_IP_PORT_LIST,$IP:5555
+  if ! PORT_DATA=$(openstack port show "$PORTNAME" -c fixed_ips -f json); then
+    PORT_DATA=$(openstack port create "$PORTNAME" --security-group "$SECGRP_ID" \
+                                                  --device-owner Octavia:health-mgr \
+                                                  --host="$node" \
+                                                  --network "$NET_ID" \
+                                                  -c fixed_ips \
+                                                  -f json)
   fi
+  for IP in $(echo "$PORT_DATA" | awk 'BEGIN { FS = "\"" } /ip_address/ { print $(NF - 1) }'); do
+    CONTROLLER_IP_PORT_LIST+=("$IP:5555")
+  done
 done
 
-echo "$CONTROLLER_IP_PORT_LIST" > /tmp/octavia_hm_controller_ip_port_list
+readarray -t sorted < <(for item in "${CONTROLLER_IP_PORT_LIST[@]}"; do echo "${item}"; done | sort)
+echo $(IFS=,; echo "${sorted[*]}") > /tmp/octavia_hm_controller_ip_port_list


### PR DESCRIPTION
This change ensures that the controller ip addresses are iterated on when discovered. the the "fixed_ips" field from ports is a list, we should expect it to potentially have multiple values.

This change also ensures that our comma separated list of ip addresses is properly formated without a leading space.

The loop will now guard when creating the port so that the script is idempotent.