### PR TITLE
modify characters '-' to '_' in ironic db and rabbitmq passwords

### DIFF
--- a/bin/create-secrets.sh
+++ b/bin/create-secrets.sh
@@ -94,8 +94,8 @@ ceilometer_rabbitmq_password=$(generate_password 32)
 memcached_shared_secret=$(generate_password 32)
 grafana_secret=$(generate_password 32)
 grafana_root_secret=$(generate_password 32)
-ironic-db-password=$(generate_password 32)
-ironic-rabbitmq-password=$(generate_password 32)
+ironic_db_password=$(generate_password 32)
+ironic_rabbitmq_password=$(generate_password 32)
 
 OUTPUT_FILE="/etc/genestack/kubesecrets.yaml"
 


### PR DESCRIPTION
modify the "ironic-db-password" and "ironic-rabbitmq-password" variables to "ironic_db_password" and "ironic_rabbitmq_password" otherwise the create-secrets.sh script fails and no passwords for ironic are created