### PR TITLE
feat: add new image for keystone that supports rbac

### DIFF
--- a/.original-images.json
+++ b/.original-images.json
@@ -32,7 +32,7 @@
   "ghcr.io/rackerlabs/genestack/neutron-oslodb:2024.1-ubuntu_jammy-1742943886",
   "ghcr.io/rackerlabs/genestack/nova-efi:2024.1-ubuntu_jammy-1737928811",
   "ghcr.io/rackerlabs/genestack/octavia-ovn:2024.1-ubuntu_jammy-1737651745",
-  "ghcr.io/rackerlabs/keystone-rxt:2024.1-ubuntu_jammy-1739377879",
+  "ghcr.io/rackerlabs/keystone-rxt:2024.1-ubuntu_jammy-1747061260",
   "ghcr.io/rackerlabs/skyline-rxt:master-ubuntu_jammy-1739967315",
   "docker.io/openstackhelm/ironic:2024.1-ubuntu_jammy",
   "ghcr.io/vexxhost/netoffload:v1.0.1",

--- a/etc/keystone/mapping.json
+++ b/etc/keystone/mapping.json
@@ -29,20 +29,7 @@
                                 "project_tag": "{3}"
                             }
                         ],
-                        "roles": [
-                            {
-                                "name": "member"
-                            },
-                            {
-                                "name": "load-balancer_member"
-                            },
-                            {
-                                "name": "heat_stack_user"
-                            },
-                            {
-                                "name": "creator"
-                            }
-                        ]
+                        "roles": []
                     }
                 ]
             }
@@ -63,10 +50,9 @@
             {
                 "type": "RXT_orgPersonType",
                 "any_one_of": [
-                    "admin",
-                    "default",
-                    "user-admin",
-                    "tenant-access"
+                    "creator",
+                    "member",
+                    "reader"
                 ]
             }
         ]


### PR DESCRIPTION
This change implements a new keystone image that has deep support for role based access as defined by global auth.