### PR TITLE
OSPC-1208: Fix for view and delete certificate on network section

### DIFF
--- a/base-helm-configs/barbican/barbican-helm-overrides.yaml
+++ b/base-helm-configs/barbican/barbican-helm-overrides.yaml
@@ -76,6 +76,9 @@ conf:
       handlers:
         - stdout
       level: INFO
+  policy:
+    "container:get": "rule:container_project_admin or (rule:container_project_member and rule:container_owner) or (rule:container_project_member and rule:container_is_not_private) or rule:container_acl_read  or role:creator"
+    "container:delete": "rule:container_project_admin or (rule:container_project_member and rule:container_owner) or (rule:container_project_member and rule:container_is_not_private) or role:creator"
 
 endpoints:
   fluentd:


### PR DESCRIPTION
Added the container:get and container:delete policy.
To view and delete the certificate from the skyline-console for a non-admin user.

Have added the  attached snapshot for it.
I have tested in my local under a project test-1, both view and delete operation are successful.

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/14c77495-84ca-4ef4-904e-be61136ec8b6" />
