### PR TITLE
docs: Add tip about creating the creator role

### DIFF
--- a/docs/openstack-keystone-federation.md
+++ b/docs/openstack-keystone-federation.md
@@ -24,6 +24,16 @@ You're also welcome to generate your own mapping to suit your needs; however, if
 
 The example mapping **JSON** file can be found within the genestack repository at `/opt/genestack/etc/keystone/mapping.json`.
 
+!!! tip "Creating the `creator` role"
+
+    The creator role does not exist by default, but is included in the example
+    mapping. One must create the creator role in order to prevent authentication
+    errors if using the mapping "as is".
+
+    ``` shell
+    openstack --os-cloud default role create creator
+    ```
+
 ## Now register the mapping within Keystone
 
 ``` shell


### PR DESCRIPTION
The default example mapping includes the "creator" role, but it does not exist by default after completing most of the OpenStack setup. To avoid errors when logging in with a valid Rackspace username/password, manually create the "creator" role. Without it, Keystone will return the following error:

> ERROR keystone.auth.plugins.mapped [None-4e390453-680f-4a5d-a315-2a0ac7693033 - - - - - -] Role creator was specified in the mapping but does not exist. All roles specified in a mapping must exist before assignment.