### PR TITLE
fix: (nova) empty list mysql_sql_mode to allow oslo.db to use databas…

### DIFF
--- a/base-helm-configs/nova/nova-helm-overrides.yaml
+++ b/base-helm-configs/nova/nova-helm-overrides.yaml
@@ -111,7 +111,7 @@ conf:
       connection_recycle_time: 600
       connection_trace: true
       idle_timeout: 3600
-      mysql_sql_mode: ""
+      mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60
       max_retries: -1
@@ -120,7 +120,7 @@ conf:
       connection_recycle_time: 600
       connection_trace: true
       idle_timeout: 3600
-      mysql_sql_mode: ""
+      mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60
       max_retries: -1
@@ -133,7 +133,7 @@ conf:
       connection_recycle_time: 600
       connection_trace: true
       idle_timeout: 3600
-      mysql_sql_mode: ""
+      mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60
       max_retries: -1


### PR DESCRIPTION
…e default

Missed this one in https://github.com/rackerlabs/genestack/pull/940.  This pr closes that gap.