### PR TITLE
chore(oslo-db): update db sections to all be the same

### DIFF
--- a/base-helm-configs/barbican/barbican-helm-overrides.yaml
+++ b/base-helm-configs/barbican/barbican-helm-overrides.yaml
@@ -28,6 +28,15 @@ conf:
   barbican:
     DEFAULT:
       host_href: "http://barbican-api.openstack.svc.cluster.local:9311"
+    database:
+      connection_debug: 0
+      connection_recycle_time: 600
+      connection_trace: true
+      idle_timeout: 3600
+      mysql_sql_mode: ""
+      use_db_reconnect: true
+      pool_timeout: 60
+      max_retries: -1
     keystone_authtoken:
       service_token_roles: service
       service_token_roles_required: true

--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -40,6 +40,13 @@ conf:
       connection: "NotUsed"
       event_connection: "NotUsed"
       metering_connection: "NotUsed"
+      connection_debug: 0
+      connection_recycle_time: 600
+      connection_trace: true
+      idle_timeout: 3600
+      mysql_sql_mode: ""
+      use_db_reconnect: true
+      pool_timeout: 60
       max_retries: -1
     notification:
       messaging_urls:

--- a/base-helm-configs/cinder/cinder-helm-overrides.yaml
+++ b/base-helm-configs/cinder/cinder-helm-overrides.yaml
@@ -88,6 +88,15 @@ conf:
       scheduler_default_filters: "AvailabilityZoneFilter,CapacityFilter,CapabilitiesFilter"
       storage_availability_zone: az1
       use_multipath_for_image_xfer: false
+    database:
+      connection_debug: 0
+      connection_recycle_time: 600
+      connection_trace: true
+      idle_timeout: 3600
+      mysql_sql_mode: ""
+      use_db_reconnect: true
+      pool_timeout: 60
+      max_retries: -1
     barbican:
       barbican_endpoint_type: internal
     key_manager:

--- a/base-helm-configs/designate/designate-helm-overrides.yaml
+++ b/base-helm-configs/designate/designate-helm-overrides.yaml
@@ -461,6 +461,13 @@ conf:
     oslo_policy:
       policy_file: /etc/designate/policy.yaml
     database:
+      connection_debug: 0
+      connection_recycle_time: 600
+      connection_trace: true
+      idle_timeout: 3600
+      mysql_sql_mode: ""
+      use_db_reconnect: true
+      pool_timeout: 60
       max_retries: -1
     storage:sqlalchemy:
       max_retries: -1

--- a/base-helm-configs/glance/glance-helm-overrides.yaml
+++ b/base-helm-configs/glance/glance-helm-overrides.yaml
@@ -87,8 +87,12 @@ conf:
       swift_store_container: glance
       swift_store_admin_tenants: admin,image-services
     database:
+      connection_debug: 0
+      connection_recycle_time: 600
+      connection_trace: true
       idle_timeout: 3600
-      connection_recycle_time: 3600
+      mysql_sql_mode: ""
+      use_db_reconnect: true
       pool_timeout: 60
       max_retries: -1
     oslo_messaging_rabbit:

--- a/base-helm-configs/heat/heat-helm-overrides.yaml
+++ b/base-helm-configs/heat/heat-helm-overrides.yaml
@@ -27,9 +27,14 @@ conf:
     clients_keystone:
       endpoint_type: publicURL
     database:
-      connection_recycle_time: 3600
+      connection_debug: 0
+      connection_recycle_time: 600
+      connection_trace: true
       idle_timeout: 3600
+      mysql_sql_mode: ""
+      use_db_reconnect: true
       pool_timeout: 60
+      max_retries: -1
     heat_api:
       workers: 1
     heat_api_cfn:

--- a/base-helm-configs/keystone/keystone-helm-overrides.yaml
+++ b/base-helm-configs/keystone/keystone-helm-overrides.yaml
@@ -38,9 +38,14 @@ conf:
       password: rxt
       totp: rxt
     database:
-      connection_recycle_time: 3600
+      connection_debug: 0
+      connection_recycle_time: 600
+      connection_trace: true
       idle_timeout: 3600
+      mysql_sql_mode: ""
+      use_db_reconnect: true
       pool_timeout: 60
+      max_retries: -1
     fernet_tokens:
       max_active_keys: 7
     oslo_concurrency:

--- a/base-helm-configs/magnum/magnum-helm-overrides.yaml
+++ b/base-helm-configs/magnum/magnum-helm-overrides.yaml
@@ -28,9 +28,14 @@ conf:
       endpoint_type: publicURL
       region_name: RegionOne
     database:
+      connection_debug: 0
+      connection_recycle_time: 600
+      connection_trace: true
       idle_timeout: 3600
-      connection_recycle_time: 3600
+      mysql_sql_mode: ""
+      use_db_reconnect: true
       pool_timeout: 60
+      max_retries: -1
     glance_client:
       api_version: 2
       endpoint_type: publicURL

--- a/base-helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/base-helm-configs/neutron/neutron-helm-overrides.yaml
@@ -97,11 +97,13 @@ conf:
       availability_zone: az1
     database:
       connection_debug: 0
-      connection_recycle_time: 3600
+      connection_recycle_time: 600
       connection_trace: true
       idle_timeout: 3600
       mysql_sql_mode: ""
       use_db_reconnect: true
+      pool_timeout: 60
+      max_retries: -1
     oslo_messaging_rabbit:
       amqp_durable_queues: false
       rabbit_ha_queues: false

--- a/base-helm-configs/nova/nova-helm-overrides.yaml
+++ b/base-helm-configs/nova/nova-helm-overrides.yaml
@@ -107,21 +107,36 @@ conf:
       cross_az_attach: true
       network_allocate_retries: 3
     api_database:
+      connection_debug: 0
+      connection_recycle_time: 600
+      connection_trace: true
       idle_timeout: 3600
-      connection_recycle_time: 3600
+      mysql_sql_mode: ""
+      use_db_reconnect: true
       pool_timeout: 60
+      max_retries: -1
     cell0_database:
+      connection_debug: 0
+      connection_recycle_time: 600
+      connection_trace: true
       idle_timeout: 3600
-      connection_recycle_time: 3600
+      mysql_sql_mode: ""
+      use_db_reconnect: true
       pool_timeout: 60
+      max_retries: -1
     compute:
       max_disk_devices_to_attach: 8
     conductor:
       workers: 4
     database:
+      connection_debug: 0
+      connection_recycle_time: 600
+      connection_trace: true
       idle_timeout: 3600
-      connection_recycle_time: 3600
+      mysql_sql_mode: ""
+      use_db_reconnect: true
       pool_timeout: 60
+      max_retries: -1
     glance:
       num_retries: 8
     key_manager:

--- a/base-helm-configs/octavia/octavia-helm-overrides.yaml
+++ b/base-helm-configs/octavia/octavia-helm-overrides.yaml
@@ -64,6 +64,15 @@ conf:
     controller_worker:
       loadbalancer_topology: ACTIVE_STANDBY
       workers: 4
+    database:
+      connection_debug: 0
+      connection_recycle_time: 600
+      connection_trace: true
+      idle_timeout: 3600
+      mysql_sql_mode: ""
+      use_db_reconnect: true
+      pool_timeout: 60
+      max_retries: -1
     driver_agent:
       enabled_provider_agents: ovn
     glance:

--- a/base-helm-configs/placement/placement-helm-overrides.yaml
+++ b/base-helm-configs/placement/placement-helm-overrides.yaml
@@ -50,9 +50,14 @@ conf:
     placement:
       randomize_allocation_candidates: true
     placement_database:
+      connection_debug: 0
+      connection_recycle_time: 600
+      connection_trace: true
       idle_timeout: 3600
-      connection_recycle_time: 3600
+      mysql_sql_mode: ""
+      use_db_reconnect: true
       pool_timeout: 60
+      max_retries: -1
   placement_api_uwsgi:
     uwsgi:
       processes: 4


### PR DESCRIPTION
All db sections for openstack services now use the same default values. Notable changes are to the `connection_recycle_time` which is set to 600, a production ready value taken from Upstream OpenStack-Ansible.