### PR TITLE
fix: correctly non-set value to pick up openstack default

### DIFF
--- a/base-helm-configs/barbican/barbican-helm-overrides.yaml
+++ b/base-helm-configs/barbican/barbican-helm-overrides.yaml
@@ -33,7 +33,7 @@ conf:
       connection_recycle_time: 600
       connection_trace: true
       idle_timeout: 3600
-      mysql_sql_mode: ""
+      mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60
       max_retries: -1

--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -44,7 +44,7 @@ conf:
       connection_recycle_time: 600
       connection_trace: true
       idle_timeout: 3600
-      mysql_sql_mode: ""
+      mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60
       max_retries: -1

--- a/base-helm-configs/cinder/cinder-helm-overrides.yaml
+++ b/base-helm-configs/cinder/cinder-helm-overrides.yaml
@@ -93,7 +93,7 @@ conf:
       connection_recycle_time: 600
       connection_trace: true
       idle_timeout: 3600
-      mysql_sql_mode: ""
+      mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60
       max_retries: -1

--- a/base-helm-configs/designate/designate-helm-overrides.yaml
+++ b/base-helm-configs/designate/designate-helm-overrides.yaml
@@ -465,7 +465,7 @@ conf:
       connection_recycle_time: 600
       connection_trace: true
       idle_timeout: 3600
-      mysql_sql_mode: ""
+      mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60
       max_retries: -1

--- a/base-helm-configs/glance/glance-helm-overrides.yaml
+++ b/base-helm-configs/glance/glance-helm-overrides.yaml
@@ -91,7 +91,7 @@ conf:
       connection_recycle_time: 600
       connection_trace: true
       idle_timeout: 3600
-      mysql_sql_mode: ""
+      mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60
       max_retries: -1

--- a/base-helm-configs/heat/heat-helm-overrides.yaml
+++ b/base-helm-configs/heat/heat-helm-overrides.yaml
@@ -31,7 +31,7 @@ conf:
       connection_recycle_time: 600
       connection_trace: true
       idle_timeout: 3600
-      mysql_sql_mode: ""
+      mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60
       max_retries: -1

--- a/base-helm-configs/keystone/keystone-helm-overrides.yaml
+++ b/base-helm-configs/keystone/keystone-helm-overrides.yaml
@@ -42,7 +42,7 @@ conf:
       connection_recycle_time: 600
       connection_trace: true
       idle_timeout: 3600
-      mysql_sql_mode: ""
+      mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60
       max_retries: -1

--- a/base-helm-configs/magnum/magnum-helm-overrides.yaml
+++ b/base-helm-configs/magnum/magnum-helm-overrides.yaml
@@ -32,7 +32,7 @@ conf:
       connection_recycle_time: 600
       connection_trace: true
       idle_timeout: 3600
-      mysql_sql_mode: ""
+      mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60
       max_retries: -1

--- a/base-helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/base-helm-configs/neutron/neutron-helm-overrides.yaml
@@ -100,7 +100,7 @@ conf:
       connection_recycle_time: 600
       connection_trace: true
       idle_timeout: 3600
-      mysql_sql_mode: ""
+      mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60
       max_retries: -1

--- a/base-helm-configs/octavia/octavia-helm-overrides.yaml
+++ b/base-helm-configs/octavia/octavia-helm-overrides.yaml
@@ -1,23 +1,23 @@
 ---
 images:
   tags:
-    bootstrap: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
-    db_drop: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
-    db_init: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
-    dep_check: 'quay.io/rackspace/rackerlabs-kubernetes-entrypoint:latest-ubuntu_jammy'
-    image_repo_sync: 'quay.io/rackspace/rackerlabs-docker:17.07.0'
-    ks_endpoints: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
-    ks_service: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
-    ks_user: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
-    octavia_api: 'quay.io/rackspace/rackerlabs-octavia-ovn:2024.1-ubuntu_jammy-1737651745'
-    octavia_db_sync: 'quay.io/rackspace/rackerlabs-octavia-ovn:2024.1-ubuntu_jammy-1737651745'
-    octavia_health_manager: 'quay.io/rackspace/rackerlabs-octavia-ovn:2024.1-ubuntu_jammy-1737651745'
-    octavia_health_manager_init: 'quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy'
-    octavia_housekeeping: 'quay.io/rackspace/rackerlabs-octavia-ovn:2024.1-ubuntu_jammy-1737651745'
-    octavia_worker: 'quay.io/rackspace/rackerlabs-octavia-ovn:2024.1-ubuntu_jammy-1737651745'
-    openvswitch_vswitchd: 'docker.io/kolla/centos-source-openvswitch-vswitchd:rocky'
-    rabbit_init: 'quay.io/rackspace/rackerlabs-rabbitmq:3.13-management'
-    test: 'quay.io/rackspace/rackerlabs-xrally-openstack:2.0.0'
+    bootstrap: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
+    db_drop: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
+    db_init: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
+    dep_check: "quay.io/rackspace/rackerlabs-kubernetes-entrypoint:latest-ubuntu_jammy"
+    image_repo_sync: "quay.io/rackspace/rackerlabs-docker:17.07.0"
+    ks_endpoints: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
+    ks_service: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
+    ks_user: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
+    octavia_api: "quay.io/rackspace/rackerlabs-octavia-ovn:2024.1-ubuntu_jammy-1737651745"
+    octavia_db_sync: "quay.io/rackspace/rackerlabs-octavia-ovn:2024.1-ubuntu_jammy-1737651745"
+    octavia_health_manager: "quay.io/rackspace/rackerlabs-octavia-ovn:2024.1-ubuntu_jammy-1737651745"
+    octavia_health_manager_init: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
+    octavia_housekeeping: "quay.io/rackspace/rackerlabs-octavia-ovn:2024.1-ubuntu_jammy-1737651745"
+    octavia_worker: "quay.io/rackspace/rackerlabs-octavia-ovn:2024.1-ubuntu_jammy-1737651745"
+    openvswitch_vswitchd: "docker.io/kolla/centos-source-openvswitch-vswitchd:rocky"
+    rabbit_init: "quay.io/rackspace/rackerlabs-rabbitmq:3.13-management"
+    test: "quay.io/rackspace/rackerlabs-xrally-openstack:2.0.0"
 
 dependencies:
   static:
@@ -69,7 +69,7 @@ conf:
       connection_recycle_time: 600
       connection_trace: true
       idle_timeout: 3600
-      mysql_sql_mode: ""
+      mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60
       max_retries: -1
@@ -90,7 +90,7 @@ conf:
       endpoint_type: internalURL
       valid_interfaces: internal
     nova:
-      enable_anti_affinity: 'True'
+      enable_anti_affinity: "True"
       endpoint_type: internalURL
     oslo_concurrency:
       lock_path: /tmp/octavia
@@ -106,15 +106,15 @@ conf:
       # https://opendev.org/openstack/oslo.messaging/commit/36fb5bceabe08a982ebd52e4a8f005cd26fdf6b8
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
-       # NOTE (deprecation warning) heartbeat_in_pthread will be deprecated in 2024.2
+      # NOTE (deprecation warning) heartbeat_in_pthread will be deprecated in 2024.2
       heartbeat_in_pthread: True
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617
       kombu_reconnect_delay: 0.5
     ovn:
-      ovn_nb_connection: 'tcp:127.0.0.1:6641'
-      ovn_sb_connection: 'tcp:127.0.0.1:6642'
+      ovn_nb_connection: "tcp:127.0.0.1:6641"
+      ovn_sb_connection: "tcp:127.0.0.1:6642"
     service_auth:
       insecure: true
   octavia_api_uwsgi:

--- a/base-helm-configs/placement/placement-helm-overrides.yaml
+++ b/base-helm-configs/placement/placement-helm-overrides.yaml
@@ -54,7 +54,7 @@ conf:
       connection_recycle_time: 600
       connection_trace: true
       idle_timeout: 3600
-      mysql_sql_mode: ""
+      mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60
       max_retries: -1


### PR DESCRIPTION
In base-helm-configs, we are setting an empty string for the value of mysql_sql_mode.  This is incorrect as helm will try to pass an empty string literal ‘' to the service .conf file.  When the service attempts to make a database connection, it is passing mysql_sql_mode=’'.  when oslo.db is expecting a value to not be set.  

mysql_sql_mode[¶](https://docs.openstack.org/nova/2023.1/configuration/config.html#database.mysql_sql_mode)

The SQL mode to be used for MySQL sessions. This option, including the default, overrides any server-set SQL mode. To use whatever SQL mode is set by the server configuration, set this to no value. Example: mysql_sql_mode=