### PR TITLE
Feat! (Glance): Add sane default policy for image download restrictions

### DIFF
--- a/base-helm-configs/glance/glance-helm-overrides.yaml
+++ b/base-helm-configs/glance/glance-helm-overrides.yaml
@@ -116,6 +116,13 @@ conf:
   glance_api_uwsgi:
     uwsgi:
       processes: 4
+  policy:
+    "admin_required": "role:admin or role:glance_admin"
+    "default": "role:admin or role:glance_admin"
+    "context_is_admin": "role:admin or role:glance_admin"
+    "publicize_image": "role:glance_admin"
+    "is_owner": "tenant:%(owner)s"
+    "download_image": "rule:is_owner or rule:context_is_admin"
   logging:
     logger_root:
       level: INFO

--- a/docs/openstack-glance.md
+++ b/docs/openstack-glance.md
@@ -30,6 +30,43 @@ OpenStack Glance is the image service within the OpenStack ecosystem, responsibl
 
     Before running the Glance deployment you should configure the backend which is defined in the `helm-configs/glance/glance-helm-overrides.yaml` file. The default is a making the assumption we're running with Ceph deployed by Rook so the backend is configured to be cephfs with multi-attach functionality. While this works great, you should consider all of the available storage backends and make the right decision for your environment.
 
+## Define policy configuration
+
+!!! note "Information about the default policy rules used"
+
+    The default policy allows only the glance_admin role to publicize images.
+    The default policy allows only the glance_admin role or owner role to download images.
+    These default policy roles are found in genestack/base-helm-configs/glance/glance-helm-overrides.yaml.
+    To modify these policies, follow the policy allow concepts in the 
+    "Policy change to allow admin or owner to publicize image" example.
+
+    ??? example "Default policy rules"
+
+        ``` yaml
+        conf:
+          policy:
+            "admin_required": "role:admin or role:glance_admin"
+            "default": "role:admin or role:glance_admin"
+            "context_is_admin": "role:admin or role:glance_admin"
+            "publicize_image": "role:glance_admin"
+            "is_owner": "tenant:%(owner)s"
+            "download_image": "rule:is_owner or rule:context_is_admin"
+        ```
+
+    ??? example "Policy change to allow admin or owner to publicize image"
+
+        ``` yaml
+        conf:
+          policy:
+            "admin_required": "role:admin or role:glance_admin"
+            "default": "role:admin or role:glance_admin"
+            "context_is_admin": "role:admin or role:glance_admin"
+            "is_owner": "tenant:%(owner)s"
+            "publicize_image": "rule:context_is_admin or role:is_owner"
+            "download_image": "rule:is_owner or rule:context_is_admin"
+        ```
+
+
 ## Run the package deployment
 
 !!! example "Run the Glance deployment Script `bin/install-glance.sh`"


### PR DESCRIPTION
Converting Flex policy to default Genestack Glance policy
    flex-host-baseline: 85113f87560d1be9eb36e8117d66b5476710f2b2

    feat(glance): image_download policy set to prevent export of Rackspace supplied images (#102)

    And allow tenants (within project) and glance admins to download the image.
    https://rackspace.atlassian.net/browse/OSPC-1210