### PR TITLE
FIX (ansible): cinder deployment playbooks need to use inventory_host…

### DIFF
--- a/ansible/playbooks/deploy-cinder-netapp-volumes-reference.yaml
+++ b/ansible/playbooks/deploy-cinder-netapp-volumes-reference.yaml
@@ -139,7 +139,7 @@
         path: "/etc/cinder/cinder.conf.stage"
         section: DEFAULT
         option: host
-        value: "{{ ansible_fqdn }}"
+        value: "{{ inventory_hostname }}"
         create: true
 
     - name: Create the cinder-volume-netapp configuration stage file

--- a/ansible/playbooks/deploy-cinder-volumes-reference.yaml
+++ b/ansible/playbooks/deploy-cinder-volumes-reference.yaml
@@ -157,7 +157,7 @@
         path: "/etc/cinder/cinder.conf.stage"
         section: DEFAULT
         option: host
-        value: "{{ ansible_fqdn }}"
+        value: "{{ inventory_hostname }}"
         create: true
 
     - name: Ensure the backend configuration is set to our expected value


### PR DESCRIPTION
…name

This fix replace ansible_fqdn that relies on the order of the 127.0.0.1 line in the /etc/hosts file and is prone to using 'localhost.localdomain' rather than the actual hostname in cinder.conf. Using inventory_hostname ensures that the actual hostname is used. Tested in new Flex deploy--correct behavior observed with change.

https://rackspace.atlassian.net/browse/OSPC-1309