### PR TITLE
chore: (hpa) convert to using cpu metrics over mem metrics

### DIFF
--- a/base-helm-configs/barbican/barbican-helm-overrides.yaml
+++ b/base-helm-configs/barbican/barbican-helm-overrides.yaml
@@ -14,6 +14,10 @@ images:
     rabbit_init: "quay.io/rackspace/rackerlabs-rabbitmq:3.13-management"
     scripted_test: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
 
+pod:
+  resources:
+    enabled: true
+
 dependencies:
   static:
     db_sync:

--- a/base-helm-configs/cinder/cinder-helm-overrides.yaml
+++ b/base-helm-configs/cinder/cinder-helm-overrides.yaml
@@ -27,6 +27,8 @@ images:
     test: "quay.io/rackspace/rackerlabs-xrally-openstack:2.0.0"
 
 pod:
+  resources:
+    enabled: true
   security_context:
     cinder_api:
       container:

--- a/base-helm-configs/glance/glance-helm-overrides.yaml
+++ b/base-helm-configs/glance/glance-helm-overrides.yaml
@@ -236,6 +236,8 @@ endpoints:
         service: 80
 
 pod:
+  resources:
+    enabled: true
   replicas:
     api: 1
   lifecycle:
@@ -266,8 +268,6 @@ pod:
             initialDelaySeconds: 30
             periodSeconds: 15
             timeoutSeconds: 10
-  resources:
-    enabled: false
 
 manifests:
   ingress_api: false

--- a/base-helm-configs/gnocchi/gnocchi-helm-overrides.yaml
+++ b/base-helm-configs/gnocchi/gnocchi-helm-overrides.yaml
@@ -88,6 +88,8 @@ conf:
     update archive policy rule: "role:admin"
 
 pod:
+  resources:
+    enabled: true
   lifecycle:
     upgrades:
       daemonsets:

--- a/base-helm-configs/heat/heat-helm-overrides.yaml
+++ b/base-helm-configs/heat/heat-helm-overrides.yaml
@@ -19,6 +19,10 @@ images:
     rabbit_init: "quay.io/rackspace/rackerlabs-rabbitmq:3.13-management"
     test: "quay.io/rackspace/rackerlabs-xrally-openstack:2.0.0"
 
+pod:
+  resources:
+    enabled: true
+
 conf:
   heat:
     DEFAULT:

--- a/base-helm-configs/horizon/horizon-helm-overrides.yaml
+++ b/base-helm-configs/horizon/horizon-helm-overrides.yaml
@@ -9,6 +9,10 @@ images:
     dep_check: "quay.io/rackspace/rackerlabs-kubernetes-entrypoint:latest-ubuntu_jammy"
     image_repo_sync: "quay.io/rackspace/rackerlabs-docker:17.07.0"
 
+pod:
+  resources:
+    enabled: true
+
 conf:
   horizon:
     branding:

--- a/base-helm-configs/ironic/ironic-helm-overrides.yaml
+++ b/base-helm-configs/ironic/ironic-helm-overrides.yaml
@@ -4,7 +4,6 @@
 # Date: April 03, 2025
 
 ---
-
 images:
   tags:
     ironic_manage_cleaning_network: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
@@ -22,7 +21,7 @@ images:
     ironic_conductor: "quay.io/rackspace/rackerlabs-ironic:2024.1-ubuntu_jammy"
     ironic_pxe: "quay.io/rackspace/rackerlabs-ironic:2024.1-ubuntu_jammy"
     ironic_pxe_init: "quay.io/rackspace/rackerlabs-ironic:2024.1-ubuntu_jammy"
-    ironic_pxe_http: "docker.io/nginx:1.13.3"  # Retained from openstack-helm default
+    ironic_pxe_http: "docker.io/nginx:1.13.3" # Retained from openstack-helm default
     ironic_inspector: "quay.io/rackspace/rackerlabs-ironic-inspector:2024.1-ubuntu_jammy"
     ironic_inspector_db_sync: "quay.io/rackspace/rackerlabs-ironic-inspector:2024.1-ubuntu_jammy"
     dep_check: "quay.io/rackspace/rackerlabs-kubernetes-entrypoint:latest-ubuntu_jammy"
@@ -33,7 +32,7 @@ conf:
   ironic:
     DEFAULT:
       log_config_append: /etc/ironic/logging.conf
-      tempdir: /var/lib/openstack-helm/tmp  # Matches openstack-helm default
+      tempdir: /var/lib/openstack-helm/tmp # Matches openstack-helm default
       default_deploy_interface: "direct"
       default_inspect_interface: "inspector"
       default_network_interface: "neutron"
@@ -76,7 +75,7 @@ conf:
       rabbit_interval_max: 10
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
-      heartbeat_in_pthread: True  # Note: Deprecation warning for 2024.2
+      heartbeat_in_pthread: True # Note: Deprecation warning for 2024.2
       kombu_reconnect_delay: 0.5
     pxe:
       pxe_append_params: "nofb nomodeset vga=normal ipa-debug=1"
@@ -111,7 +110,7 @@ network:
     neutron_subnet_cidr: 172.24.6.0/24
     neutron_subnet_alloc_start: 172.24.6.100
     neutron_subnet_alloc_end: 172.24.6.200
-    neutron_subnet_dns_nameserver: 8.8.8.8  # Aligned with Neutron's OVN DNS
+    neutron_subnet_dns_nameserver: 8.8.8.8 # Aligned with Neutron's OVN DNS
 
 dependencies:
   static:
@@ -219,6 +218,8 @@ endpoints:
         default: 5672
 
 pod:
+  resources:
+    enabled: true
   replicas:
     api: 1
     conductor: 1

--- a/base-helm-configs/keystone/keystone-helm-overrides.yaml
+++ b/base-helm-configs/keystone/keystone-helm-overrides.yaml
@@ -18,6 +18,10 @@ images:
     rabbit_init: "quay.io/rackspace/rackerlabs-rabbitmq:3.13-management"
     test: "quay.io/rackspace/rackerlabs-xrally-openstack:2.0.0"
 
+pod:
+  resources:
+    enabled: true
+
 dependencies:
   static:
     db_sync:

--- a/base-helm-configs/magnum/magnum-helm-overrides.yaml
+++ b/base-helm-configs/magnum/magnum-helm-overrides.yaml
@@ -14,6 +14,10 @@ images:
     magnum_db_sync: "quay.io/rackspace/rackerlabs-magnum:2024.1-ubuntu_jammy"
     rabbit_init: "quay.io/rackspace/rackerlabs-rabbitmq:3.13-management"
 
+pod:
+  resources:
+    enabled: true
+
 conf:
   logging:
     logger_root:

--- a/base-helm-configs/memcached/memcached-helm-overrides.yaml
+++ b/base-helm-configs/memcached/memcached-helm-overrides.yaml
@@ -213,6 +213,7 @@ lifecycleHooks: {}
 ## @param resources.requests.cpu The requested cpu for the Memcached containers
 ##
 resources:
+  enabled: true
   limits: {}
   requests:
     memory: 1G

--- a/base-helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/base-helm-configs/neutron/neutron-helm-overrides.yaml
@@ -65,6 +65,8 @@ dependencies:
         - neutron-ks-endpoints
 
 pod:
+  resources:
+    enabled: true
   use_fqdn:
     neutron_agent: false
 

--- a/base-helm-configs/nova/nova-helm-overrides.yaml
+++ b/base-helm-configs/nova/nova-helm-overrides.yaml
@@ -280,6 +280,8 @@ endpoints:
         service: 8778
 
 pod:
+  resources:
+    enabled: true  
   probes:
     rpc_retries: 3
   security_context:

--- a/base-helm-configs/octavia/octavia-helm-overrides.yaml
+++ b/base-helm-configs/octavia/octavia-helm-overrides.yaml
@@ -178,6 +178,8 @@ endpoints:
       default: rabbitmq-nodes
 
 pod:
+  resources:
+    enabled: true
   affinity:
     anti:
       weight:

--- a/base-helm-configs/placement/placement-helm-overrides.yaml
+++ b/base-helm-configs/placement/placement-helm-overrides.yaml
@@ -11,6 +11,10 @@ images:
     placement: "quay.io/rackspace/rackerlabs-placement:2024.1-ubuntu_jammy"
     placement_db_sync: "quay.io/rackspace/rackerlabs-placement:2024.1-ubuntu_jammy"
 
+pod:
+  resources:
+    enabled: true
+
 conf:
   logging:
     logger_root:

--- a/base-kustomize/barbican/base/hpa-barbican-api.yaml
+++ b/base-kustomize/barbican/base/hpa-barbican-api.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          type: AverageValue
-          averageValue: 500Mi
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/ceilometer/base/hpa-ceilometer-notification.yaml
+++ b/base-kustomize/ceilometer/base/hpa-ceilometer-notification.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          type: AverageValue
-          averageValue: 500Mi
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/cinder/base/hpa-cinder-api.yaml
+++ b/base-kustomize/cinder/base/hpa-cinder-api.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          type: AverageValue
-          averageValue: 500Mi
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/cinder/base/hpa-cinder-scheduler.yaml
+++ b/base-kustomize/cinder/base/hpa-cinder-scheduler.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          type: AverageValue
-          averageValue: 500Mi
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/designate/base/hpa-designate-api.yaml
+++ b/base-kustomize/designate/base/hpa-designate-api.yaml
@@ -10,14 +10,8 @@ spec:
     - resource:
         name: cpu
         target:
-          averageUtilization: 50
+          averageUtilization: 70
           type: Utilization
-      type: Resource
-    - resource:
-        name: memory
-        target:
-          type: AverageValue
-          averageValue: 500Mi
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/glance/base/hpa-glance-api.yaml
+++ b/base-kustomize/glance/base/hpa-glance-api.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
-        target:
-          type: AverageValue
-          averageValue: 500Mi
+      name: cpu
+      target:
+        averageUtilization: 70
+        type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/gnocchi/base/hpa-gnocchi-api.yaml
+++ b/base-kustomize/gnocchi/base/hpa-gnocchi-api.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          type: AverageValue
-          averageValue: 500Mi
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/heat/base/hpa-heat-api.yaml
+++ b/base-kustomize/heat/base/hpa-heat-api.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          type: AverageValue
-          averageValue: 500Mi
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/heat/base/hpa-heat-cfn.yaml
+++ b/base-kustomize/heat/base/hpa-heat-cfn.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          type: AverageValue
-          averageValue: 500Mi
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/heat/base/hpa-heat-engine.yaml
+++ b/base-kustomize/heat/base/hpa-heat-engine.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          type: AverageValue
-          averageValue: 500Mi
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/horizon/base/hpa-horizon-api.yaml
+++ b/base-kustomize/horizon/base/hpa-horizon-api.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          type: AverageValue
-          averageValue: 500Mi
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/ironic/base/hpa-iconic-conductor.yaml
+++ b/base-kustomize/ironic/base/hpa-iconic-conductor.yaml
@@ -10,7 +10,7 @@ spec:
     - resource:
         name: cpu
         target:
-          averageUtilization: 50
+          averageUtilization: 70
           type: Utilization
       type: Resource
   scaleTargetRef:

--- a/base-kustomize/ironic/base/hpa-ironic-api.yaml
+++ b/base-kustomize/ironic/base/hpa-ironic-api.yaml
@@ -10,7 +10,7 @@ spec:
     - resource:
         name: cpu
         target:
-          averageUtilization: 50
+          averageUtilization: 70
           type: Utilization
       type: Resource
   scaleTargetRef:

--- a/base-kustomize/keystone/base/hpa-keystone-api.yaml
+++ b/base-kustomize/keystone/base/hpa-keystone-api.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          type: AverageValue
-          averageValue: 500Mi
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/magnum/base/hpa-magnum-api.yaml
+++ b/base-kustomize/magnum/base/hpa-magnum-api.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          type: AverageValue
-          averageValue: 500Mi
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/magnum/base/hpa-magnum-conductor.yaml
+++ b/base-kustomize/magnum/base/hpa-magnum-conductor.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          type: AverageValue
-          averageValue: 1Gi
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/neutron/base/hpa-neutron-rpc-server.yaml
+++ b/base-kustomize/neutron/base/hpa-neutron-rpc-server.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          type: AverageValue
-          averageValue: 2Gi
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/neutron/base/hpa-neutron-server.yaml
+++ b/base-kustomize/neutron/base/hpa-neutron-server.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          type: AverageValue
-          averageValue: 2Gi
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/nova/base/hpa-nova-api-metadata.yaml
+++ b/base-kustomize/nova/base/hpa-nova-api-metadata.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          type: AverageValue
-          averageValue: 500Mi
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/nova/base/hpa-nova-api-osapi.yaml
+++ b/base-kustomize/nova/base/hpa-nova-api-osapi.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          type: AverageValue
-          averageValue: 500Mi
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/nova/base/hpa-nova-conductor.yaml
+++ b/base-kustomize/nova/base/hpa-nova-conductor.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          type: AverageValue
-          averageValue: 500Mi
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/nova/base/hpa-nova-novncproxy.yaml
+++ b/base-kustomize/nova/base/hpa-nova-novncproxy.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          type: AverageValue
-          averageValue: 500Mi
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/nova/base/hpa-nova-scheduler.yaml
+++ b/base-kustomize/nova/base/hpa-nova-scheduler.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          type: AverageValue
-          averageValue: 1Gi
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/octavia/base/hpa-octavia-api.yaml
+++ b/base-kustomize/octavia/base/hpa-octavia-api.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          averageValue: 2200Mi
-          type: Value
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/octavia/base/hpa-octavia-worker.yaml
+++ b/base-kustomize/octavia/base/hpa-octavia-worker.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          averageValue: 500Mi
-          type: Value
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/placement/base/hpa-placement-api.yaml
+++ b/base-kustomize/placement/base/hpa-placement-api.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          averageValue: 500Mi
-          type: Value
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1

--- a/base-kustomize/skyline/base/hpa-skyline-apiserver.yaml
+++ b/base-kustomize/skyline/base/hpa-skyline-apiserver.yaml
@@ -8,10 +8,10 @@ spec:
   minReplicas: 3
   metrics:
     - resource:
-        name: memory
+        name: cpu
         target:
-          averageValue: 500Mi
-          type: Value
+          averageUtilization: 70
+          type: Utilization
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
Currently we are using memory metrics for HPA.  However, with the nature of OpenStack services being fairly static from a memory consumption standpoint (certain number of processes running a certain number of threads equals fairly static run time memory consumption) we need a different way to identify load on services.  By converting to CPU bases limits for HPA, we allow for scaling when the service is under load.  

This PR is a first attempt at tuning genestack for CPU based HPA.