### PR TITLE
Limit memcached to control plane placement

### DIFF
--- a/base-helm-configs/memcached/memcached-helm-overrides.yaml
+++ b/base-helm-configs/memcached/memcached-helm-overrides.yaml
@@ -303,19 +303,12 @@ nodeAffinityPreset:
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ## Note: podAffinityPreset, podAntiAffinityPreset, and nodeAffinityPreset will be ignored when it's set
 ##
-affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-        - matchExpressions:
-            - key: node-role.kubernetes.io/worker
-              operator: In
-              values:
-                - worker
+affinity: {}
 ## @param nodeSelector Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
 ##
-nodeSelector: {}
+nodeSelector:
+  openstack-control-plane: enabled
 ## @param tolerations Tolerations for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
@@ -413,7 +406,7 @@ enableServiceLinks: true
 ##
 autoscaling:
   enabled: true
-  minReplicas: 3
+  minReplicas: 1
   maxReplicas: 6
   targetCPU: 50
   targetMemory: 50

--- a/releasenotes/notes/memcached-placement-be7d472ba25cb94f.yaml
+++ b/releasenotes/notes/memcached-placement-be7d472ba25cb94f.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    The memcached helm chart now places memcached on the openstack control plane
+    using the label `openstack-control-plane=enabled`.
+    Min replicas set to 1 as default setting and can be change according the
+    control plane installation.


### PR DESCRIPTION
The memcached helm chart now places memcached on the openstack controlplane using the label `openstack-control-plane=enabled`. The min replica set to 1 as default setting.