### PR TITLE
modify prometheus blackbox exporter doc to source genestack.rc

### DIFF
--- a/docs/prometheus-blackbox-exporter.md
+++ b/docs/prometheus-blackbox-exporter.md
@@ -8,6 +8,7 @@ The blackbox exporter ideally would be ran outside the cluster but can still pro
 
 
 ``` shell
+source /opt/genestack/scripts/genestack.rc
 bin/install-chart.sh prometheus-blackbox-exporter
 ```
 


### PR DESCRIPTION
before running install-chart.sh shell script; genestack.rc script is required to be sourced otherwise the script will fail with permission-denied errors