### PR TITLE
fix: Remove check for metallb-openstack-service-lb.yml because one always exists

### DIFF
--- a/scripts/hyperconverged-lab.sh
+++ b/scripts/hyperconverged-lab.sh
@@ -332,7 +332,7 @@ if [ ! -d "/etc/genestack" ]; then
   sudo chown \${USER}:\${USER} -R /etc/genestack
 fi
 
-if [ ! -f "/etc/genestack/manifests/metallb/metallb-openstack-service-lb.yml" ]; then
+# We need to clobber the sample or else we get a bogus LB vip
 cat > /etc/genestack/manifests/metallb/metallb-openstack-service-lb.yml <<EOF
 ---
 apiVersion: metallb.io/v1beta1
@@ -354,7 +354,6 @@ spec:
   ipAddressPools:
     - gateway-api-external
 EOF
-fi
 
 if [ ! -f "/etc/genestack/inventory/inventory.yaml" ]; then
 cat > /etc/genestack/inventory/inventory.yaml <<EOF


### PR DESCRIPTION
The check would always avoid creating a correct file because there's always one there so the correct metallb vip was not being set