### PR TITLE
chore: (python-openstackclient) update minimium version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ ruamel.yaml==0.18.6
 ruamel.yaml.clib==0.2.8
 kubernetes>=24.2.0
 openstacksdk>=1.0.0
-python-openstackclient==6.3.0
+python-openstackclient==7.4.0


### PR DESCRIPTION
Keystome mapping requires a more current python-openstackclient.  This pr ups the python-openstackclient version to 7.4.0
