### PR TITLE
Fix(glance-api): Run glance as non uwsgi process

### DIFF
--- a/base-kustomize/glance/base/kustomization.yaml
+++ b/base-kustomize/glance/base/kustomization.yaml
@@ -8,6 +8,11 @@ resources:
 
 patches:
   - target:
+      kind: ConfigMap
+      name: glance-bin
+    path: patch-glance-bin.yaml
+
+  - target:
       kind: PersistentVolumeClaim
       name: glance-images
     patch: |-

--- a/base-kustomize/glance/base/patch-glance-bin.yaml
+++ b/base-kustomize/glance/base/patch-glance-bin.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: glance-bin
+data:
+  glance-api.sh: |
+    #!/bin/bash
+
+    set -ex
+    COMMAND="${@:-start}"
+
+    function start () {
+      /var/lib/openstack/bin/glance-api --config-file /etc/glance/glance-api.conf
+    }
+
+    function stop () {
+      kill -TERM 1
+    }
+
+    $COMMAND


### PR DESCRIPTION
Running glance-api as uwsgi process does not work. In the current setup, snapshots consistently fails with IOError on data read. Running it as non uwsgi process fixes this issue. Until we have more work done on uwsgi process to make it more stable we switch back to running it under normal eventlet python process.