### PR TITLE
Add Masakari to Genestack

### DIFF
--- a/.github/workflows/release-cinder-netapp.yml
+++ b/.github/workflows/release-cinder-netapp.yml
@@ -1,5 +1,5 @@
 #
-name: Create and publish a the Cinder RXT compatible image
+name: Create and publish a Cinder RXT compatible image
 
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:

--- a/.github/workflows/release-glance.yml
+++ b/.github/workflows/release-glance.yml
@@ -1,5 +1,5 @@
 #
-name: Create and publish a the Glance compatible image
+name: Create and publish a Glance compatible image
 
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:

--- a/.github/workflows/release-horizon-rxt.yml
+++ b/.github/workflows/release-horizon-rxt.yml
@@ -1,5 +1,5 @@
 #
-name: Create and publish a the Horizon RXT compatible image
+name: Create and publish a Horizon RXT compatible image
 
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:

--- a/.github/workflows/release-neutron-oslodb.yaml
+++ b/.github/workflows/release-neutron-oslodb.yaml
@@ -1,5 +1,5 @@
 #
-name: Create and publish a the Neutron oslodb patched image
+name: Create and publish a Neutron oslodb patched image
 
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:

--- a/.github/workflows/release-nova-oslodb.yaml
+++ b/.github/workflows/release-nova-oslodb.yaml
@@ -1,5 +1,5 @@
 #
-name: Create and publish a the Nova oslodb patched image
+name: Create and publish a Nova oslodb patched image
 
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:

--- a/.github/workflows/release-octavia-ovn.yml
+++ b/.github/workflows/release-octavia-ovn.yml
@@ -1,4 +1,4 @@
-name: Create and publish a the Octavia compatible image
+name: Create and publish an Octavia compatible image
 
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:

--- a/.github/workflows/smoke-deploy-lab.yaml
+++ b/.github/workflows/smoke-deploy-lab.yaml
@@ -1,6 +1,44 @@
 name: Running hyperconverged smoke tests
 
 on:
+  workflow_dispatch:
+    inputs:
+      acmeEmail:
+        description: Set email for ACME
+        required: true
+        default: "cloud@example.local"
+        type: string
+      gatewayDomain:
+        description: Set domain for the gateway
+        required: true
+        default: master
+        type: string
+      osImage:
+        description: Set OS image
+        required: true
+        default: "Ubuntu 24.04"
+        type: choice
+        options:
+          - "Ubuntu 24.04"
+          - "Ubuntu 22.04"
+          - "Debian 12"
+      sshUsername:
+        description: Set SSH username
+        required: true
+        default: "ubuntu"
+        type: choice
+        options:
+          - "ubuntu"
+          - "debian"
+      mode:
+        description: Set mode
+        required: true
+        default: "test"
+        type: choice
+        options:
+          - "test"
+          - "deploy"
+          - "cleanup"
   pull_request:
     paths:
       - ansible/**
@@ -8,6 +46,7 @@ on:
       - base-helm-configs/**
       - bin/**
       - scripts/**
+      - ".github/workflows/smoke-deploy-lab.yaml"
 
 env:
   HYPERCONVERGED_DEV: "true"
@@ -26,13 +65,24 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Dynamically set MY_DATE environment variable
+        if: ${{ github.event_name == 'pull_request' }}
         run: echo "LAB_NAME_PREFIX=smoke-$(date +%s)" >> $GITHUB_ENV
 
+      - name: Statically set environment variable
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "LAB_NAME_PREFIX=${{ github.event.inputs.mode }}-$(date +%s)" >> $GITHUB_ENV
+          echo "GATEWAY_DOMAIN=${{ github.event.inputs.gatewayDomain }}-$(date +%s)" >> $GITHUB_ENV
+          echo "ACME_EMAIL=${{ github.event.inputs.acmeEmail }}-$(date +%s)" >> $GITHUB_ENV
+          echo "OS_IMAGE=${{ github.event.inputs.osImage }}-$(date +%s)" >> $GITHUB_ENV
+          echo "SSH_USERNAME=${{ github.event.inputs.sshUsername }}-$(date +%s)" >> $GITHUB_ENV
+
       - name: Run deployment script
+        if: ${{ github.event_name == 'pull_request' || contains(fromJSON('["deploy", "test"]'), github.event.inputs.mode) }}
         run: |
           eval "$(ssh-agent -s)"
           scripts/hyperconverged-lab.sh
 
       - name: Cleanup the lab
-        if: always()
+        if: ${{ always() && (github.event_name == 'pull_request' || contains(fromJSON('["cleanup", "test"]'), github.event.inputs.mode)) }}
         run: scripts/hyperconverged-lab-uninstall.sh

--- a/base-helm-configs/keystone/keystone-helm-overrides-saml.yaml.example
+++ b/base-helm-configs/keystone/keystone-helm-overrides-saml.yaml.example
@@ -1,0 +1,85 @@
+---
+conf:
+  software:
+    apache2:
+      a2enmod:
+        - shib
+  keystone:
+    auth:
+      methods: "password,token,saml2,application_credential,totp"
+    saml2:
+      remote_id_attribute: Shib-Identity-Provider
+    federation:
+      trusted_dashboard:
+        type: multistring
+        values:
+          - https://skyline.api.example.com/api/openstack/skyline/api/v1/websso
+          - https://horizon.api.example.com/auth/websso
+  wsgi_keystone: |
+    {{- $portInt := tuple "identity" "service" "api" $ | include "helm-toolkit.endpoints.endpoint_port_lookup" }}
+
+    Listen 0.0.0.0:{{ $portInt }}
+
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy
+
+    SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+    CustomLog /dev/stdout combined env=!forwarded
+    CustomLog /dev/stdout proxy env=forwarded
+
+    <VirtualHost *:{{ $portInt }}>
+        ServerName https://keystone.api.example.com:443
+        UseCanonicalName On
+
+        WSGIDaemonProcess keystone-public processes={{ .Values.conf.keystone_api_wsgi.wsgi.processes }} threads={{ .Values.conf.keystone_api_wsgi.wsgi.threads }} user=keystone group=keystone display-name=%{GROUP}
+        WSGIProcessGroup keystone-public
+        WSGIScriptAlias / /var/www/cgi-bin/keystone/keystone-wsgi-public
+        WSGIScriptAliasMatch ^(/v3/OS-FEDERATION/identity_providers/IDENTITY_PROVIDER_NAME/protocols/saml2/auth)$ /var/www/cgi-bin/keystone/keystone-wsgi-public/$1
+        WSGIApplicationGroup %{GLOBAL}
+        WSGIPassAuthorization On
+        LimitRequestBody 114688
+
+        <IfVersion >= 2.4>
+          ErrorLogFormat "%{cu}t %M"
+        </IfVersion>
+        ErrorLog /dev/stdout
+
+        SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+        CustomLog /dev/stdout combined env=!forwarded
+        CustomLog /dev/stdout proxy env=forwarded
+
+        <Location /Shibboleth.sso>
+            SetHandler shib
+        </Location>
+        <Location /v3/OS-FEDERATION/identity_providers/IDENTITY_PROVIDER_NAME/protocols/saml2/auth>
+            Require valid-user
+            AuthType shibboleth
+            ShibRequestSetting requireSession 1
+            ShibExportAssertion off
+            <IfVersion < 2.4>
+                ShibRequireSession On
+                ShibRequireAll On
+            </IfVersion>
+        </Location>
+        RedirectMatch ^/v3/auth/OS-FEDERATION/websso/IDENTITY_PROVIDER_NAME$ /v3/auth/OS-FEDERATION/websso/saml2
+        <Location /v3/auth/OS-FEDERATION/websso/saml2>
+            Require valid-user
+            AuthType shibboleth
+            ShibRequestSetting requireSession 1
+            ShibExportAssertion off
+            <IfVersion < 2.4>
+                ShibRequireSession On
+                ShibRequireAll On
+            </IfVersion>
+        </Location>
+        <Location /v3/auth/OS-FEDERATION/identity_providers/IDENTITY_PROVIDER_NAME/protocols/saml2/websso>
+            Require valid-user
+            AuthType shibboleth
+            ShibRequestSetting requireSession 1
+            ShibExportAssertion off
+            <IfVersion < 2.4>
+                ShibRequireSession On
+                ShibRequireAll On
+            </IfVersion>
+        </Location>
+    </VirtualHost>

--- a/base-helm-configs/keystone/keystone-helm-overrides.yaml
+++ b/base-helm-configs/keystone/keystone-helm-overrides.yaml
@@ -6,14 +6,14 @@ images:
     db_init: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
     dep_check: "quay.io/rackspace/rackerlabs-kubernetes-entrypoint:latest-ubuntu_jammy"
     image_repo_sync: "quay.io/rackspace/rackerlabs-docker:17.07.0"
-    keystone_api: "quay.io/rackspace/rackerlabs-keystone-rxt:2024.1-ubuntu_jammy-1747934956"
+    keystone_api: "quay.io/rackspace/rackerlabs-keystone-rxt:2024.1-ubuntu_jammy-1747958291"
     keystone_credential_cleanup: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
-    keystone_credential_rotate: "quay.io/rackspace/rackerlabs-keystone-rxt:2024.1-ubuntu_jammy-1747934956"
-    keystone_credential_setup: "quay.io/rackspace/rackerlabs-keystone-rxt:2024.1-ubuntu_jammy-1747934956"
-    keystone_db_sync: "quay.io/rackspace/rackerlabs-keystone-rxt:2024.1-ubuntu_jammy-1747934956"
-    keystone_domain_manage: "quay.io/rackspace/rackerlabs-keystone-rxt:2024.1-ubuntu_jammy-1747934956"
-    keystone_fernet_rotate: "quay.io/rackspace/rackerlabs-keystone-rxt:2024.1-ubuntu_jammy-1747934956"
-    keystone_fernet_setup: "quay.io/rackspace/rackerlabs-keystone-rxt:2024.1-ubuntu_jammy-1747934956"
+    keystone_credential_rotate: "quay.io/rackspace/rackerlabs-keystone-rxt:2024.1-ubuntu_jammy-1747958291"
+    keystone_credential_setup: "quay.io/rackspace/rackerlabs-keystone-rxt:2024.1-ubuntu_jammy-1747958291"
+    keystone_db_sync: "quay.io/rackspace/rackerlabs-keystone-rxt:2024.1-ubuntu_jammy-1747958291"
+    keystone_domain_manage: "quay.io/rackspace/rackerlabs-keystone-rxt:2024.1-ubuntu_jammy-1747958291"
+    keystone_fernet_rotate: "quay.io/rackspace/rackerlabs-keystone-rxt:2024.1-ubuntu_jammy-1747958291"
+    keystone_fernet_setup: "quay.io/rackspace/rackerlabs-keystone-rxt:2024.1-ubuntu_jammy-1747958291"
     ks_user: "quay.io/rackspace/rackerlabs-heat:2024.1-ubuntu_jammy"
     rabbit_init: "quay.io/rackspace/rackerlabs-rabbitmq:3.13-management"
     test: "quay.io/rackspace/rackerlabs-xrally-openstack:2.0.0"
@@ -111,6 +111,7 @@ conf:
         WSGIApplicationGroup %{GLOBAL}
         WSGIPassAuthorization On
         LimitRequestBody 114688
+
         <IfVersion >= 2.4>
           ErrorLogFormat "%{cu}t %M"
         </IfVersion>

--- a/base-helm-configs/masakari/masakari-helm-overrides.yaml
+++ b/base-helm-configs/masakari/masakari-helm-overrides.yaml
@@ -1,0 +1,264 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+images:
+  tags:
+    db_init: quay.io/airshipit/heat:2024.1-ubuntu_jammy
+    db_sync: docker.io/openstackhelm/masakari:2024.1-ubuntu_jammy
+    db_drop: quay.io/airshipit/heat:2024.1-ubuntu_jammy
+    ks_endpoints: quay.io/airshipit/heat:2024.1-ubuntu_jammy
+    ks_service: quay.io/airshipit/heat:2024.1-ubuntu_jammy
+    ks_user: quay.io/airshipit/heat:2024.1-ubuntu_jammy
+    masakari_api: quay.io/rackspace/rackerlabs-masakari:2024.1-ubuntu_jammy
+    masakari_engine: quay.io/rackspace/rackerlabs-masakari:2024.1-ubuntu_jammy
+    #TEMP HOST-MONITOR IMAGE TO FIX: https://github.com/zhmarvi/masakari-monitors/tree/kubernetes_check_status 
+    masakari_host_monitor: kernelpanic53/rackerlabs-masakari-monitors:zhmarvi-ubuntu_jammy_v1.0
+    masakari_process_monitor: quay.io/rackspace/rackerlabs-masakari-monitors:2024.1-ubuntu_jammy
+    masakari_instance_monitor: quay.io/rackspace/rackerlabs-masakari-monitors:2024.1-ubuntu_jammy
+    rabbit_init: docker.io/rabbitmq:3.13-management
+    dep_check: quay.io/airshipit/kubernetes-entrypoint:latest-ubuntu_focal
+  pull_policy: "IfNotPresent"
+  local_registry:
+    active: false
+    exclude:
+      - dep_check
+      - image_repo_sync
+
+labels:
+  masakari:
+    node_selector_key: openstack-control-plane
+    node_selector_value: enabled
+  job:
+    node_selector_key: openstack-control-plane
+    node_selector_value: enabled
+  monitors:
+    node_selector_key: openstack-compute-node
+    node_selector_value: enabled
+  test:
+    node_selector_key: openstack-control-plane
+    node_selector_value: enabled
+endpoints:
+  identiy:
+    port:
+      api:
+        default: 5000
+        internal: 5000
+        public: 80
+        service: 5000
+  instance_ha:
+    port:
+      api:
+        default: 15868
+        internal: 15868
+        public: 80
+        service: 15868
+  oslo_db:
+    host_fqdn_override:
+      default: mariadb-cluster-primary.openstack.svc.cluster.local
+    hosts:
+      default: mariadb-cluster-primary
+  oslo_cache:
+    host_fqdn_override:
+      default: memcached.openstack.svc.cluster.local
+    hosts:
+      default: memcached
+  oslo_messaging:
+    host_fqdn_override:
+      default: rabbitmq.openstack.svc.cluster.local
+    hosts:
+      default: rabbitmq-nodes
+
+secrets:
+  identity:
+    admin: masakari-keystone-admin
+    masakari: masakari-keystone-user
+    test: masakari-keystone-test
+  oslo_db:
+    admin: masakari-db-admin
+    masakari: masakari-db-user
+  oslo_messaging:
+    admin: masakari-rabbitmq-admin
+    masakari: masakari-rabbitmq-user
+  oci_image_registry:
+    masakari: masakari-oci-image-registry
+
+dependencies:
+  static:
+    masakari_api:
+      jobs:
+        - masakari-db-sync
+        - masakari-ks-user
+        - masakari-ks-endpoints
+        - masakari-ks-service
+      services:
+        - endpoint: internal
+          service: identity
+    masakari_engine:
+      jobs:
+        - masakari-db-sync
+        - masakari-ks-user
+        - masakari-ks-endpoints
+        - masakari-ks-service
+      services:
+        - endpoint: internal
+          service: identity
+    db_init:
+      services:
+        - endpoint: internal
+          service: oslo_db
+    db_sync:
+      jobs:
+        - masakari-db-init
+      services:
+        - endpoint: internal
+          service: oslo_db
+    ks_endpoints:
+      jobs:
+        - masakari-ks-service
+      services:
+        - endpoint: internal
+          service: identity
+    ks_service:
+      services:
+        - endpoint: internal
+          service: identity
+    ks_user:
+      services:
+        - endpoint: internal
+          service: identity
+
+pod:
+  probes:
+    rpc_retries: 2
+  security_context:
+    masakari:
+      container:
+        masakari_engine:
+          readOnlyRootFilesystem: false
+  replicas:
+    masakari_api: 3
+    masakari_engine: 3
+  use_fqdn:
+    api: false
+conf:
+  paste:
+    composite:masakari_api:
+      use: call:masakari.api.urlmap:urlmap_factory
+      /: apiversions
+      /v1: masakari_api_v1
+    composite:masakari_api_v1:
+      use: call:masakari.api.auth:pipeline_factory_v1
+      keystone: cors http_proxy_to_wsgi request_id faultwrap sizelimit authtoken keystonecontext osapi_masakari_app_v1
+      noauth2: cors http_proxy_to_wsgi request_id faultwrap sizelimit noauth2 osapi_masakari_app_v1
+    filter:cors:
+      paste.filter_factory: oslo_middleware.cors:filter_factory
+      oslo_config_project: masakari
+    filter:http_proxy_to_wsgi:
+      paste.filter_factory: oslo_middleware.http_proxy_to_wsgi:HTTPProxyToWSGI.factory
+    filter:request_id:
+      paste.filter_factory: oslo_middleware:RequestId.factory
+    filter:faultwrap:
+      paste.filter_factory: masakari.api.openstack:FaultWrapper.factory
+    filter:sizelimit:
+      paste.filter_factory: oslo_middleware:RequestBodySizeLimiter.factory
+    filter:authtoken:
+      paste.filter_factory: keystonemiddleware.auth_token:filter_factory
+    filter:keystonecontext:
+      paste.filter_factory: masakari.api.auth:MasakariKeystoneContext.factory
+    filter:noauth2:
+      paste.filter_factory: masakari.api.auth:NoAuthMiddleware.factory
+    app:osapi_masakari_app_v1:
+      paste.app_factory: masakari.api.openstack.ha:APIRouterV1.factory
+    pipeline:apiversions:
+      pipeline: faultwrap http_proxy_to_wsgi apiversionsapp
+    app:apiversionsapp:
+      paste.app_factory: masakari.api.openstack.ha.versions:Versions.factory
+  masakari:
+    DEFAULT:
+      auth_strategy: keystone
+      duplicate_notification_detection_interval: 180
+      host_failure_recovery_threads: 1
+      masakari_api_workers: 4
+      graceful_shutdown_timeout: 5
+      api_paste_config: /etc/masakari/api-paste.ini
+      nova_catalog_admin_info: compute:nova:adminURL
+      service_down_time: 30
+      wait_period_after_service_update: 30
+    host_failure:
+      ignore_instances_in_error_state: true
+      add_reserved_host_to_aggregate: true
+    instance_failure:
+      process_all_instances: false
+    keystone_authtoken:
+      auth_type: password
+      service_type: instance-ha
+    database:
+      max_retries: -1
+    # Connection string is evaluated though the endpoints for taskflow.
+    taskflow:
+      connection: null
+  masakarimonitors:
+    DEFAULT:
+      debug: False
+    api:
+      api_version: v1
+      api_interface: internal
+    callback:
+      retry_max: 10
+      retry_interval: 10
+    host:
+      monitoring_driver: kubernetes
+      monitoring_interval: 30
+      monitoring_samples: 2
+      disable_ipmi_checks: true
+      corosync_multicast_interfaces: null
+      corosync_multicast_ports: null
+    kubernetes:
+      monitoring_node_labels: "openstack-compute-node=enabled"
+  masakari_sudoers: |
+    Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/var/lib/openstack/bin"
+    masakari-monitors ALL=(ALL:ALL) NOPASSWD: /var/lib/openstack/bin/privsep-helper
+
+# Note(xuxant): Hooks will break the upgrade for helm2
+# Set to false if using helm2.
+helm3_hook: true
+
+network:
+  masakari_api:
+    node_port:
+      enabled: false
+      port: 33033
+    external_policy_local: false
+
+manifests:
+  job_ks_user: true
+  job_db_sync: true
+  job_db_init: false
+  job_db_drop: false
+  job_ks_endpoints: true
+  job_ks_service: true
+  deployment_api: true
+  deployment_engine: true
+  configmap_bin: true
+  configmap_etc: true
+  secret_db: true
+  secret_rabbitmq: true
+  secret_keystone: true
+  secret_registry: true
+  job_rabbit_init: false
+  service_api: true
+  pdb_api: true
+  # Host Monitors in containers needs pacemaker remote or kubernetes_check.
+  host_monitor: true
+  instance_monitor: true
+  process_monitor: false

--- a/base-helm-configs/masakari/masakari-helm-overrides.yaml
+++ b/base-helm-configs/masakari/masakari-helm-overrides.yaml
@@ -66,19 +66,19 @@ pod:
     masakari:
       container:
         masakari_api:
-          allowPrivilegeEscalation: false
+          allowPrivilegeEscalation: true
           privileged: true
         masakari_engine:
-          allowPrivilegeEscalation: false
+          allowPrivilegeEscalation: true
           privileged: true
         masakari_host_monitor:
           allowPrivilegeEscalation: true
           privileged: true
         masakari_process_monitor:
-          allowPrivilegeEscalation: false
+          allowPrivilegeEscalation: true
           privileged: true
         masakari_instance_monitor:
-          allowPrivilegeEscalation: false
+          allowPrivilegeEscalation: true
           privileged: true
           runAsUser: 0
 conf:

--- a/base-helm-configs/masakari/masakari-helm-overrides.yaml
+++ b/base-helm-configs/masakari/masakari-helm-overrides.yaml
@@ -21,7 +21,7 @@ images:
     ks_user: quay.io/airshipit/heat:2024.1-ubuntu_jammy
     masakari_api: quay.io/rackspace/rackerlabs-masakari:2024.1-ubuntu_jammy
     masakari_engine: quay.io/rackspace/rackerlabs-masakari:2024.1-ubuntu_jammy
-    #TEMP HOST-MONITOR IMAGE TO FIX: https://github.com/zhmarvi/masakari-monitors/tree/kubernetes_check_status 
+    # TEMP HOST-MONITOR IMAGE TO FIX: https://review.opendev.org/c/openstack/masakari-monitors/+/951336
     masakari_host_monitor: kernelpanic53/rackerlabs-masakari-monitors:zhmarvi-ubuntu_jammy_v1.0
     masakari_process_monitor: quay.io/rackspace/rackerlabs-masakari-monitors:2024.1-ubuntu_jammy
     masakari_instance_monitor: quay.io/rackspace/rackerlabs-masakari-monitors:2024.1-ubuntu_jammy
@@ -209,7 +209,7 @@ conf:
       connection: null
   masakarimonitors:
     DEFAULT:
-      debug: False
+      debug: false
     api:
       api_version: v1
       api_interface: internal

--- a/base-helm-configs/masakari/masakari-helm-overrides.yaml
+++ b/base-helm-configs/masakari/masakari-helm-overrides.yaml
@@ -28,25 +28,7 @@ images:
     rabbit_init: docker.io/rabbitmq:3.13-management
     dep_check: quay.io/airshipit/kubernetes-entrypoint:latest-ubuntu_focal
   pull_policy: "IfNotPresent"
-  local_registry:
-    active: false
-    exclude:
-      - dep_check
-      - image_repo_sync
 
-labels:
-  masakari:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-  job:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
-  monitors:
-    node_selector_key: openstack-compute-node
-    node_selector_value: enabled
-  test:
-    node_selector_key: openstack-control-plane
-    node_selector_value: enabled
 endpoints:
   identiy:
     port:
@@ -62,6 +44,7 @@ endpoints:
         internal: 15868
         public: 80
         service: 15868
+
   oslo_db:
     host_fqdn_override:
       default: mariadb-cluster-primary.openstack.svc.cluster.local
@@ -78,111 +61,27 @@ endpoints:
     hosts:
       default: rabbitmq-nodes
 
-secrets:
-  identity:
-    admin: masakari-keystone-admin
-    masakari: masakari-keystone-user
-    test: masakari-keystone-test
-  oslo_db:
-    admin: masakari-db-admin
-    masakari: masakari-db-user
-  oslo_messaging:
-    admin: masakari-rabbitmq-admin
-    masakari: masakari-rabbitmq-user
-  oci_image_registry:
-    masakari: masakari-oci-image-registry
-
-dependencies:
-  static:
-    masakari_api:
-      jobs:
-        - masakari-db-sync
-        - masakari-ks-user
-        - masakari-ks-endpoints
-        - masakari-ks-service
-      services:
-        - endpoint: internal
-          service: identity
-    masakari_engine:
-      jobs:
-        - masakari-db-sync
-        - masakari-ks-user
-        - masakari-ks-endpoints
-        - masakari-ks-service
-      services:
-        - endpoint: internal
-          service: identity
-    db_init:
-      services:
-        - endpoint: internal
-          service: oslo_db
-    db_sync:
-      jobs:
-        - masakari-db-init
-      services:
-        - endpoint: internal
-          service: oslo_db
-    ks_endpoints:
-      jobs:
-        - masakari-ks-service
-      services:
-        - endpoint: internal
-          service: identity
-    ks_service:
-      services:
-        - endpoint: internal
-          service: identity
-    ks_user:
-      services:
-        - endpoint: internal
-          service: identity
-
 pod:
-  probes:
-    rpc_retries: 2
   security_context:
     masakari:
       container:
+        masakari_api:
+          allowPrivilegeEscalation: false
+          privileged: true
         masakari_engine:
-          readOnlyRootFilesystem: false
-  replicas:
-    masakari_api: 3
-    masakari_engine: 3
-  use_fqdn:
-    api: false
+          allowPrivilegeEscalation: false
+          privileged: true
+        masakari_host_monitor:
+          allowPrivilegeEscalation: true
+          privileged: true
+        masakari_process_monitor:
+          allowPrivilegeEscalation: false
+          privileged: true
+        masakari_instance_monitor:
+          allowPrivilegeEscalation: false
+          privileged: true
+          runAsUser: 0
 conf:
-  paste:
-    composite:masakari_api:
-      use: call:masakari.api.urlmap:urlmap_factory
-      /: apiversions
-      /v1: masakari_api_v1
-    composite:masakari_api_v1:
-      use: call:masakari.api.auth:pipeline_factory_v1
-      keystone: cors http_proxy_to_wsgi request_id faultwrap sizelimit authtoken keystonecontext osapi_masakari_app_v1
-      noauth2: cors http_proxy_to_wsgi request_id faultwrap sizelimit noauth2 osapi_masakari_app_v1
-    filter:cors:
-      paste.filter_factory: oslo_middleware.cors:filter_factory
-      oslo_config_project: masakari
-    filter:http_proxy_to_wsgi:
-      paste.filter_factory: oslo_middleware.http_proxy_to_wsgi:HTTPProxyToWSGI.factory
-    filter:request_id:
-      paste.filter_factory: oslo_middleware:RequestId.factory
-    filter:faultwrap:
-      paste.filter_factory: masakari.api.openstack:FaultWrapper.factory
-    filter:sizelimit:
-      paste.filter_factory: oslo_middleware:RequestBodySizeLimiter.factory
-    filter:authtoken:
-      paste.filter_factory: keystonemiddleware.auth_token:filter_factory
-    filter:keystonecontext:
-      paste.filter_factory: masakari.api.auth:MasakariKeystoneContext.factory
-    filter:noauth2:
-      paste.filter_factory: masakari.api.auth:NoAuthMiddleware.factory
-    app:osapi_masakari_app_v1:
-      paste.app_factory: masakari.api.openstack.ha:APIRouterV1.factory
-    pipeline:apiversions:
-      pipeline: faultwrap http_proxy_to_wsgi apiversionsapp
-    app:apiversionsapp:
-      paste.app_factory: masakari.api.openstack.ha.versions:Versions.factory
   masakari:
     DEFAULT:
       auth_strategy: keystone
@@ -202,24 +101,48 @@ conf:
     keystone_authtoken:
       auth_type: password
       service_type: instance-ha
+      auth_version: v3
+      memcache_security_strategy: ENCRYPT
+      service_token_roles: service
+      service_token_roles_required: true
     database:
+      connection_debug: 0
+      connection_recycle_time: 600
+      connection_trace: true
+      idle_timeout: 3600
+      mysql_sql_mode: {}
+      use_db_reconnect: true
+      pool_timeout: 60
       max_retries: -1
-    # Connection string is evaluated though the endpoints for taskflow.
+    oslo_messaging_rabbit:
+      amqp_durable_queues: false
+      rabbit_ha_queues: false
+      rabbit_quorum_queue: true
+      rabbit_transient_quorum_queue: false
+      use_queue_manager: false
+      rabbit_interval_max: 10
+      # Send more frequent heartbeats and fail unhealthy nodes faster
+      # heartbeat_timeout / heartbeat_rate / 2.0 = 30 / 3 / 2.0 = 5
+      # https://opendev.org/openstack/oslo.messaging/commit/36fb5bceabe08a982ebd52e4a8f005cd26fdf6b8
+      heartbeat_rate: 3
+      heartbeat_timeout_threshold: 60
+      # DEPRECIATION:  (warning) heartbeat_in_pthread will be deprecated in 2024.2
+      heartbeat_in_pthread: True
+      # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
+      # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
+      # https://review.opendev.org/c/openstack/oslo.messaging/+/866617
+      kombu_reconnect_delay: 0.5
     taskflow:
       connection: null
   masakarimonitors:
     DEFAULT:
       debug: false
     api:
-      api_version: v1
       api_interface: internal
-    callback:
-      retry_max: 10
-      retry_interval: 10
     host:
       monitoring_driver: kubernetes
       monitoring_interval: 30
-      monitoring_samples: 2
+      monitoring_samples: 3
       disable_ipmi_checks: true
       corosync_multicast_interfaces: null
       corosync_multicast_ports: null
@@ -228,17 +151,6 @@ conf:
   masakari_sudoers: |
     Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/var/lib/openstack/bin"
     masakari-monitors ALL=(ALL:ALL) NOPASSWD: /var/lib/openstack/bin/privsep-helper
-
-# Note(xuxant): Hooks will break the upgrade for helm2
-# Set to false if using helm2.
-helm3_hook: true
-
-network:
-  masakari_api:
-    node_port:
-      enabled: false
-      port: 33033
-    external_policy_local: false
 
 manifests:
   job_ks_user: true
@@ -258,7 +170,7 @@ manifests:
   job_rabbit_init: false
   service_api: true
   pdb_api: true
-  # Host Monitors in containers needs pacemaker remote or kubernetes_check.
+  # Genestack is using Kubernetes Check driver for Host-Monitor
   host_monitor: true
   instance_monitor: true
   process_monitor: false

--- a/base-kustomize/keystone/federation/kustomization.yaml
+++ b/base-kustomize/keystone/federation/kustomization.yaml
@@ -1,0 +1,89 @@
+---
+sortOptions:
+  order: fifo
+resources:
+  - ../base
+
+images:
+  - name: keystone-shib
+    newName: ghcr.io/rackerlabs/keystone-rxt/shibd
+    newTag: "1747958286"
+
+patches:
+  - target:
+      kind: Service
+      name: keystone-api
+    patch: |-
+      - op: add
+        path: /spec/sessionAffinity
+        value: ClientIP
+      - op: add
+        path: /spec/sessionAffinityConfig
+        value:
+          clientIP:
+            timeoutSeconds: 28800
+  - target:
+      kind: Deployment
+      name: keystone-api
+    patch: |-
+      - op: add
+        path: /spec/template/spec/volumes/-
+        value:
+          name: keystone-shibd-etc
+          secret:
+            secretName: keystone-shibd-etc
+      - op: add
+        path: /spec/template/spec/volumes/-
+        value:
+          name: run-shibd
+          emptyDir: {}
+      - op: add
+        path: /spec/template/spec/containers/0/volumeMounts/-
+        value:
+          mountPath: "/etc/shibboleth"
+          name: keystone-shibd-etc
+          readOnly: true
+      - op: add
+        path: /spec/template/spec/containers/0/volumeMounts/-
+        value:
+          mountPath: "/var/run/shibboleth"
+          name: run-shibd
+      - op: add
+        path: /spec/template/spec/containers/-
+        value:
+          command:
+            - /usr/sbin/shibd
+            - -f
+            - -c
+            - /etc/shibboleth/shibboleth2.xml
+            - -p
+            - /var/run/shibboleth/shibd.pid
+            - -F
+          name: keystone-shib
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          image: keystone-shib
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: "/etc/shibboleth"
+              name: keystone-shibd-etc
+              readOnly: true
+            - mountPath: /var/run/shibboleth
+              name: run-shibd
+          livenessProbe:
+            exec:
+              command:
+              - stat
+              - /var/run/shibboleth/shibd.sock
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+              - stat
+              - /var/run/shibboleth/shibd.sock
+            initialDelaySeconds: 10
+            periodSeconds: 10

--- a/base-kustomize/masakari/aio/kustomization.yaml
+++ b/base-kustomize/masakari/aio/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 sortOptions:
   order: fifo
 resources:

--- a/base-kustomize/masakari/aio/kustomization.yaml
+++ b/base-kustomize/masakari/aio/kustomization.yaml
@@ -1,0 +1,16 @@
+sortOptions:
+  order: fifo
+resources:
+  - ../base
+
+patches:
+  - target:
+      kind: HorizontalPodAutoscaler
+      name: masakari-api
+    patch: |-
+      - op: replace
+        path: /spec/minReplicas
+        value: 1
+      - op: replace
+        path: /spec/maxReplicas
+        value: 1

--- a/base-kustomize/masakari/base/hpa-masakari-api.yaml
+++ b/base-kustomize/masakari/base/hpa-masakari-api.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/base-kustomize/masakari/base/hpa-masakari-api.yaml
+++ b/base-kustomize/masakari/base/hpa-masakari-api.yaml
@@ -1,0 +1,25 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: masakari-api
+  namespace: openstack
+spec:
+  maxReplicas: 9
+  minReplicas: 3
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 50
+          type: Utilization
+      type: Resource
+    - resource:
+        name: memory
+        target:
+          type: AverageValue
+          averageValue: 500Mi
+      type: Resource
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: masakari-api

--- a/base-kustomize/masakari/base/kustomization.yaml
+++ b/base-kustomize/masakari/base/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 sortOptions:
   order: fifo
 resources:

--- a/base-kustomize/masakari/base/kustomization.yaml
+++ b/base-kustomize/masakari/base/kustomization.yaml
@@ -1,0 +1,8 @@
+sortOptions:
+  order: fifo
+resources:
+  - masakari-mariadb-database.yaml
+  - masakari-rabbitmq-queue.yaml
+  - all.yaml
+  - hpa-masakari-api.yaml
+  - masakari-hostmonitor-clusterrolebinding.yaml

--- a/base-kustomize/masakari/base/masakari-hostmonitor-clusterrolebinding.yaml
+++ b/base-kustomize/masakari/base/masakari-hostmonitor-clusterrolebinding.yaml
@@ -1,0 +1,23 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: masakari-hostmonitor
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  #verbs: ["get", "watch", "list"]
+  verbs: ["list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: masakari-hostmonitor
+subjects:
+- kind: ServiceAccount
+  name: masakari-host-monitor
+  namespace: openstack
+roleRef:
+  kind: ClusterRole
+  name: masakari-hostmonitor
+  apiGroup: rbac.authorization.k8s.io

--- a/base-kustomize/masakari/base/masakari-hostmonitor-clusterrolebinding.yaml
+++ b/base-kustomize/masakari/base/masakari-hostmonitor-clusterrolebinding.yaml
@@ -4,19 +4,18 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: masakari-hostmonitor
 rules:
-- apiGroups: [""]
-  resources: ["nodes"]
-  #verbs: ["get", "watch", "list"]
-  verbs: ["list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: masakari-hostmonitor
 subjects:
-- kind: ServiceAccount
-  name: masakari-host-monitor
-  namespace: openstack
+  - kind: ServiceAccount
+    name: masakari-host-monitor
+    namespace: openstack
 roleRef:
   kind: ClusterRole
   name: masakari-hostmonitor

--- a/base-kustomize/masakari/base/masakari-mariadb-database.yaml
+++ b/base-kustomize/masakari/base/masakari-mariadb-database.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Database
+metadata:
+  name: masakari
+  namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    helm.sh/resource-policy: keep
+    meta.helm.sh/release-name: "masakari"
+    meta.helm.sh/release-namespace: "openstack"
+spec:
+  # If you want the database to be created with a different name than the resource name
+  # name: data-custom
+  mariaDbRef:
+    name: mariadb-cluster
+  characterSet: utf8
+  collate: utf8_general_ci
+  retryInterval: 5s
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: User
+metadata:
+  name: masakari
+  namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    helm.sh/resource-policy: keep
+    meta.helm.sh/release-name: "masakari"
+    meta.helm.sh/release-namespace: "openstack"
+spec:
+  # If you want the user to be created with a different name than the resource name
+  # name: user-custom
+  mariaDbRef:
+    name: mariadb-cluster
+  passwordSecretKeyRef:
+    name: masakari-db-password
+    key: password
+  # This field is immutable and defaults to 10, 0 means unlimited.
+  maxUserConnections: 0
+  host: "%"
+  retryInterval: 5s
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Grant
+metadata:
+  name: masakari-grant
+  namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    helm.sh/resource-policy: keep
+    meta.helm.sh/release-name: "masakari"
+    meta.helm.sh/release-namespace: "openstack"
+spec:
+  mariaDbRef:
+    name: mariadb-cluster
+  privileges:
+    - "ALL"
+  database: "masakari"
+  table: "*"
+  username: masakari
+  grantOption: true
+  host: "%"
+  retryInterval: 5s

--- a/base-kustomize/masakari/base/masakari-rabbitmq-queue.yaml
+++ b/base-kustomize/masakari/base/masakari-rabbitmq-queue.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: User
+metadata:
+  name: masakari
+  namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  tags:
+  - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
+  - policymaker
+  rabbitmqClusterReference:
+    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
+    namespace: openstack
+  importCredentialsSecret:
+    name: masakari-rabbitmq-password
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Vhost
+metadata:
+  name: masakari-vhost
+  namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  name: "masakari" # vhost name; required and cannot be updated
+  defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
+  rabbitmqClusterReference:
+    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
+    namespace: openstack
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: masakari-queue
+  namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  name: masakari-qq # name of the queue
+  vhost: "masakari" # default to '/' if not provided
+  type: quorum # without providing a queue type, rabbitmq creates a classic queue
+  autoDelete: false
+  durable: true # seting 'durable' to false means this queue won't survive a server restart
+  rabbitmqClusterReference:
+    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
+    namespace: openstack
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Permission
+metadata:
+  name: masakari-permission
+  namespace: openstack
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  vhost: "masakari" # name of a vhost
+  userReference:
+    name: "masakari" # name of a user.rabbitmq.com in the same namespace; must specify either spec.userReference or spec.user
+  permissions:
+    write: ".*"
+    configure: ".*"
+    read: ".*"
+  rabbitmqClusterReference:
+    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
+    namespace: openstack

--- a/base-kustomize/masakari/base/masakari-rabbitmq-queue.yaml
+++ b/base-kustomize/masakari/base/masakari-rabbitmq-queue.yaml
@@ -8,10 +8,10 @@ metadata:
     helm.sh/resource-policy: keep
 spec:
   tags:
-  - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
-  - policymaker
+      - management   # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
+      - policymaker
   rabbitmqClusterReference:
-    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
+    name: rabbitmq   # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack
   importCredentialsSecret:
     name: masakari-rabbitmq-password
@@ -24,10 +24,10 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
 spec:
-  name: "masakari" # vhost name; required and cannot be updated
-  defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
+  name: "masakari"   # vhost name; required and cannot be updated
+  defaultQueueType: quorum   # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
   rabbitmqClusterReference:
-    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
+    name: rabbitmq   # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack
 ---
 apiVersion: rabbitmq.com/v1beta1
@@ -38,13 +38,13 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
 spec:
-  name: masakari-qq # name of the queue
-  vhost: "masakari" # default to '/' if not provided
-  type: quorum # without providing a queue type, rabbitmq creates a classic queue
+  name: masakari-qq   # name of the queue
+  vhost: "masakari"   # default to '/' if not provided
+  type: quorum   # without providing a queue type, rabbitmq creates a classic queue
   autoDelete: false
-  durable: true # seting 'durable' to false means this queue won't survive a server restart
+  durable: true   # seting 'durable' to false means this queue won't survive a server restart
   rabbitmqClusterReference:
-    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
+    name: rabbitmq   # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack
 ---
 apiVersion: rabbitmq.com/v1beta1
@@ -55,13 +55,13 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
 spec:
-  vhost: "masakari" # name of a vhost
+  vhost: "masakari"   # name of a vhost
   userReference:
-    name: "masakari" # name of a user.rabbitmq.com in the same namespace; must specify either spec.userReference or spec.user
+    name: "masakari"   # name of a user.rabbitmq.com in the same namespace; must specify either spec.userReference or spec.user
   permissions:
     write: ".*"
     configure: ".*"
     read: ".*"
   rabbitmqClusterReference:
-    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
+    name: rabbitmq   # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack

--- a/base-kustomize/masakari/base/masakari-rabbitmq-queue.yaml
+++ b/base-kustomize/masakari/base/masakari-rabbitmq-queue.yaml
@@ -8,8 +8,8 @@ metadata:
     helm.sh/resource-policy: keep
 spec:
   tags:
-      - management   # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
-      - policymaker
+    - management   # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
+    - policymaker
   rabbitmqClusterReference:
     name: rabbitmq   # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack

--- a/base-kustomize/skyline/base/configmap-bin.yaml
+++ b/base-kustomize/skyline/base/configmap-bin.yaml
@@ -53,6 +53,9 @@ data:
     yq -yi ".openstack.system_project_domain=\"${SERVICE_PROJECT_DOMAIN}\"" /etc/skyline/skyline.yaml
     yq -yi ".openstack.keystone_url=\"${SKYLINE_KEYSTONE_ENDPOINT}\"" /etc/skyline/skyline.yaml
     yq -yi ".openstack.default_region=\"${SKYLINE_DEFAULT_REGION}\"" /etc/skyline/skyline.yaml
+    yq -yi ".openstack.sso_enabled=${SKYLINE_SSO_ENABLED:-false}" /etc/skyline/skyline.yaml
+    yq -yi ".openstack.sso_protocols=${SKYLINE_SSO_PROTOCOLS:-[]}" /etc/skyline/skyline.yaml
+    yq -yi ".openstack.sso_region=\"${SKYLINE_SSO_REGION:-RegionOne}\"" /etc/skyline/skyline.yaml
     yq -yi ".default.secret_key=\"${SKYLINE_SECRET_KEY}\"" /etc/skyline/skyline.yaml
     yq -yi ".default.database_url=\"mysql://${DB_USERNAME}:${DB_PASSWORD}@${DB_ENDPOINT}/${DB_NAME}\"" /etc/skyline/skyline.yaml
     yq -yi ".default.prometheus_basic_auth_password=\"${PROMETHEUS_BASIC_AUTH_PASSWORD}\"" /etc/skyline/skyline.yaml
@@ -91,12 +94,15 @@ data:
       reclaim_instance_interval: 604800
       service_mapping:
         baremetal: ironic
+        block-storage: cinder
         compute: nova
         container: zun
         container-infra: magnum
         database: trove
+        dns: designate
         identity: keystone
         image: glance
+        instance-ha: masakari
         key-manager: barbican
         load-balancer: octavia
         network: neutron
@@ -104,11 +110,10 @@ data:
         orchestration: heat
         placement: placement
         sharev2: manilav2
-        volumev3: cinder
-        cloudformation: heat-cfn
       sso_enabled: false
       sso_protocols:
       - openid
+      sso_region: RegionOne
       system_admin_roles:
       - admin
       system_project: 'service'

--- a/base-kustomize/skyline/base/deployment-apiserver.yaml
+++ b/base-kustomize/skyline/base/deployment-apiserver.yaml
@@ -32,23 +32,23 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: release_group
-                  operator: In
-                  values:
-                  - skyline
-                - key: application
-                  operator: In
-                  values:
-                  - skyline
-                - key: component
-                  operator: In
-                  values:
-                  - server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: release_group
+                      operator: In
+                      values:
+                        - skyline
+                    - key: application
+                      operator: In
+                      values:
+                        - skyline
+                    - key: component
+                      operator: In
+                      values:
+                        - server
+                topologyKey: kubernetes.io/hostname
+              weight: 10
       nodeSelector:
         openstack-control-plane: enabled
       terminationGracePeriodSeconds: 30
@@ -123,87 +123,87 @@ spec:
               subPath: data-skyline-service-init.sh
               readOnly: true
           env:
-          - name: SERVICE_USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: service-username
-          - name: SERVICE_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: service-password
-          - name: SERVICE_DOMAIN
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: service-domain
-          - name: SERVICE_PROJECT
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: service-project
-          - name: SERVICE_PROJECT_DOMAIN
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: service-project-domain
-          - name: OS_IDENTITY_API_VERSION
-            value: "3"
-          - name: OS_AUTH_URL
-            valueFrom:
-              secretKeyRef:
-                name: keystone-keystone-admin
-                key: OS_AUTH_URL
-          - name: OS_REGION_NAME
-            valueFrom:
-              secretKeyRef:
-                name: keystone-keystone-admin
-                key: OS_REGION_NAME
-          - name: OS_INTERFACE
-            valueFrom:
-              secretKeyRef:
-                name: keystone-keystone-admin
-                key: OS_INTERFACE
-          - name: OS_ENDPOINT_TYPE
-            valueFrom:
-              secretKeyRef:
-                name: keystone-keystone-admin
-                key: OS_INTERFACE
-          - name: OS_PROJECT_DOMAIN_NAME
-            valueFrom:
-              secretKeyRef:
-                name: keystone-keystone-admin
-                key: OS_PROJECT_DOMAIN_NAME
-          - name: OS_PROJECT_NAME
-            valueFrom:
-              secretKeyRef:
-                name: keystone-keystone-admin
-                key: OS_PROJECT_NAME
-          - name: OS_USER_DOMAIN_NAME
-            valueFrom:
-              secretKeyRef:
-                name: keystone-keystone-admin
-                key: OS_USER_DOMAIN_NAME
-          - name: OS_USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: keystone-keystone-admin
-                key: OS_USERNAME
-          - name: OS_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: keystone-keystone-admin
-                key: OS_PASSWORD
-          - name: OS_DEFAULT_DOMAIN
-            valueFrom:
-              secretKeyRef:
-                name: keystone-keystone-admin
-                key: OS_DEFAULT_DOMAIN
-          - name: OS_SERVICE_NAME
-            value: "keystone"
-          - name: OS_SERVICE_TYPE
-            value: "image"
+            - name: SERVICE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: service-username
+            - name: SERVICE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: service-password
+            - name: SERVICE_DOMAIN
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: service-domain
+            - name: SERVICE_PROJECT
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: service-project
+            - name: SERVICE_PROJECT_DOMAIN
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: service-project-domain
+            - name: OS_IDENTITY_API_VERSION
+              value: "3"
+            - name: OS_AUTH_URL
+              valueFrom:
+                secretKeyRef:
+                  name: keystone-keystone-admin
+                  key: OS_AUTH_URL
+            - name: OS_REGION_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: keystone-keystone-admin
+                  key: OS_REGION_NAME
+            - name: OS_INTERFACE
+              valueFrom:
+                secretKeyRef:
+                  name: keystone-keystone-admin
+                  key: OS_INTERFACE
+            - name: OS_ENDPOINT_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: keystone-keystone-admin
+                  key: OS_INTERFACE
+            - name: OS_PROJECT_DOMAIN_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: keystone-keystone-admin
+                  key: OS_PROJECT_DOMAIN_NAME
+            - name: OS_PROJECT_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: keystone-keystone-admin
+                  key: OS_PROJECT_NAME
+            - name: OS_USER_DOMAIN_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: keystone-keystone-admin
+                  key: OS_USER_DOMAIN_NAME
+            - name: OS_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: keystone-keystone-admin
+                  key: OS_USERNAME
+            - name: OS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keystone-keystone-admin
+                  key: OS_PASSWORD
+            - name: OS_DEFAULT_DOMAIN
+              valueFrom:
+                secretKeyRef:
+                  name: keystone-keystone-admin
+                  key: OS_DEFAULT_DOMAIN
+            - name: OS_SERVICE_NAME
+              value: "keystone"
+            - name: OS_SERVICE_TYPE
+              value: "image"
         - name: skyline-apiserver-config
           image: "ghcr.io/linuxserver/yq:latest"
           imagePullPolicy: IfNotPresent
@@ -232,90 +232,108 @@ spec:
               subPath: data-skyline-setup.sh
               readOnly: true
           env:
-          - name: SERVICE_USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: service-username
-          - name: SERVICE_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: service-password
-          - name: SERVICE_DOMAIN
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: service-domain
-          - name: SERVICE_PROJECT
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: service-project
-          - name: SERVICE_PROJECT_DOMAIN
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: service-project-domain
-          - name: DB_ENDPOINT
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: db-endpoint
-          - name: DB_NAME
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: db-name
-          - name: DB_USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: db-username
-          - name: DB_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: db-password
-          - name: SKYLINE_SECRET_KEY
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: secret-key
-          - name: SKYLINE_KEYSTONE_ENDPOINT
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: keystone-endpoint
-          - name: SKYLINE_DEFAULT_REGION
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: default-region
-          - name: PROMETHEUS_BASIC_AUTH_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: prometheus_basic_auth_password
-                optional: true
-          - name: PROMETHEUS_BASIC_AUTH_USER
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: prometheus_basic_auth_user
-                optional: true
-          - name: PROMETHEUS_ENABLE_BASIC_AUTH
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: prometheus_enable_basic_auth
-                optional: true
-          - name: PROMETHEUS_ENDPOINT
-            valueFrom:
-              secretKeyRef:
-                name: skyline-apiserver-secrets
-                key: prometheus_endpoint
-                optional: true
+            - name: SERVICE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: service-username
+            - name: SERVICE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: service-password
+            - name: SERVICE_DOMAIN
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: service-domain
+            - name: SERVICE_PROJECT
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: service-project
+            - name: SERVICE_PROJECT_DOMAIN
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: service-project-domain
+            - name: DB_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: db-endpoint
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: db-name
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: db-username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: db-password
+            - name: SKYLINE_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: secret-key
+            - name: SKYLINE_KEYSTONE_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: keystone-endpoint
+            - name: SKYLINE_DEFAULT_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: default-region
+            - name: SKYLINE_SSO_ENABLED
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: sso-enabled
+                  optional: true
+            - name: SKYLINE_SSO_PROTOCOLS
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: sso-protocols
+                  optional: true
+            - name: SKYLINE_SSO_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: sso-region
+                  optional: true
+            - name: PROMETHEUS_BASIC_AUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: prometheus_basic_auth_password
+                  optional: true
+            - name: PROMETHEUS_BASIC_AUTH_USER
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: prometheus_basic_auth_user
+                  optional: true
+            - name: PROMETHEUS_ENABLE_BASIC_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: prometheus_enable_basic_auth
+                  optional: true
+            - name: PROMETHEUS_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: skyline-apiserver-secrets
+                  key: prometheus_endpoint
+                  optional: true
         - name: skyline-apiserver-db-migrate
           image: "quay.io/rackspace/rackerlabs-skyline-rxt:master-ubuntu_jammy-1739967315"
           imagePullPolicy: IfNotPresent

--- a/base-kustomize/skyline/base/services.yaml
+++ b/base-kustomize/skyline/base/services.yaml
@@ -51,3 +51,7 @@ spec:
     release_group: skyline
     application: skyline
     component: api
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 600

--- a/bin/create-secrets.sh
+++ b/bin/create-secrets.sh
@@ -81,6 +81,9 @@ barbican_admin_password=$(generate_password 32)
 magnum_rabbitmq_password=$(generate_password 64)
 magnum_db_password=$(generate_password 32)
 magnum_admin_password=$(generate_password 32)
+masakari_rabbitmq_password=$(generate_password 64)
+masakari_db_password=$(generate_password 32)
+masakari_admin_password=$(generate_password 32)
 postgresql_identity_admin_password=$(generate_password 32)
 postgresql_db_admin_password=$(generate_password 32)
 postgresql_db_exporter_password=$(generate_password 32)
@@ -516,6 +519,34 @@ metadata:
 type: Opaque
 data:
   password: $(echo -n $magnum_admin_password | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: masakari-rabbitmq-password
+  namespace: openstack
+type: Opaque
+data:
+  username: $(echo -n "masakari" | base64)
+  password: $(echo -n $masakari_rabbitmq_password | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: masakari-db-password
+  namespace: openstack
+type: Opaque
+data:
+  password: $(echo -n $masakari_db_password | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: masakari-admin
+  namespace: openstack
+type: Opaque
+data:
+  password: $(echo -n $masakari_admin_password | base64 -w0)
 ---
 apiVersion: v1
 kind: Secret

--- a/bin/install-masakari.sh
+++ b/bin/install-masakari.sh
@@ -27,7 +27,6 @@ HELM_CMD+=" --set endpoints.oslo_db.auth.admin.password=\"\$(kubectl --namespace
 HELM_CMD+=" --set endpoints.oslo_db.auth.masakari.password=\"\$(kubectl --namespace openstack get secret masakari-db-password -o jsonpath='{.data.password}' | base64 -d)\""
 HELM_CMD+=" --set endpoints.oslo_cache.auth.memcache_secret_key=\"\$(kubectl --namespace openstack get secret os-memcached -o jsonpath='{.data.memcache_secret_key}' | base64 -d)\""
 HELM_CMD+=" --set conf.masakari.keystone_authtoken.memcache_secret_key=\"\$(kubectl --namespace openstack get secret os-memcached -o jsonpath='{.data.memcache_secret_key}' | base64 -d)\""
-HELM_CMD+=" --set conf.masakari.database.slave_connection=\"mysql+pymysql://masakari:\$(kubectl --namespace openstack get secret masakari-db-password -o jsonpath='{.data.password}' | base64 -d)@mariadb-cluster-secondary.openstack.svc.cluster.local:3306/masakari\""
 HELM_CMD+=" --set endpoints.oslo_messaging.auth.admin.password=\"\$(kubectl --namespace openstack get secret rabbitmq-default-user -o jsonpath='{.data.password}' | base64 -d)\""
 HELM_CMD+=" --set endpoints.oslo_messaging.auth.masakari.password=\"\$(kubectl --namespace openstack get secret masakari-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)\""
 

--- a/bin/install-masakari.sh
+++ b/bin/install-masakari.sh
@@ -4,7 +4,7 @@ GLOBAL_OVERRIDES_DIR="/etc/genestack/helm-configs/global_overrides"
 SERVICE_CONFIG_DIR="/etc/genestack/helm-configs/masakari"
 BASE_OVERRIDES="/opt/genestack/base-helm-configs/masakari/masakari-helm-overrides.yaml"
 
-HELM_CMD="helm upgrade --install masakari openstack-helm/masakari --version 2024.2.157+13651f45-628a320c  \
+HELM_CMD="helm upgrade --install masakari openstack-helm/masakari --version 2024.2.17+13651f45-628a320c  \
     --namespace=openstack \
     --timeout 10m"
 

--- a/bin/install-masakari.sh
+++ b/bin/install-masakari.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+GLOBAL_OVERRIDES_DIR="/etc/genestack/helm-configs/global_overrides"
+SERVICE_CONFIG_DIR="/etc/genestack/helm-configs/masakari"
+BASE_OVERRIDES="/opt/genestack/base-helm-configs/masakari/masakari-helm-overrides.yaml"
+
+HELM_CMD="helm upgrade --install masakari openstack-helm/masakari --version 2024.2.157+13651f45-628a320c  \
+    --namespace=openstack \
+    --timeout 10m"
+
+HELM_CMD+=" -f ${BASE_OVERRIDES}"
+
+for dir in "$GLOBAL_OVERRIDES_DIR" "$SERVICE_CONFIG_DIR"; do
+  if compgen -G "${dir}/*.yaml" > /dev/null; then
+    for yaml_file in "${dir}"/*.yaml; do
+      # Avoid re-adding the base override file if it appears in the service directory
+      if [ "${yaml_file}" != "${BASE_OVERRIDES}" ]; then
+        HELM_CMD+=" -f ${yaml_file}"
+      fi
+    done
+  fi
+done
+
+HELM_CMD+=" --set endpoints.identity.auth.admin.password=\"\$(kubectl --namespace openstack get secret keystone-admin -o jsonpath='{.data.password}' | base64 -d)\""
+HELM_CMD+=" --set endpoints.identity.auth.masakari.password=\"\$(kubectl --namespace openstack get secret masakari-admin -o jsonpath='{.data.password}' | base64 -d)\""
+HELM_CMD+=" --set endpoints.oslo_db.auth.admin.password=\"\$(kubectl --namespace openstack get secret mariadb -o jsonpath='{.data.root-password}' | base64 -d)\""
+HELM_CMD+=" --set endpoints.oslo_db.auth.masakari.password=\"\$(kubectl --namespace openstack get secret masakari-db-password -o jsonpath='{.data.password}' | base64 -d)\""
+HELM_CMD+=" --set endpoints.oslo_cache.auth.memcache_secret_key=\"\$(kubectl --namespace openstack get secret os-memcached -o jsonpath='{.data.memcache_secret_key}' | base64 -d)\""
+HELM_CMD+=" --set conf.masakari.keystone_authtoken.memcache_secret_key=\"\$(kubectl --namespace openstack get secret os-memcached -o jsonpath='{.data.memcache_secret_key}' | base64 -d)\""
+HELM_CMD+=" --set conf.masakari.database.slave_connection=\"mysql+pymysql://masakari:\$(kubectl --namespace openstack get secret masakari-db-password -o jsonpath='{.data.password}' | base64 -d)@mariadb-cluster-secondary.openstack.svc.cluster.local:3306/masakari\""
+HELM_CMD+=" --set endpoints.oslo_messaging.auth.admin.password=\"\$(kubectl --namespace openstack get secret rabbitmq-default-user -o jsonpath='{.data.password}' | base64 -d)\""
+HELM_CMD+=" --set endpoints.oslo_messaging.auth.masakari.password=\"\$(kubectl --namespace openstack get secret masakari-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)\""
+
+HELM_CMD+=" --post-renderer /etc/genestack/kustomize/kustomize.sh"
+HELM_CMD+=" --post-renderer-args masakari/overlay"
+
+helm repo add openstack-helm https://tarballs.opendev.org/openstack/openstack-helm
+helm repo update
+
+HELM_CMD+=" $@"
+
+echo "Executing Helm command:"
+echo "${HELM_CMD}"
+eval "${HELM_CMD}"

--- a/bin/setup-openstack.sh
+++ b/bin/setup-openstack.sh
@@ -30,6 +30,7 @@ runTrackErator /opt/genestack/bin/install-nova.sh
 runTrackErator /opt/genestack/bin/install-neutron.sh
 runTrackErator /opt/genestack/bin/install-magnum.sh
 runTrackErator /opt/genestack/bin/install-octavia.sh
+runTrackErator /opt/genestack/bin/install-masakari.sh
 
 # Install telemetry services
 if [ "${GENESTACK_INSTALL_TELEMETRY}" = true ]; then

--- a/docs/openstack-keystone-federation.md
+++ b/docs/openstack-keystone-federation.md
@@ -1,18 +1,20 @@
-# Setup the Keystone Federation Plugin
+# Setup the Keystone Federation Plugins
 
-## Create the domain
+## Create the Rackspace Domain
 
 ``` shell
 openstack --os-cloud default domain create rackspace_cloud_domain
 ```
 
-## Create the identity provider
+## Global Auth Identity Provider
+
+First step is to create the identity provider and connect it to a domain.
 
 ``` shell
 openstack --os-cloud default identity provider create --remote-id rackspace --domain rackspace_cloud_domain rackspace
 ```
 
-### Create the mapping for our identity provider
+### Create the Global Auth mapping for our identity provider
 
 You're also welcome to generate your own mapping to suit your needs; however, if you want to use the example mapping (which is suitable for production) you can.
 
@@ -34,19 +36,19 @@ The example mapping **JSON** file can be found within the genestack repository a
     openstack --os-cloud default role create creator
     ```
 
-## Now register the mapping within Keystone
+### Register the Global Auth mapping within Keystone
 
 ``` shell
 openstack --os-cloud default mapping create --rules /tmp/mapping.json --schema-version 2.0 rackspace_mapping
 ```
 
-## Create the federation protocol
+### Create the Global Auth federation protocol
 
 ``` shell
 openstack --os-cloud default federation protocol create rackspace --mapping rackspace_mapping --identity-provider rackspace
 ```
 
-## Rackspace Configuration Options
+### Rackspace Global Auth Configuration Options
 
 The `[rackspace]` section can also be used in your `keystone.conf` to allow you to configure how to anchor on
 roles.
@@ -55,3 +57,329 @@ roles.
 | --- | ----- | ------- |
 | `role_attribute` | A string option used as an anchor to discover roles attributed to a given user | **os_flex** |
 | `role_attribute_enforcement` | When set `true` will limit a users project to only the discovered GUID for the defined `role_attribute` | **false** |
+
+---
+
+## SAML2 Service Provider
+
+Before getting started with the SAML2 service provider setup, you will need to locate your SAML2 identity provider entity ID. This is the value
+that will be used to configure the SAML2 identity provider within Keystone.
+
+High level diagram of the SAML2 Service Provider environment
+
+``` mermaid
+flowchart TB
+    direction LR
+    Auth["User -> keystone.api.example.com"]
+    UI["User -> skyline.api.example.com"]
+    envoyAuth[Envoy Gateway cookie: KeystoneSession]
+    envoyUI[Envoy Gateway cookie: SkylineSession]
+    svc[ClusterIP Service keystone-api]
+    Auth --> envoyAuth --> svc
+    UI --> envoyUI --> envoyAuth
+    svc --> Apache1
+    subgraph "Infrastructure Hosts"
+      subgraph P1["Keystone pod x 3"]
+            Shib1[Shibd]
+            Apache1[Apache]
+            Shib1 -. shared Socket .- Apache1
+      end
+      subgraph P2["Memcached pod x 3"]
+            memc["Memcached"] -.- Shib1
+      end
+    end
+```
+
+### Gather Shibboleth files
+
+The following steps make the assumption that the system is running Docker and that the `docker` command is available. While these steps are useful,
+they are not required. You can also use the `shibd` command directly on the host system or use file copies from the `shibboleth` package.
+
+#### Retrieve the SAML2 files
+
+Using the `docker` command and the shibd image, retrieve the SAML2 files from the container and place them in a local directory.
+
+``` shell
+docker run -v /etc/genestack/keystone-sp:/mnt \
+       ghcr.io/rackerlabs/keystone-rxt/shibd:latest \
+       cp -R /etc/shibboleth /mnt/
+```
+
+#### Update the `shibboleth2.xml` file
+
+The files will be created and stored in a kubernetes secret named `keystone-shib-etc` and mounted to `/etc/shibboleth` in the `keystone` pod. The files are:
+
+Store the SAML metadata and configure the SAML identity provider at `/etc/genestack/keystone-sp/shibboleth/idp-metadata.xml`.
+
+Before you can upload the secrets to the kubernetes cluster, you need to edit the `shibboleth2.xml` file.
+
+!!! example "shibboleth2.xml file"
+
+    ``` xml
+    --8<-- "etc/keystone/shibboleth2.xml"
+    ```
+
+* The entity ID in the `SSO` field is the same value as the `EXAMPLE_ENTITY_ID_REPLACED_WITH_THE_ENTITY_ID_OF_THE_IDP` used when
+  defining the OpenStack Identity provider.
+* The references to `example.com` should be replaced with the actual domain name used within the cloud
+* Take note of the memcached configuration in the `shibboleth2.xml` file. The `memcached` service is used to cache the SAML2
+  responses and requests. The default configuration uses the `memcached` service running on the assumed cluster memcached environment
+  using three different nodes: `memcached-{0,1,2}.memcached.openstack.svc.cluster.local:11211`. If the memcached service is on a
+  different host or port, update the `shibboleth2.xml` file accordingly.
+
+#### Update the logger to use the `console` logger"
+
+The `shibd.logger` file is used to configure the logging for the SAML2 identity provider. The default logger is set to log to a
+file which isn't ideal. It is recommended to update the logger to use the `console`.
+
+``` shell
+sed -i 's@fileName=.*@fileName=/dev/stdout@g' /etc/genestack/keystone-sp/shibboleth/shibd.logger
+```
+
+#### Update the Attribute Map
+
+The `attribute-map.xml` file is used to configure the attribute mapping for the SAML2 identity provider. Every provider has a different
+attribute mapping. The default attribute mapping is set to use the `urn:oid:` values. The `urn:oid:` values are the standard values
+used by the SAML2 identity provider.
+
+!!! genestack "Example `attribute-map.xml` configurations"
+
+    === "Auth-0"
+
+        The followig attributes are used by the Auth-0 identity provider. Add the following optins to the
+        `attribute-map.xml` to have it compatible with the provided `saml-mapping.json` which will be used
+        within keystone.
+
+        ``` xml
+        <!-- Auth-0 attributes -->
+        <Attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" id="REMOTE_EMAIL"/>
+        <Attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name" id="uid"/>
+        <Attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier" id="REMOTE_UID"/>
+        <Attribute name="http://schemas.auth0.com/email_verified" id="REMOTE_VERIFIED"/>
+        <Attribute name="http://schemas.auth0.com/project_ids" id="REMOTE_PROJECT_NAME"/>
+        <Attribute name="http://schemas.auth0.com/roles" id="REMOTE_ORG_PERSON_TYPE"/>
+        ```
+
+        Within the Auth-0 portal you can find the `project_ids` and `roles` attributes. The `project_ids` attribute
+        is used to map the project name to the project ID. The `roles` attribute is used to map the roles to the user.
+
+        !!! example "User Metadata"
+
+            ``` json
+            {
+                "roles": [
+                    "observer",
+                    "creator",
+                    "member"
+                ],
+                "project_ids": [
+                    "project_id_1",
+                    "project_id_2"
+                ]
+            }
+            ```
+
+    === "OKTA"
+
+        The following attributes are used by the OKTA identity provider. Add the following options to the
+        `attribute-map.xml` to have it compatible with the provided `saml-mapping.json` which will be used
+        within keystone.
+
+        ``` xml
+        <!-- OKTA attributes -->
+        <Attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" id="REMOTE_EMAIL"/>
+        <Attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name" id="uid"/>
+        <Attribute name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier" id="REMOTE_UID"/>
+        <Attribute name="http://schemas.okta.com/claims/email_verified" id="REMOTE_VERIFIED"/>
+        <Attribute name="http://schemas.okta.com/claims/project_ids" id="REMOTE_PROJECT_NAME"/>
+        <Attribute name="http://schemas.okta.com/claims/roles" id="REMOTE_ORG_PERSON_TYPE"/>
+        ```
+
+        Within the OKTA portal you can find the `project_ids` and `person_type` attributes. The `project_ids`
+        attribute is used to map the project name to the project ID. The `person_type` attribute is used to map
+        the roles to the user.
+
+        !!! example "User Metadata"
+
+            ``` json
+            {
+                "roles": [
+                    "observer",
+                    "creator",
+                    "member"
+                ],
+                "project_ids": [
+                    "project_id_1",
+                    "project_id_2"
+                ]
+            }
+            ```
+
+#### Generate the SAML Keys
+
+For **N** numbers of years. The keys are used to sign the SAML requests and responses.
+
+``` shell
+docker run -v /etc/genestack/keystone-sp:/etc/shibboleth \
+       ghcr.io/rackerlabs/keystone-rxt/shibd:latest \
+       shib-keygen -y 5
+```
+
+!!! note "The `shib-keygen` command"
+
+    * The `shib-keygen` command is used to generate the SAML keys. The keys are used to sign the SAML requests and responses.
+    * The `-y` option is used to specify the number of years for which the keys are valid. The example uses 5 years.
+
+    While the example command doesn't specifically call it out, deployers can further customize the keys by using the following options:
+
+    | Switch | Description |
+    | ------ | ----------- |
+    | -u | username to own keypair |
+    | -g | owning groupname |
+    | -h | hostname for cert |
+    | -y | years to issue cert |
+    | -e | entityID to embed in cert |
+    | -n | filename prefix (default 'sp') |
+
+    Upon completion, the `shib-keygen` command will generate a set of keys and certificates for the SAML2 identity provider. The keys are used to sign the SAML requests and responses.
+
+    The default filenames are:
+
+    * sp-key.pem
+    * sp-cert.pem
+
+#### Upload the SAML2 files to the kubernetes cluster
+
+Ingest all files into the kubernetes secret as a secrete, which will be mounted to the keystone pod.
+
+``` shell
+kubectl -n openstack create secret generic keystone-shibd-etc \
+        --from-file=/etc/genestack/keystone-sp/shibboleth/attrChecker.html \
+        --from-file=/etc/genestack/keystone-sp/shibboleth/attribute-map.xml \
+        --from-file=/etc/genestack/keystone-sp/shibboleth/attribute-policy.xml \
+        --from-file=/etc/genestack/keystone-sp/shibboleth/bindingTemplate.html \
+        --from-file=/etc/genestack/keystone-sp/shibboleth/discoveryTemplate.html \
+        --from-file=/etc/genestack/keystone-sp/shibboleth/globalLogout.html \
+        --from-file=/etc/genestack/keystone-sp/shibboleth/idp-metadata.xml \
+        --from-file=/etc/genestack/keystone-sp/shibboleth/localLogout.html \
+        --from-file=/etc/genestack/keystone-sp/shibboleth/metadataError.html \
+        --from-file=/etc/genestack/keystone-sp/shibboleth/partialLogout.html \
+        --from-file=/etc/genestack/keystone-sp/shibboleth/postTemplate.html \
+        --from-file=/etc/genestack/keystone-sp/shibboleth/protocols.xml \
+        --from-file=/etc/genestack/keystone-sp/shibboleth/security-policy.xml \
+        --from-file=/etc/genestack/keystone-sp/shibboleth/sessionError.html \
+        --from-file=/etc/genestack/keystone-sp/shibboleth/shibboleth2.xml \
+        --from-file=/etc/genestack/keystone-sp/shibboleth/shibd.logger \
+        --from-file=/etc/genestack/keystone-sp/shibboleth/sp-cert.pem \
+        --from-file=/etc/genestack/keystone-sp/shibboleth/sp-key.pem \
+        --from-file=/etc/genestack/keystone-sp/shibboleth/sslError.html
+```
+
+### Create the SAML identity provider
+
+Create the identity provider within Keystone. The `--remote-id` is the entity ID of the SAML identity provider. This is the value that will be used to configure the SAML2 `shibboleth2.xml` file.
+
+``` shell
+openstack --os-cloud default identity provider create \
+          --remote-id EXAMPLE_ENTITY_ID_REPLACED_WITH_THE_ENTITY_ID_OF_THE_IDP \
+          --domain rackspace_cloud_domain \
+          IDENTITY_PROVIDER_NAME
+```
+
+#### Create the SAML auth mapping for our identity provider
+
+You're also welcome to generate your own mapping to suit your needs; however, if you want to use the example mapping (which is suitable for production) you can.
+
+!!! abstract "Example keystone `saml-mapping.json` file"
+
+    ``` json
+    --8<-- "etc/keystone/saml-mapping.json"
+    ```
+
+The example mapping **JSON** file can be found within the genestack repository at `etc/keystone/saml-mapping.json`.
+
+#### Register the SAML mapping within Keystone
+
+``` shell
+openstack --os-cloud default mapping create \
+          --rules /opt/genestack/etc/keystone/saml-mapping.json \
+          --schema-version 2.0 \
+          saml_mapping
+```
+
+#### Create the SAML federation protocol
+
+``` shell
+openstack --os-cloud default federation protocol create saml2 \
+          --mapping saml_mapping \
+          --identity-provider IDENTITY_PROVIDER_NAME
+```
+
+### Redeploy the Keystone Helm Chart
+
+Before running the deployment, you need to edit the `keystone-helm-overrides.yaml` file to include the following configuration options.
+
+!!! example "keystone-helm-overrides.yaml"
+
+    ``` yaml
+    --8<-- "base-helm-configs/keystone/keystone-helm-overrides-saml.yaml.example"
+    ```
+
+    !!! note "Keystone Configuration Options"
+
+        The above example is a sample configuration file that can be used to deploy Keystone with SAML2 support.
+        The following options are important:
+
+        * The `trusted_dashboard` configuration option in the above example must be updated to the public URL of the UI experience for the cloud
+        * The references to `example.com` should be replaced with the actual domain name used within the cloud
+        * The references to `IDENTITY_PROVIDER_NAME` should be replaced with the name of your identity provider (e.g., `Auth0`, `OKTA`)
+
+Edit the Keystone Onverlay file at `/etc/genestack/kustomize/keystone/overlay/kustomization.yaml` to ensure that it is including the `federation` backend as the base.
+
+``` yaml
+kind: Kustomization
+resources:
+  - ../federation
+```
+
+Now run the helm deployment to update keystone to use the new federation setup.
+
+``` shell
+/opt/genestack/bin/install-keystone.sh
+```
+
+### Redeploy the Skyline UI with SSO Enabled
+
+Finally update the Skyline configuration to use the SAML2 identity provider.
+
+``` shell
+echo sso-protocols: $(echo -n '["IDENTITY_PROVIDER_NAME"]' | base64)
+echo sso-enabled: $(echo -n 'true' | base64)
+echo sso-region: $(echo -n 'RegionOne' | base64)
+echo keystone-endpoint: $(echo  -n 'https://keystone.api.example.com/v3' | base64)
+```
+
+!!! example "Output of the above command"
+
+    ``` yaml
+    sso-protocols: WyJJREVOVElUWV9QUk9WSURFUl9OQU1FIl0=
+    sso-enabled: dHJ1ZQ==
+    sso_region: UmVnaW9uT25l
+    keystone-endpoint: aHR0cHM6Ly9rZXlzdG9uZS5hcGkuZXhhbXBsZS5jb20vdjM=
+    ```
+
+    !!! note "The Keystone Endpoint must be the public endpoint"
+
+        The Keystone URL must be the URL of your Public Cloud Keystone service.
+
+Edit the `skyline-apiserver-secrets` secret to include the new SSO configuration options.
+
+``` shell
+kubectl -n openstack edit secrets skyline-apiserver-secrets
+```
+
+Run the following command to update the skyline-apiserver deployment.
+
+``` shell
+kubectl -n openstack rollout restart deployment skyline
+```

--- a/etc/gateway-api/listeners/masakari-https.json
+++ b/etc/gateway-api/listeners/masakari-https.json
@@ -1,0 +1,27 @@
+[
+    {
+        "op": "add",
+        "path": "/spec/listeners/-",
+        "value": {
+            "name": "masakari-https",
+            "port": 443,
+            "protocol": "HTTPS",
+            "hostname": "masakari.your.domain.tld",
+            "allowedRoutes": {
+                "namespaces": {
+                    "from": "All"
+                }
+            },
+            "tls": {
+                "certificateRefs": [
+                    {
+                        "group": "",
+                        "kind": "Secret",
+                        "name": "masakari-gw-tls-secret"
+                    }
+                ],
+                "mode": "Terminate"
+            }
+        }
+    }
+]

--- a/etc/gateway-api/routes/custom-keystone-gateway-route.yaml
+++ b/etc/gateway-api/routes/custom-keystone-gateway-route.yaml
@@ -6,12 +6,18 @@ metadata:
   namespace: openstack
 spec:
   parentRefs:
-  - name: flex-gateway
-    sectionName: keystone-https
-    namespace: nginx-gateway
+    - name: flex-gateway
+      sectionName: keystone-https
+      namespace: nginx-gateway
   hostnames:
-  - "keystone.your.domain.tld"
+    - "keystone.your.domain.tld"
   rules:
     - backendRefs:
-      - name: keystone-api
-        port: 5000
+        - name: keystone-api
+          port: 5000
+      sessionPersistence:
+        sessionName: KeystoneSession
+        type: Cookie
+        absoluteTimeout: 300s
+        cookieConfig:
+          lifetimeType: Permanent

--- a/etc/gateway-api/routes/custom-masakari-gateway-route.yaml
+++ b/etc/gateway-api/routes/custom-masakari-gateway-route.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: custom-masakari-gateway-route
+  namespace: openstack
+  labels:
+    application: gateway-api
+    service: HTTPRoute
+    route: masakari
+spec:
+  parentRefs:
+  - name: flex-gateway
+    sectionName: masakari-https
+    namespace: nginx-gateway
+  hostnames:
+  - "masakari.your.domain.tld"
+  rules:
+    - backendRefs:
+      - name: masakari-api
+        port: 15868

--- a/etc/gateway-api/routes/custom-masakari-gateway-route.yaml
+++ b/etc/gateway-api/routes/custom-masakari-gateway-route.yaml
@@ -10,12 +10,12 @@ metadata:
     route: masakari
 spec:
   parentRefs:
-  - name: flex-gateway
-    sectionName: masakari-https
-    namespace: nginx-gateway
+    - name: flex-gateway
+      sectionName: masakari-https
+      namespace: nginx-gateway
   hostnames:
-  - "masakari.your.domain.tld"
+    - "masakari.your.domain.tld"
   rules:
     - backendRefs:
-      - name: masakari-api
-        port: 15868
+       - name: masakari-api
+         port: 15868

--- a/etc/gateway-api/routes/custom-masakari-gateway-route.yaml
+++ b/etc/gateway-api/routes/custom-masakari-gateway-route.yaml
@@ -17,5 +17,5 @@ spec:
     - "masakari.your.domain.tld"
   rules:
     - backendRefs:
-       - name: masakari-api
-         port: 15868
+        - name: masakari-api
+          port: 15868

--- a/etc/gateway-api/routes/custom-skyline-gateway-route.yaml
+++ b/etc/gateway-api/routes/custom-skyline-gateway-route.yaml
@@ -10,12 +10,18 @@ metadata:
     route: skyline
 spec:
   parentRefs:
-  - name: flex-gateway
-    sectionName: skyline-https
-    namespace: nginx-gateway
+    - name: flex-gateway
+      sectionName: skyline-https
+      namespace: nginx-gateway
   hostnames:
-  - "skyline.your.domain.tld"
+    - "skyline.your.domain.tld"
   rules:
     - backendRefs:
-      - name: skyline-apiserver
-        port: 9999
+        - name: skyline-apiserver
+          port: 9999
+      sessionPersistence:
+        sessionName: SkylineSession
+        type: Cookie
+        absoluteTimeout: 300s
+        cookieConfig:
+          lifetimeType: Permanent

--- a/etc/keystone/saml-mapping.json
+++ b/etc/keystone/saml-mapping.json
@@ -1,0 +1,194 @@
+[
+    {
+        "local": [
+            {
+                "user": {
+                    "id": "{0}",
+                    "name": "{1}",
+                    "email": "{2}",
+                    "domain": {
+                        "name": "rackspace_cloud_domain"
+                    }
+                }
+            },
+            {
+                "projects": [
+                    {
+                        "name": "{3}",
+                        "domain": {
+                            "name": "rackspace_cloud_domain"
+                        },
+                        "roles": [
+                            {
+                                "name": "reader"
+                            },
+                            {
+                                "name": "load-balancer_observer"
+                            },
+                            {
+                                "name": "network_observer"
+                            },
+                            {
+                                "name": "heat_stack_user"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "remote": [
+            {
+                "type": "REMOTE_UID"
+            },
+            {
+                "type": "REMOTE_USER"
+            },
+            {
+                "type": "REMOTE_EMAIL"
+            },
+            {
+                "type": "REMOTE_PROJECT_NAME"
+            },
+            {
+                "type": "REMOTE_ORG_PERSON_TYPE",
+                "any_one_of": [
+                    "observer"
+                ]
+            },
+            {
+                "type": "REMOTE_VERIFIED",
+                "any_one_of": [
+                    "true"
+                ]
+            }
+        ]
+    },
+    {
+        "local": [
+            {
+                "user": {
+                    "id": "{0}",
+                    "name": "{1}",
+                    "email": "{2}",
+                    "domain": {
+                        "name": "rackspace_cloud_domain"
+                    }
+                }
+            },
+            {
+                "projects": [
+                    {
+                        "name": "{3}",
+                        "domain": {
+                            "name": "rackspace_cloud_domain"
+                        },
+                        "roles": [
+                            {
+                                "name": "member"
+                            },
+                            {
+                                "name": "load-balancer_member"
+                            },
+                            {
+                                "name": "network_member"
+                            },
+                            {
+                                "name": "heat_stack_user"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "remote": [
+            {
+                "type": "REMOTE_UID"
+            },
+            {
+                "type": "REMOTE_USER"
+            },
+            {
+                "type": "REMOTE_EMAIL"
+            },
+            {
+                "type": "REMOTE_PROJECT_NAME"
+            },
+            {
+                "type": "REMOTE_ORG_PERSON_TYPE",
+                "any_one_of": [
+                    "member"
+                ]
+            },
+            {
+                "type": "REMOTE_VERIFIED",
+                "any_one_of": [
+                    "true"
+                ]
+            }
+        ]
+    },
+    {
+        "local": [
+            {
+                "user": {
+                    "id": "{0}",
+                    "name": "{1}",
+                    "email": "{2}",
+                    "domain": {
+                        "name": "rackspace_cloud_domain"
+                    }
+                }
+            },
+            {
+                "projects": [
+                    {
+                        "name": "{3}",
+                        "domain": {
+                            "name": "rackspace_cloud_domain"
+                        },
+                        "roles": [
+                            {
+                                "name": "creator"
+                            },
+                            {
+                                "name": "load-balancer_member"
+                            },
+                            {
+                                "name": "network_creator"
+                            },
+                            {
+                                "name": "heat_stack_user"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "remote": [
+            {
+                "type": "REMOTE_UID"
+            },
+            {
+                "type": "REMOTE_USER"
+            },
+            {
+                "type": "REMOTE_EMAIL"
+            },
+            {
+                "type": "REMOTE_PROJECT_NAME"
+            },
+            {
+                "type": "REMOTE_ORG_PERSON_TYPE",
+                "any_one_of": [
+                    "creator"
+                ]
+            },
+            {
+                "type": "REMOTE_VERIFIED",
+                "any_one_of": [
+                    "true"
+                ]
+            }
+        ]
+    }
+]

--- a/etc/keystone/shibboleth2.xml
+++ b/etc/keystone/shibboleth2.xml
@@ -1,0 +1,83 @@
+<SPConfig xmlns="urn:mace:shibboleth:3.0:native:sp:config"
+    xmlns:conf="urn:mace:shibboleth:3.0:native:sp:config"
+    clockSkew="180">
+    <OutOfProcess logger="shibd.logger"
+        tranLogFormat="%u|%s|%IDP|%i|%ac|%t|%attr|%n|%b|%E|%S|%SS|%L|%UA|%a">
+        <Extensions>
+            <Library path="memcache-store.so" fatal="true" />
+        </Extensions>
+    </OutOfProcess>
+    <StorageService type="MEMCACHE"
+        id="mc"
+        prefix="shib:">
+        <Hosts>
+            memcached.openstack.svc.cluster.local:11211
+        </Hosts>
+    </StorageService>
+    <StorageService type="MEMCACHE"
+        id="mc-ctx"
+        prefix="shib:"
+        buildMap="1">
+        <Hosts>
+            memcached.openstack.svc.cluster.local:11211
+        </Hosts>
+    </StorageService>
+    <SessionCache type="StorageService"
+        StorageService="mc-ctx"
+        StorageServiceLite="mc"
+        cacheAllowance="3600"
+        inprocTimeout="900"
+        cleanupInterval="900" />
+    <ReplayCache StorageService="mc" />
+    <ArtifactMap StorageService="mc" artifactTTL="180" />
+    <!-- The following is a sample configuration for the SP.
+         You will need to replace the entityID and the metadata URL with your own values.
+         For the REMOTE_USER, common values are "eppn" "persistent-id" "targeted-id"
+         The example "uid" value is a custom mapping comming from the IDP -->
+    <ApplicationDefaults
+        entityID="https://skyline.api.example.com/api/openstack/skyline/api/v1/websso"
+        REMOTE_USER="eppn persistent-id targeted-id uid"
+        cipherSuites="DEFAULT:!EXP:!LOW:!aNULL:!eNULL:!DES:!IDEA:!SEED:!RC4:!3DES:!kRSA:!SSLv2:!SSLv3:!TLSv1:!TLSv1.1">
+        <Sessions lifetime="28800"
+            timeout="3600"
+            relayState="ss:mc"
+            checkAddress="false"
+            handlerSSL="true"
+            cookieProps="https"
+            redirectLimit="exact">
+            <SSO entityID="EXAMPLE_ENTITY_ID_REPLACED_WITH_THE_ENTITY_ID_OF_THE_IDP">
+                SAML2
+            </SSO>
+            <Logout>
+                SAML2 Local
+            </Logout>
+            <LogoutInitiator type="Admin" Location="/Logout/Admin" acl="127.0.0.1 ::1" />
+            <Handler type="MetadataGenerator" Location="/Metadata" signing="false" />
+            <Handler type="Status" Location="/Status" acl="127.0.0.1 ::1" />
+            <Handler type="Session" Location="/Session" showAttributeValues="false" />
+            <Handler type="DiscoveryFeed" Location="/DiscoFeed" />
+        </Sessions>
+        <Errors supportContact="admin@example.com"
+            helpLocation="https://example.com/about.html"
+            styleSheet="/shibboleth-sp/main.css" />
+        <MetadataProvider type="XML" path="idp-metadata.xml" />
+        <AttributeExtractor type="XML"
+            validate="true"
+            reloadChanges="false"
+            path="attribute-map.xml" />
+        <AttributeFilter type="XML" validate="true" path="attribute-policy.xml" />
+        <CredentialResolver type="File"
+            use="signing"
+            key="sp-key.pem"
+            certificate="sp-cert.pem" />
+        <CredentialResolver type="File"
+            use="encryption"
+            key="sp-key.pem"
+            certificate="sp-cert.pem" />
+    </ApplicationDefaults>
+    <SecurityPolicyProvider type="XML" validate="true" path="security-policy.xml" />
+    <ProtocolProvider type="XML"
+        validate="true"
+        reloadChanges="false"
+        path="protocols.xml" />
+</SPConfig>

--- a/releasenotes/notes/SAML-Federation-upgrades-da9aab798b240ce4.yaml
+++ b/releasenotes/notes/SAML-Federation-upgrades-da9aab798b240ce4.yaml
@@ -1,0 +1,53 @@
+---
+upgrade:
+  - |
+    When upgrading from a previous release of Genestack, if SAML Federation
+    was enabled, you must update the HTTP Routes for both Keystone and
+    Skyline. During the development of the SAML Federation feature,
+    Keystone and Skyline HTTRoutes were updated to have cookie driven session
+    persistence to ensure compatibility with Shibboleth.
+
+    ::
+
+      Full example files for the HTTP Routes can be found in the
+      ``etc/gateway-api/routes`` directory.
+
+    The following stanza should be added to the HTTP Routes for Keystone; file typically
+    located at ``/etc/genestack/gateway-api/routes/custom-keystone-gateway-route.yaml``.
+
+    .. code-block:: yaml
+
+      sessionPersistence:
+        sessionName: KeystoneSession
+        type: Cookie
+        absoluteTimeout: 300s
+        cookieConfig:
+          lifetimeType: Permanent
+
+    The following stanza should be added to the HTTP Routes for Skyline; file typically
+    located at ``/etc/genestack/gateway-api/routes/custom-skyline-gateway-route.yaml``.
+
+    .. code-block:: yaml
+
+      sessionPersistence:
+        sessionName: SkylineSession
+        type: Cookie
+        absoluteTimeout: 300s
+        cookieConfig:
+          lifetimeType: Permanent
+
+    Once the configuration is updated, Run the deployment update with the
+    following apply commands.
+
+    .. code-block:: shell
+
+      kubectl -n openstack apply -f /etc/genestack/gateway-api/routes/custom-keystone-gateway-route.yaml
+      kubectl -n openstack apply -f /etc/genestack/gateway-api/routes/custom-skyline-gateway-route.yaml
+
+    Once the HTTP Routes are updated, verify that the changes have been
+    applied by checking the status of the HTTP Routes.
+
+    .. code-block:: shell
+
+      kubectl -n openstack get httproutes.gateway.networking.k8s.io custom-keystone-gateway-route -o yaml
+      kubectl -n openstack get httproutes.gateway.networking.k8s.io custom-skyline-gateway-route -o yaml


### PR DESCRIPTION
Adding Masakari installation to Genestack. This feature will allow for automated failover of VMs in case of compute node failure utilizing the kube-api to check for compute node uptime. This also includes VM uptime failover in cases of sudden VM failure at the KVM level.

future implementation includes masakari-instance-introspection, which will need many updates to the masakari upstream helm chart.