### PR TITLE
Consolidate metallb configuration

### DIFF
--- a/base-kustomize/rabbitmq-cluster/base/rabbitmq-cluster.yaml
+++ b/base-kustomize/rabbitmq-cluster/base/rabbitmq-cluster.yaml
@@ -1,10 +1,11 @@
+---
 apiVersion: rabbitmq.com/v1beta1
 kind: RabbitmqCluster
 metadata:
   name: rabbitmq
   namespace: openstack
   annotations:
-    metallb.universe.tf/address-pool: pool1
+    metallb.universe.tf/address-pool: primary
 spec:
   replicas: 3
   resources:
@@ -38,13 +39,13 @@ spec:
                   - worker
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchExpressions:
+        - labelSelector:
+            matchExpressions:
               - key: app.kubernetes.io/name
                 operator: In
                 values:
-                - rabbitmq
-        topologyKey: kubernetes.io/hostname
+                  - rabbitmq
+          topologyKey: kubernetes.io/hostname
   override:
     service:
       spec:
@@ -55,12 +56,13 @@ spec:
           spec:
             containers: []
             topologySpreadConstraints:
-            - maxSkew: 1
-              topologyKey: "topology.kubernetes.io/zone"
-              whenUnsatisfiable: ScheduleAnyway  # This should be changed to DoNotSchedule for production
-              labelSelector:
-                matchLabels:
-                  app.kubernetes.io/name: openstack
+              - maxSkew: 1
+                topologyKey: "topology.kubernetes.io/zone"
+                # Should be changed to DoNotSchedule for production
+                whenUnsatisfiable: ScheduleAnyway
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: openstack
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/manifests/metallb/metallb-openstack-service-lb.yml
+++ b/manifests/metallb/metallb-openstack-service-lb.yml
@@ -20,5 +20,29 @@ spec:
   nodeSelectors:  # Optional block to limit nodes for a given advertisement
     - matchLabels:
         node-role.kubernetes.io/worker: worker
-  # interfaces:  # Optional block to limit ifaces used to advertise VIPs
-  #   - br-mgmt
+#  interfaces:  # Optional block to limit ifaces used to advertise VIPs
+#    - br-host
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: primary
+  namespace: metallb-system
+spec:
+  addresses:
+    - 10.234.0.0/24
+  autoAssign: false
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: cluster-internal-advertisement
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - primary
+  nodeSelectors:  # Optional block to limit nodes for a given advertisement
+    - matchLabels:
+        node-role.kubernetes.io/worker: worker
+#  interfaces:  # Optional block to limit ifaces used to advertise VIPs
+#    - br-host

--- a/releasenotes/notes/metallb-consolidation-52e5d0d301cc216b.yaml
+++ b/releasenotes/notes/metallb-consolidation-52e5d0d301cc216b.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    The metallb configuration is now consolidated and cleaned up by providing the
+    metallb IP address pools:
+    - `gateway-api-external` for Envoy
+    - `primary` for all internal services including MariaDB, RabbitMQ and others
+    - The pool `pool1` is replaced by `primary`


### PR DESCRIPTION
The metallb configuration is now consolidated and cleaned up by providing the metallb IP address pools:
- `gateway-api-external` for Envoy/Nginx
- `primary` for all internal services including MariaDB, RabbitMQ and others
- The pool `pool1` is replaced by `primary`