### PR TITLE
fix: (host-setup) properly set and pin the desired kernel

### DIFF
--- a/ansible/roles/host_setup/tasks/pin_kernel.yml
+++ b/ansible/roles/host_setup/tasks/pin_kernel.yml
@@ -27,7 +27,7 @@
     - ansible_facts['kernel'] is version(host_required_kernel, '!=')
 
 - name: "Install specific kernel image/modules/extra version {{ host_required_kernel }}"
-  ansible.builtin.apt:
+  ansible.builtin.package:
     name:
       - "linux-image-{{ host_required_kernel }}"
       - "linux-modules-{{ host_required_kernel }}"
@@ -90,6 +90,6 @@
       value: "0"
 
 - name: Ensure unattended-upgrades package is removed
-  ansible.builtin.apt:
+  ansible.builtin.package:
     name: unattended-upgrades
     state: absent

--- a/ansible/roles/host_setup/tasks/pin_kernel.yml
+++ b/ansible/roles/host_setup/tasks/pin_kernel.yml
@@ -18,27 +18,48 @@
     filter: "ansible_kernel"
 
 - name: Check Kernel Version
-  ansible.builtin.fail:
+  ansible.builtin.debug:
     msg: >
       Wrong kernel Version found
-      [ {{ ansible_facts['kernel'] }} < {{ host_required_kernel }} ]
+      [ {{ ansible_facts['kernel'] }} != {{ host_required_kernel }} ]
       Resolve this issue before continuing.
   when:
-    - ansible_facts['kernel'] is version(host_required_kernel, '<')
+    - ansible_facts['kernel'] is version(host_required_kernel, '!=')
 
-- name: Pin kernel packages version
-  ansible.builtin.copy:
-    dest: "{{ apt_preferences }}/pin-kernel"
-    content: |
-      Package: linux-image-{{ ansible_facts['kernel'] }}
+- name: "Install specific kernel image/modules/extra version {{ host_required_kernel }}"
+  ansible.builtin.apt:
+    name:
+      - "linux-image-{{ host_required_kernel }}"
+      - "linux-modules-{{ host_required_kernel }}"
+      - "linux-modules-extra-{{ host_required_kernel }}"
+    state: present
+
+- name: "Update grub to boot the desired kernel {{ host_required_kernel }}"
+  ansible.builtin.lineinfile:
+    path: /etc/default/grub
+    regexp: '^GRUB_DEFAULT='
+    line: 'GRUB_DEFAULT="Advanced options for Ubuntu>Ubuntu, with Linux 6.8.0-47-generic"'
+  notify: "Update Grub2 config file"
+
+- name: Update Grub2 config file
+  ansible.builtin.command: update-grub
+  become: yes # Required for update-grub
+  tags: grub_update
+
+- name: Create apt preference file for specific kernel
+  ansible.builtin.blockinfile:
+    path: "{{ apt_preferences }}/pin-kernel"
+    create: true
+    block: |
+      Package: linux-image-{{ host_required_kernel }}
       Pin: release *
       Pin-Priority: 1001
 
-      Package: linux-headers-{{ ansible_facts['kernel'] }}
+      Package: linux-modules-{{ host_required_kernel }}
       Pin: release *
       Pin-Priority: 1001
 
-      Package: linux-modules-{{ ansible_facts['kernel'] }}
+      Package: linux-modules-extra-{{ host_required_kernel }}
       Pin: release *
       Pin-Priority: 1001
 
@@ -46,16 +67,10 @@
       Pin: release *
       Pin-Priority: -1
 
-      Package: linux-headers-*
-      Pin: release *
-      Pin-Priority: -1
-
       Package: linux-modules-*
       Pin: release *
       Pin-Priority: -1
     mode: '0644'
-  when:
-    - ansible_facts['kernel'] is version(host_required_kernel, '<')
 
 - name: Disable unattended-upgrades
   ansible.builtin.lineinfile:

--- a/ansible/roles/host_setup/tasks/pin_kernel.yml
+++ b/ansible/roles/host_setup/tasks/pin_kernel.yml
@@ -38,7 +38,7 @@
   ansible.builtin.lineinfile:
     path: /etc/default/grub
     regexp: '^GRUB_DEFAULT='
-    line: 'GRUB_DEFAULT="Advanced options for Ubuntu>Ubuntu, with Linux 6.8.0-47-generic"'
+    line: 'GRUB_DEFAULT="Advanced options for Ubuntu>Ubuntu, with Linux {{ host_required_kernel }}"'
   notify: "Update Grub2 config file"
 
 - name: Update Grub2 config file

--- a/ansible/roles/host_setup/tasks/pin_kernel.yml
+++ b/ansible/roles/host_setup/tasks/pin_kernel.yml
@@ -39,12 +39,11 @@
     path: /etc/default/grub
     regexp: '^GRUB_DEFAULT='
     line: 'GRUB_DEFAULT="Advanced options for Ubuntu>Ubuntu, with Linux {{ host_required_kernel }}"'
-  notify: "Update Grub2 config file"
+  notify: "Update Grub"
 
-- name: Update Grub2 config file
-  ansible.builtin.command: update-grub
-  become: yes # Required for update-grub
-  tags: grub_update
+- name: Update Grub
+  ansible.builtin.command: update-grub2
+  become: yes
 
 - name: Create apt preference file for specific kernel
   ansible.builtin.blockinfile:
@@ -71,6 +70,7 @@
       Pin: release *
       Pin-Priority: -1
     mode: '0644'
+  when: ansible_distribution == 'Ubuntu'    
 
 - name: Disable unattended-upgrades
   ansible.builtin.lineinfile:

--- a/ansible/roles/host_setup/vars/ubuntu.yml
+++ b/ansible/roles/host_setup/vars/ubuntu.yml
@@ -1,7 +1,7 @@
 ---
 
 ## Defined required kernel
-host_required_kernel: 6.8.0-0-generic
+host_required_kernel: 6.8.0-47-generic
 host_sysstat_file: /etc/default/sysstat
 host_sysstat_cron_file: /etc/cron.d/sysstat
 host_cron_template: sysstat.cron.debian.j2

--- a/ansible/roles/host_setup/vars/ubuntu.yml
+++ b/ansible/roles/host_setup/vars/ubuntu.yml
@@ -1,6 +1,8 @@
 ---
 
 ## Defined required kernel
+# This variable is used to set the default kernel in grub.  Ensure you are 
+# using the ENTIRE output from uname -r
 host_required_kernel: 6.8.0-47-generic
 host_sysstat_file: /etc/default/sysstat
 host_sysstat_cron_file: /etc/cron.d/sysstat


### PR DESCRIPTION
pin-kernel task wasnt actaully pinning the desired kernel but rather checking to see if it wasin the same major/minor series.  This pr defines a static kernel  and ensures that its installed and "pinned" via GRUB_DEFAULT updates.