### PR TITLE
chore: patch the heat liveness probes

### DIFF
--- a/base-kustomize/heat/base/kustomization.yaml
+++ b/base-kustomize/heat/base/kustomization.yaml
@@ -7,3 +7,37 @@ resources:
   - hpa-heat-api.yaml
   - hpa-heat-cfn.yaml
   - hpa-heat-engine.yaml
+
+patches:
+  - target:
+      kind: Deployment
+      name: heat-api
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/livenessProbe
+        value:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 8004
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 120
+  - target:
+      kind: Deployment
+      name: heat-cfn
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/livenessProbe
+        value:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 8004
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 120


### PR DESCRIPTION
The heat liveness probes are failing too fast, especially when the cluster is busy. This change extends the liveness probes so that they're not creating a problem when the cluster is under load.