### PR TITLE
feat: add kustomize to kube-ovn

### DIFF
--- a/base-kustomize/kube-ovn/base/kube-ovn-nodeSelector-patch.yaml
+++ b/base-kustomize/kube-ovn/base/kube-ovn-nodeSelector-patch.yaml
@@ -1,0 +1,5 @@
+- op: replace
+  path: "/spec/template/spec/nodeSelector"
+  value:
+    "kubernetes.io/os": "linux"
+    "kube-ovn/role": "master"

--- a/base-kustomize/kube-ovn/base/kustomization.yaml
+++ b/base-kustomize/kube-ovn/base/kustomization.yaml
@@ -1,0 +1,12 @@
+sortOptions:
+  order: fifo
+
+resources:
+  - all.yaml
+
+patches:
+  - path: kube-ovn-nodeSelector-patch.yaml
+    target:
+      kind: Deployment
+      name: kube-ovn-controller
+      namespace: kube-system

--- a/bin/install-kube-ovn.sh
+++ b/bin/install-kube-ovn.sh
@@ -37,6 +37,8 @@ for dir in "$GLOBAL_OVERRIDES_DIR" "$SERVICE_CONFIG_DIR"; do
     fi
 done
 
+HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
+HELM_CMD+=" --post-renderer-args kube-ovn/overlay"
 
 HELM_CMD+=" $@"
 


### PR DESCRIPTION
This will ensure that our deployment of kube-ovn-controller is scoped to only
nodes that are labled with the following labels:

* "kube-ovn/role": "master"
* "kubernetes.io/os": "linux"