### PR TITLE
chore: Upgrade Kube-OVN to 1.13.x

### DIFF
--- a/base-helm-configs/kube-ovn/kube-ovn-helm-overrides.yaml
+++ b/base-helm-configs/kube-ovn/kube-ovn-helm-overrides.yaml
@@ -3,14 +3,13 @@
 # Declare variables to be passed into your templates.
 global:
   registry:
-    address: ghcr.io/rackerlabs
+    address: docker.io/kubeovn
     imagePullSecrets: []
   images:
     kubeovn:
       repository: kube-ovn
-      dpdkRepository: kube-ovn-dpdk
       vpcRepository: vpc-nat-gateway
-      tag: v1.12.32
+      tag: v1.13.13
       support_arm: true
       thirdparty: true
 

--- a/base-kustomize/ovn-backup/base/ovn-backup.yaml
+++ b/base-kustomize/ovn-backup/base/ovn-backup.yaml
@@ -50,7 +50,7 @@ spec:
                 - secretRef:
                     name: ovn-backup-swift-tempauth-account
               command: ["/backup-script/ovn-backup.sh"]
-              image: docker.io/kubeovn/kube-ovn:v1.12.30
+              image: docker.io/kubeovn/kube-ovn:v1.13.13
               imagePullPolicy: IfNotPresent
               volumeMounts:
                 - name: backup

--- a/bin/install-kube-ovn.sh
+++ b/bin/install-kube-ovn.sh
@@ -4,7 +4,7 @@
 GLOBAL_OVERRIDES_DIR="/etc/genestack/helm-configs/global_overrides"
 SERVICE_CONFIG_DIR="/etc/genestack/helm-configs/kube-ovn"
 BASE_OVERRIDES="/opt/genestack/base-helm-configs/kube-ovn/kube-ovn-helm-overrides.yaml"
-KUBE_OVN_VERSION="v1.12.31"
+KUBE_OVN_VERSION="v1.13.13"
 MASTER_NODES=$(kubectl get nodes -l kube-ovn/role=master -o json | jq -r '[.items[].status.addresses[] | select(.type == "InternalIP") | .address] | join(",")' | sed 's/,/\\,/g')
 MASTER_NODE_COUNT=$(kubectl get nodes -l kube-ovn/role=master -o json | jq -r '.items[].status.addresses[] | select(.type=="InternalIP") | .address' | wc -l)
 

--- a/docs/infrastructure-ovn-db-backup.md
+++ b/docs/infrastructure-ovn-db-backup.md
@@ -84,7 +84,7 @@ spec:
       - "/usr/bin/sleep"
     args:
       - "infinity"
-    image: docker.io/kubeovn/kube-ovn:v1.12.30
+    image: docker.io/kubeovn/kube-ovn:v1.13.13
     volumeMounts:
     - mountPath: /etc/ovn
       name: host-config-ovn

--- a/docs/ovn-troubleshooting.md
+++ b/docs/ovn-troubleshooting.md
@@ -16,9 +16,9 @@ openstack server show ${INSTANCE_UUID} -c hypervisor_hostname
 ## Kube-OVN kubectl plugin
 
 - Kube-OVN has a `kubectl` plugin.
-- You can see documentation at [the Kube-OVN documentation](https://kubeovn.github.io/docs/v1.12.x/en/)
+- You can see documentation at [the Kube-OVN documentation](https://kubeovn.github.io/docs/v1.13.x/en/)
 - You should install it from wherever you would like to use `kubectl` from, as described
-      [here](https://kubeovn.github.io/docs/v1.12.x/en/ops/kubectl-ko/#plugin-installation)
+      [here](https://kubeovn.github.io/docs/v1.13.x/en/ops/kubectl-ko/#plugin-installation)
   - However, you will also find it already on installed on _Genestack_ Kubernetes
       nodes, so you can use it with `kubectl` there, if desired.
 - You can use this to run many OVS commands for a particular node


### PR DESCRIPTION
This change updates our deployment of Kube-OVN to 1.13.x which is a major version upgrade, but also a shift to the new stable release.