### PR TITLE
fix: (install-scripts) correctly allow for additional flags

### DIFF
--- a/bin/install-barbican.sh
+++ b/bin/install-barbican.sh
@@ -29,10 +29,12 @@ HELM_CMD+=" --set endpoints.oslo_cache.auth.memcache_secret_key=\"$(kubectl --na
 HELM_CMD+=" --set conf.barbican.keystone_authtoken.memcache_secret_key=\"$(kubectl --namespace openstack get secret os-memcached -o jsonpath='{.data.memcache_secret_key}' | base64 -d)\""
 
 HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
-HELM_CMD+=" --post-renderer-args barbican/overlay $*"
+HELM_CMD+=" --post-renderer-args barbican/overlay"
 
 helm repo add openstack-helm https://tarballs.opendev.org/openstack/openstack-helm
 helm repo update
+
+HELM_CMD+=" $@"
 
 echo "Executing Helm command:"
 echo "${HELM_CMD}"

--- a/bin/install-ceilometer.sh
+++ b/bin/install-ceilometer.sh
@@ -42,10 +42,12 @@ rabbit://octavia:\$(kubectl --namespace openstack get secret octavia-rabbitmq-pa
 rabbit://magnum:\$(kubectl --namespace openstack get secret magnum-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)@rabbitmq.openstack.svc.cluster.local:5672/magnum}\""
 
 HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
-HELM_CMD+=" --post-renderer-args ceilometer/overlay $*"
+HELM_CMD+=" --post-renderer-args ceilometer/overlay"
 
 helm repo add openstack-helm https://tarballs.opendev.org/openstack/openstack-helm
 helm repo update
+
+HELM_CMD+=" $@"
 
 echo "Executing Helm command:"
 echo "${HELM_CMD}"

--- a/bin/install-cinder.sh
+++ b/bin/install-cinder.sh
@@ -29,10 +29,12 @@ HELM_CMD+=" --set endpoints.oslo_messaging.auth.admin.password=\"\$(kubectl --na
 HELM_CMD+=" --set endpoints.oslo_messaging.auth.cinder.password=\"\$(kubectl --namespace openstack get secret cinder-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)\""
 
 HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
-HELM_CMD+=" --post-renderer-args cinder/overlay $*"
+HELM_CMD+=" --post-renderer-args cinder/overlay"
 
 helm repo add openstack-helm https://tarballs.opendev.org/openstack/openstack-helm
 helm repo update
+
+HELM_CMD+=" $@"
 
 echo "Executing Helm command:"
 echo "${HELM_CMD}"

--- a/bin/install-glance.sh
+++ b/bin/install-glance.sh
@@ -29,10 +29,12 @@ HELM_CMD+=" --set endpoints.oslo_messaging.auth.admin.password=\"\$(kubectl --na
 HELM_CMD+=" --set endpoints.oslo_messaging.auth.glance.password=\"\$(kubectl --namespace openstack get secret glance-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)\""
 
 HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
-HELM_CMD+=" --post-renderer-args glance/overlay $*"
+HELM_CMD+=" --post-renderer-args glance/overlay"
 
 helm repo add openstack-helm https://tarballs.opendev.org/openstack/openstack-helm
 helm repo update
+
+HELM_CMD+=" $@"
 
 echo "Executing Helm command:"
 echo "${HELM_CMD}"

--- a/bin/install-gnocchi.sh
+++ b/bin/install-gnocchi.sh
@@ -29,10 +29,12 @@ HELM_CMD+=" --set endpoints.oslo_db_postgresql.auth.admin.password=\"\$(kubectl 
 HELM_CMD+=" --set endpoints.oslo_db_postgresql.auth.gnocchi.password=\"\$(kubectl --namespace openstack get secret gnocchi-pgsql-password -o jsonpath='{.data.password}' | base64 -d)\""
 
 HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
-HELM_CMD+=" --post-renderer-args gnocchi/overlay $*"
+HELM_CMD+=" --post-renderer-args gnocchi/overlay"
 
 helm repo add openstack-helm-infra https://tarballs.opendev.org/openstack/openstack-helm-infra
 helm repo update
+
+HELM_CMD+=" $@"
 
 echo "Executing Helm command:"
 echo "${HELM_CMD}"

--- a/bin/install-heat.sh
+++ b/bin/install-heat.sh
@@ -31,10 +31,12 @@ HELM_CMD+=" --set endpoints.oslo_messaging.auth.admin.password=\"\$(kubectl --na
 HELM_CMD+=" --set endpoints.oslo_messaging.auth.heat.password=\"\$(kubectl --namespace openstack get secret heat-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)\""
 
 HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
-HELM_CMD+=" --post-renderer-args heat/overlay $*"
+HELM_CMD+=" --post-renderer-args heat/overlay"
 
 helm repo add openstack-helm https://tarballs.opendev.org/openstack/openstack-helm
 helm repo update
+
+HELM_CMD+=" $@"
 
 echo "Executing Helm command:"
 echo "${HELM_CMD}"

--- a/bin/install-horizon.sh
+++ b/bin/install-horizon.sh
@@ -28,10 +28,12 @@ HELM_CMD+=" --set endpoints.oslo_db.auth.admin.password=\"\$(kubectl --namespace
 HELM_CMD+=" --set endpoints.oslo_db.auth.horizon.password=\"\$(kubectl --namespace openstack get secret horizon-db-password -o jsonpath='{.data.password}' | base64 -d)\""
 
 HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
-HELM_CMD+=" --post-renderer-args horizon/overlay $*"
+HELM_CMD+=" --post-renderer-args horizon/overlay"
 
 helm repo add openstack-helm https://tarballs.opendev.org/openstack/openstack-helm
 helm repo update
+
+HELM_CMD+=" $@"
 
 echo "Executing Helm command:"
 echo "${HELM_CMD}"

--- a/bin/install-keystone.sh
+++ b/bin/install-keystone.sh
@@ -30,10 +30,12 @@ HELM_CMD+=" --set endpoints.oslo_messaging.auth.admin.password=\"\$(kubectl --na
 HELM_CMD+=" --set endpoints.oslo_messaging.auth.keystone.password=\"\$(kubectl --namespace openstack get secret keystone-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)\""
 
 HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
-HELM_CMD+=" --post-renderer-args keystone/overlay $*"
+HELM_CMD+=" --post-renderer-args keystone/overlay"
 
 helm repo add openstack-helm https://tarballs.opendev.org/openstack/openstack-helm
 helm repo update
+
+HELM_CMD+=" $@"
 
 echo "Executing Helm command:"
 echo "${HELM_CMD}"

--- a/bin/install-kube-ovn.sh
+++ b/bin/install-kube-ovn.sh
@@ -37,6 +37,7 @@ for dir in "$GLOBAL_OVERRIDES_DIR" "$SERVICE_CONFIG_DIR"; do
     fi
 done
 
+
 HELM_CMD+=" $@"
 
 echo "Executing Helm command:"

--- a/bin/install-magnum.sh
+++ b/bin/install-magnum.sh
@@ -31,10 +31,12 @@ HELM_CMD+=" --set endpoints.oslo_cache.auth.memcache_secret_key=\"\$(kubectl --n
 HELM_CMD+=" --set conf.magnum.keystone_authtoken.memcache_secret_key=\"\$(kubectl --namespace openstack get secret os-memcached -o jsonpath='{.data.memcache_secret_key}' | base64 -d)\""
 
 HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
-HELM_CMD+=" --post-renderer-args magnum/overlay $*"
+HELM_CMD+=" --post-renderer-args magnum/overlay"
 
 helm repo add openstack-helm https://tarballs.opendev.org/openstack/openstack-helm
 helm repo update
+
+HELM_CMD+=" $@"
 
 echo "Executing Helm command:"
 echo "${HELM_CMD}"

--- a/bin/install-neutron.sh
+++ b/bin/install-neutron.sh
@@ -42,10 +42,12 @@ HELM_CMD+=" --set conf.plugins.ml2_conf.ovn.ovn_nb_connection=\"tcp:\$(kubectl -
 HELM_CMD+=" --set conf.plugins.ml2_conf.ovn.ovn_sb_connection=\"tcp:\$(kubectl --namespace kube-system get service ovn-sb -o jsonpath='{.spec.clusterIP}:{.spec.ports[0].port}')\""
 
 HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
-HELM_CMD+=" --post-renderer-args neutron/overlay $*"
+HELM_CMD+=" --post-renderer-args neutron/overlay"
 
 helm repo add openstack-helm https://tarballs.opendev.org/openstack/openstack-helm
 helm repo update
+
+HELM_CMD+=" $@"
 
 echo "Executing Helm command:"
 echo "${HELM_CMD}"

--- a/bin/install-nova.sh
+++ b/bin/install-nova.sh
@@ -45,10 +45,12 @@ HELM_CMD+=" --set network.ssh.public_key=\"\$(kubectl -n openstack get secret no
 HELM_CMD+=" --set network.ssh.private_key=\"\$(kubectl -n openstack get secret nova-ssh-keypair -o jsonpath='{.data.private_key}' | base64 -d)\"\$'\n'"
 
 HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
-HELM_CMD+=" --post-renderer-args nova/overlay $*"
+HELM_CMD+=" --post-renderer-args nova/overlay"
 
 helm repo add openstack-helm https://tarballs.opendev.org/openstack/openstack-helm
 helm repo update
+
+HELM_CMD+=" $@"
 
 echo "Executing Helm command:"
 echo "${HELM_CMD}"

--- a/bin/install-octavia.sh
+++ b/bin/install-octavia.sh
@@ -35,10 +35,12 @@ HELM_CMD+=" --set conf.octavia.ovn.ovn_nb_connection=\"tcp:\$(kubectl --namespac
 HELM_CMD+=" --set conf.octavia.ovn.ovn_sb_connection=\"tcp:\$(kubectl --namespace kube-system get service ovn-sb -o jsonpath='{.spec.clusterIP}:{.spec.ports[0].port}')\""
 
 HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
-HELM_CMD+=" --post-renderer-args octavia/overlay $*"
+HELM_CMD+=" --post-renderer-args octavia/overlay"
 
 helm repo add openstack-helm https://tarballs.opendev.org/openstack/openstack-helm
 helm repo update
+
+HELM_CMD+=" $@"
 
 echo "Executing Helm command:"
 echo "${HELM_CMD}"

--- a/bin/install-placement.sh
+++ b/bin/install-placement.sh
@@ -31,7 +31,9 @@ HELM_CMD+=" --set conf.placement.keystone_authtoken.memcache_secret_key=\"\$(kub
 HELM_CMD+=" --set conf.placement.placement_database.slave_connection=\"mysql+pymysql://placement:\$(kubectl --namespace openstack get secret placement-db-password -o jsonpath='{.data.password}' | base64 -d)@mariadb-cluster-secondary.openstack.svc.cluster.local:3306/placement\""
 
 HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
-HELM_CMD+=" --post-renderer-args placement/overlay $*"
+HELM_CMD+=" --post-renderer-args placement/overlay"
+
+HELM_CMD+=" $@"
 
 echo "Executing Helm command:"
 echo "${HELM_CMD}"

--- a/bin/install-sealed-secrets.sh
+++ b/bin/install-sealed-secrets.sh
@@ -22,6 +22,8 @@ if compgen -G "${CONFIG_DIR}/*.yaml" > /dev/null; then
     done
 fi
 
+HELM_CMD+=" $@"
+
 # Run the helm command
 echo "Executing Helm command:"
 echo "${HELM_CMD}"

--- a/bin/install-topolvm.sh
+++ b/bin/install-topolvm.sh
@@ -26,6 +26,8 @@ if compgen -G "${CONFIG_DIR}/*.yaml" > /dev/null; then
     done
 fi
 
+HELM_CMD+=" $@"
+
 # Run the helm command
 echo "Executing Helm command:"
 echo "${HELM_CMD}"


### PR DESCRIPTION
Fix the install scripts to properly allow for additional flags such as --debug.