### PR TITLE
chore: up the native workers for glance

### DIFF
--- a/base-helm-configs/glance/glance-helm-overrides.yaml
+++ b/base-helm-configs/glance/glance-helm-overrides.yaml
@@ -55,7 +55,7 @@ network_policy:
 conf:
   glance:
     DEFAULT:
-      workers: 2
+      workers: 8
       # NOTE(cloudnull): This option is required when using the new glance multi-backend feature.
       #                  The example below is for the rxt_swift backend, but could easily be used
       #                  for other backends.


### PR DESCRIPTION
Now that our glance service is running without uWSGI, we need to up the default workers so that it matches our default expectations.