### PR TITLE
fix: (hpa) rework hpa values based on minReplicas=2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,7 @@ repos:
           - >-
             -d {extends: default, rules: {line-length: disable},
             ignore: [submodules/]}
+            #, min-spaces-from-content: 1}
   - repo: https://github.com/ansible-community/ansible-lint
     rev: v24.9.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,6 @@ repos:
           - >-
             -d {extends: default, rules: {line-length: disable},
             ignore: [submodules/]}
-            #, min-spaces-from-content: 1}
   - repo: https://github.com/ansible-community/ansible-lint
     rev: v24.9.2
     hooks:

--- a/base-helm-configs/barbican/barbican-helm-overrides.yaml
+++ b/base-helm-configs/barbican/barbican-helm-overrides.yaml
@@ -22,8 +22,8 @@ pod:
     enabled: true
     api:
       requests:
-        memory: "384Mi"
-        cpu: "200m"
+        memory: "256Mi"
+        cpu: "100m"
       limits: {}
 
 dependencies:

--- a/base-helm-configs/barbican/barbican-helm-overrides.yaml
+++ b/base-helm-configs/barbican/barbican-helm-overrides.yaml
@@ -73,7 +73,7 @@ conf:
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
       # DEPRECIATION:  (warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: True
+      heartbeat_in_pthread: true
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617

--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -1766,32 +1766,32 @@ pod:
     enabled: true
     compute:
       requests:
-        memory: "128Mi"
-        cpu: "100m"
+        memory: {}
+        cpu: {}
       limits:
-        memory: "6144Mi"
-        cpu: "2000m"
+        memory: {}
+        cpu: {}
     notification:
       requests:
-        memory: "256Mi"
-        cpu: "100m"
+        memory: {}
+        cpu: {}
       limits:
-        memory: "6144Mi"
-        cpu: "2000m"
+        memory: {}
+        cpu: {}
     central:
       requests:
-        memory: "128Mi"
-        cpu: "100m"
+        memory: {}
+        cpu: {}
       limits:
-        memory: "6144Mi"
-        cpu: "2000m"
+        memory: {}
+        cpu: {}
     ipmi:
       requests:
-        memory: "124Mi"
-        cpu: "100m"
+        memory: {}
+        cpu: {}
       limits:
-        memory: "6144Mi"
-        cpu: "2000m"
+        memory: {}
+        cpu: {}
   replicas:
     central: 1
     notification: 1

--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -80,7 +80,7 @@ conf:
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
       # DEPRECIATION:  (warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: True
+      heartbeat_in_pthread: true
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617

--- a/base-helm-configs/cinder/cinder-helm-overrides.yaml
+++ b/base-helm-configs/cinder/cinder-helm-overrides.yaml
@@ -136,7 +136,7 @@ conf:
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
       # DEPRECIATION:  (warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: True
+      heartbeat_in_pthread: true
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617

--- a/base-helm-configs/cinder/cinder-helm-overrides.yaml
+++ b/base-helm-configs/cinder/cinder-helm-overrides.yaml
@@ -34,13 +34,13 @@ pod:
     enabled: true
     api:
       requests:
-        memory: "512Mi"
-        cpu: "300m"
+        memory: "384Mi"
+        cpu: "100m"
       limits: {}
     scheduler:
       requests:
-        memory: "256Mi"
-        cpu: "300m"
+        memory: "192Mi"
+        cpu: "100m"
       limits: {}
   security_context:
     cinder_api:

--- a/base-helm-configs/designate/designate-helm-overrides.yaml
+++ b/base-helm-configs/designate/designate-helm-overrides.yaml
@@ -149,7 +149,7 @@ pod:
         cpu: {}
       limits:
         memory: {}
-        cpu: {}      
+        cpu: {}
 
 network:
   api:
@@ -437,7 +437,7 @@ conf:
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
       # DEPRECIATION:  (warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: True
+      heartbeat_in_pthread: true
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617

--- a/base-helm-configs/designate/designate-helm-overrides.yaml
+++ b/base-helm-configs/designate/designate-helm-overrides.yaml
@@ -141,73 +141,15 @@ pod:
         timeout: 30
       mdns:
         timeout: 30
-
   resources:
     enabled: true
     api:
       requests:
-        memory: "128Mi"
-        cpu: "100m"
+        memory: {}
+        cpu: {}
       limits:
-        memory: "4096Mi"
-        cpu: "2000m"
-    jobs:
-      bootstrap:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      db_init:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      db_sync:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      ks_endpoints:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      ks_service:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      ks_user:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      rabbit_init:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
-      tests:
-        requests:
-          memory: "128Mi"
-          cpu: "100m"
-        limits:
-          memory: "1024Mi"
-          cpu: "2000m"
+        memory: {}
+        cpu: {}      
 
 network:
   api:

--- a/base-helm-configs/glance/glance-helm-overrides.yaml
+++ b/base-helm-configs/glance/glance-helm-overrides.yaml
@@ -108,7 +108,7 @@ conf:
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
       # DEPRECIATION:  (warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: True
+      heartbeat_in_pthread: true
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617

--- a/base-helm-configs/glance/glance-helm-overrides.yaml
+++ b/base-helm-configs/glance/glance-helm-overrides.yaml
@@ -245,7 +245,7 @@ pod:
     api:
       requests:
         memory: "384Mi"
-        cpu: "300m"
+        cpu: "100m"
       limits: {}
   replicas:
     api: 1

--- a/base-helm-configs/heat/heat-helm-overrides.yaml
+++ b/base-helm-configs/heat/heat-helm-overrides.yaml
@@ -27,18 +27,18 @@ pod:
     enabled: true
     api:
       requests:
-        memory: "384Mi"
-        cpu: "300m"
+        memory: "256Mi"
+        cpu: "100m"
       limits: {}
     cfn:
       requests:
-        memory: "384Mi"
-        cpu: "300m"
+        memory: "256Mi"
+        cpu: "100m"
       limits: {}
     engine:
       requests:
-        memory: "384Mi"
-        cpu: "300m"
+        memory: "256Mi"
+        cpu: "100m"
       limits: {}
 
 conf:

--- a/base-helm-configs/heat/heat-helm-overrides.yaml
+++ b/base-helm-configs/heat/heat-helm-overrides.yaml
@@ -86,7 +86,7 @@ conf:
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
       # DEPRECIATION:  (warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: True
+      heartbeat_in_pthread: true
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617

--- a/base-helm-configs/ironic/ironic-helm-overrides.yaml
+++ b/base-helm-configs/ironic/ironic-helm-overrides.yaml
@@ -75,7 +75,7 @@ conf:
       rabbit_interval_max: 10
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
-      heartbeat_in_pthread: True # Note: Deprecation warning for 2024.2
+      heartbeat_in_pthread: true # Note: Deprecation warning for 2024.2
       kombu_reconnect_delay: 0.5
     pxe:
       pxe_append_params: "nofb nomodeset vga=normal ipa-debug=1"

--- a/base-helm-configs/keystone/keystone-helm-overrides.yaml
+++ b/base-helm-configs/keystone/keystone-helm-overrides.yaml
@@ -27,8 +27,10 @@ pod:
     api:
       requests:
         memory: "512Mi"
-        cpu: "500m"
-      limits: {}
+        cpu: "2"
+      limits:
+        memory: 2Gi
+        cpu: "4"
 
 dependencies:
   static:

--- a/base-helm-configs/keystone/keystone-helm-overrides.yaml
+++ b/base-helm-configs/keystone/keystone-helm-overrides.yaml
@@ -77,7 +77,7 @@ conf:
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
       # DEPRECIATION:  (warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: True
+      heartbeat_in_pthread: true
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617

--- a/base-helm-configs/magnum/magnum-helm-overrides.yaml
+++ b/base-helm-configs/magnum/magnum-helm-overrides.yaml
@@ -22,15 +22,15 @@ pod:
     enabled: true
     api:
       requests:
-        memory: "384Mi"
+        memory: "256Mi"
         cpu: "300m"
       limits: {}
     conductor:
       requests:
-        memory: "768Mi"
+        memory: "512Mi"
         cpu: "300m"
       limits:
-        memory: "3072Mi"
+        memory: "2048Mi"
         cpu: "2000m"
 
 conf:

--- a/base-helm-configs/magnum/magnum-helm-overrides.yaml
+++ b/base-helm-configs/magnum/magnum-helm-overrides.yaml
@@ -101,7 +101,7 @@ conf:
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
       # NOTE (deprecation warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: True
+      heartbeat_in_pthread: true
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617

--- a/base-helm-configs/masakari/masakari-helm-overrides.yaml
+++ b/base-helm-configs/masakari/masakari-helm-overrides.yaml
@@ -29,8 +29,33 @@ images:
     dep_check: quay.io/airshipit/kubernetes-entrypoint:latest-ubuntu_focal
   pull_policy: "IfNotPresent"
 
+# NOTE: (brew) requests cpu/mem values based on a three node
+# hyperconverged lab (/scripts/hyperconverged-lab.sh).
+# limit values based on defaults from the openstack-helm charts unless defined
+pod:
+  resources:
+    enabled: true
+    masakari_api:
+      requests:
+        memory: "256Mi"
+        cpu: "100m"
+      limits:
+        memory: "1024Mi"
+        cpu: "2000m"
+    masakari_engine:
+      requests: {}
+      limits: {}
+    masakari_host_monitor:
+      requests:
+        memory: "192Mi"
+        cpu: "100m"
+      limits: {}        
+    masakari_instance_monitor:
+      requests: {}
+      limits: {}
+
 endpoints:
-  identiy:
+  identity:
     port:
       api:
         default: 5000

--- a/base-helm-configs/masakari/masakari-helm-overrides.yaml
+++ b/base-helm-configs/masakari/masakari-helm-overrides.yaml
@@ -49,7 +49,7 @@ pod:
       requests:
         memory: "192Mi"
         cpu: "100m"
-      limits: {}        
+      limits: {}
     masakari_instance_monitor:
       requests: {}
       limits: {}
@@ -132,7 +132,7 @@ conf:
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
       # DEPRECIATION:  (warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: True
+      heartbeat_in_pthread: true
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617

--- a/base-helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/base-helm-configs/neutron/neutron-helm-overrides.yaml
@@ -136,7 +136,7 @@ conf:
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
       # NOTE (deprecation warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: True
+      heartbeat_in_pthread: true
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617

--- a/base-helm-configs/nova/nova-helm-overrides.yaml
+++ b/base-helm-configs/nova/nova-helm-overrides.yaml
@@ -296,19 +296,13 @@ pod:
       requests:
         memory: "384Mi"
         cpu: "300m"
-      limits:
-        memory: "1024Mi"
-        cpu: "2000m"
+      limits: {}
     ssh:
-      requests:
-        memory: "512Mi"
-        cpu: "200m"
-      limits:
-        memory: "4096Mi"
-        cpu: "4000m"
+      requests: {}
+      limits: {}
     api:
       requests:
-        memory: "640Mi"
+        memory: "512Mi"
         cpu: "500m"
       limits: {}
     conductor:

--- a/base-helm-configs/nova/nova-helm-overrides.yaml
+++ b/base-helm-configs/nova/nova-helm-overrides.yaml
@@ -168,7 +168,7 @@ conf:
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
       # NOTE (deprecation warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: True
+      heartbeat_in_pthread: true
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617

--- a/base-helm-configs/octavia/octavia-helm-overrides.yaml
+++ b/base-helm-configs/octavia/octavia-helm-overrides.yaml
@@ -187,7 +187,9 @@ pod:
       requests:
         memory: "768Mi"
         cpu: "300m"
-      limits: {}
+      limits:
+        memory: "3072Mi"
+        cpu: "2000m"
     worker:
       requests:
         memory: "256Mi"

--- a/base-helm-configs/octavia/octavia-helm-overrides.yaml
+++ b/base-helm-configs/octavia/octavia-helm-overrides.yaml
@@ -109,7 +109,7 @@ conf:
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
       # NOTE (deprecation warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: True
+      heartbeat_in_pthread: true
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617

--- a/base-helm-configs/placement/placement-helm-overrides.yaml
+++ b/base-helm-configs/placement/placement-helm-overrides.yaml
@@ -54,7 +54,7 @@ conf:
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
       # NOTE (deprecation warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: True
+      heartbeat_in_pthread: true
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617

--- a/base-kustomize/barbican/base/hpa-barbican-api.yaml
+++ b/base-kustomize/barbican/base/hpa-barbican-api.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/ceilometer/base/hpa-ceilometer-notification.yaml
+++ b/base-kustomize/ceilometer/base/hpa-ceilometer-notification.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/base-kustomize/ceilometer/base/hpa-ceilometer-notification.yaml
+++ b/base-kustomize/ceilometer/base/hpa-ceilometer-notification.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/cinder/base/hpa-cinder-api.yaml
+++ b/base-kustomize/cinder/base/hpa-cinder-api.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/cinder/base/hpa-cinder-scheduler.yaml
+++ b/base-kustomize/cinder/base/hpa-cinder-scheduler.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/cinder/netapp/hpa-cinder-volume-netapp.yaml
+++ b/base-kustomize/cinder/netapp/hpa-cinder-volume-netapp.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/base-kustomize/cinder/netapp/hpa-cinder-volume-netapp.yaml
+++ b/base-kustomize/cinder/netapp/hpa-cinder-volume-netapp.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/designate/base/hpa-designate-api.yaml
+++ b/base-kustomize/designate/base/hpa-designate-api.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/base-kustomize/designate/base/hpa-designate-api.yaml
+++ b/base-kustomize/designate/base/hpa-designate-api.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/envoyproxy-gateway/base/envoy-custom-proxy-config.yaml
+++ b/base-kustomize/envoyproxy-gateway/base/envoy-custom-proxy-config.yaml
@@ -11,7 +11,7 @@ spec:
       envoyService:
         externalTrafficPolicy: Cluster
       envoyHpa:
-        minReplicas: 1
+        minReplicas: 2
         maxReplicas: 9
         metrics:
           - resource:

--- a/base-kustomize/glance/base/hpa-glance-api.yaml
+++ b/base-kustomize/glance/base/hpa-glance-api.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/gnocchi/base/hpa-gnocchi-api.yaml
+++ b/base-kustomize/gnocchi/base/hpa-gnocchi-api.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/base-kustomize/gnocchi/base/hpa-gnocchi-api.yaml
+++ b/base-kustomize/gnocchi/base/hpa-gnocchi-api.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/heat/base/hpa-heat-api.yaml
+++ b/base-kustomize/heat/base/hpa-heat-api.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/heat/base/hpa-heat-cfn.yaml
+++ b/base-kustomize/heat/base/hpa-heat-cfn.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/heat/base/hpa-heat-engine.yaml
+++ b/base-kustomize/heat/base/hpa-heat-engine.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/horizon/base/hpa-horizon-api.yaml
+++ b/base-kustomize/horizon/base/hpa-horizon-api.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/base-kustomize/horizon/base/hpa-horizon-api.yaml
+++ b/base-kustomize/horizon/base/hpa-horizon-api.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/ironic/base/hpa-iconic-conductor.yaml
+++ b/base-kustomize/ironic/base/hpa-iconic-conductor.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/base-kustomize/ironic/base/hpa-iconic-conductor.yaml
+++ b/base-kustomize/ironic/base/hpa-iconic-conductor.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/ironic/base/hpa-ironic-api.yaml
+++ b/base-kustomize/ironic/base/hpa-ironic-api.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/base-kustomize/ironic/base/hpa-ironic-api.yaml
+++ b/base-kustomize/ironic/base/hpa-ironic-api.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openstack
   spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/keystone/base/hpa-keystone-api.yaml
+++ b/base-kustomize/keystone/base/hpa-keystone-api.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/base-kustomize/keystone/base/hpa-keystone-api.yaml
+++ b/base-kustomize/keystone/base/hpa-keystone-api.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/magnum/base/hpa-magnum-api.yaml
+++ b/base-kustomize/magnum/base/hpa-magnum-api.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/magnum/base/hpa-magnum-conductor.yaml
+++ b/base-kustomize/magnum/base/hpa-magnum-conductor.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/masakari/base/hpa-masakari-api.yaml
+++ b/base-kustomize/masakari/base/hpa-masakari-api.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/masakari/base/hpa-masakari-api.yaml
+++ b/base-kustomize/masakari/base/hpa-masakari-api.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 3
+  minReplicas: 1
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/masakari/base/masakari-rabbitmq-queue.yaml
+++ b/base-kustomize/masakari/base/masakari-rabbitmq-queue.yaml
@@ -8,10 +8,10 @@ metadata:
     helm.sh/resource-policy: keep
 spec:
   tags:
-    - management   # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
+    - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
     - policymaker
   rabbitmqClusterReference:
-    name: rabbitmq   # rabbitmqCluster must exist in the same namespace as this resource
+    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack
   importCredentialsSecret:
     name: masakari-rabbitmq-password
@@ -24,10 +24,10 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
 spec:
-  name: "masakari"   # vhost name; required and cannot be updated
-  defaultQueueType: quorum   # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
+  name: "masakari" # vhost name; required and cannot be updated
+  defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
   rabbitmqClusterReference:
-    name: rabbitmq   # rabbitmqCluster must exist in the same namespace as this resource
+    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack
 ---
 apiVersion: rabbitmq.com/v1beta1
@@ -38,13 +38,13 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
 spec:
-  name: masakari-qq   # name of the queue
-  vhost: "masakari"   # default to '/' if not provided
-  type: quorum   # without providing a queue type, rabbitmq creates a classic queue
+  name: masakari-qq # name of the queue
+  vhost: "masakari" # default to '/' if not provided
+  type: quorum # without providing a queue type, rabbitmq creates a classic queue
   autoDelete: false
-  durable: true   # seting 'durable' to false means this queue won't survive a server restart
+  durable: true # seting 'durable' to false means this queue won't survive a server restart
   rabbitmqClusterReference:
-    name: rabbitmq   # rabbitmqCluster must exist in the same namespace as this resource
+    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack
 ---
 apiVersion: rabbitmq.com/v1beta1
@@ -55,13 +55,13 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
 spec:
-  vhost: "masakari"   # name of a vhost
+  vhost: "masakari" # name of a vhost
   userReference:
-    name: "masakari"   # name of a user.rabbitmq.com in the same namespace; must specify either spec.userReference or spec.user
+    name: "masakari" # name of a user.rabbitmq.com in the same namespace; must specify either spec.userReference or spec.user
   permissions:
     write: ".*"
     configure: ".*"
     read: ".*"
   rabbitmqClusterReference:
-    name: rabbitmq   # rabbitmqCluster must exist in the same namespace as this resource
+    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack

--- a/base-kustomize/memcached/base/hpa.yaml
+++ b/base-kustomize/memcached/base/hpa.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/base-kustomize/memcached/base/hpa.yaml
+++ b/base-kustomize/memcached/base/hpa.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   $patch: replace
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - type: Resource
       resource:

--- a/base-kustomize/neutron/base/hpa-neutron-rpc-server.yaml
+++ b/base-kustomize/neutron/base/hpa-neutron-rpc-server.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/base-kustomize/neutron/base/hpa-neutron-rpc-server.yaml
+++ b/base-kustomize/neutron/base/hpa-neutron-rpc-server.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/neutron/base/hpa-neutron-server.yaml
+++ b/base-kustomize/neutron/base/hpa-neutron-server.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/base-kustomize/neutron/base/hpa-neutron-server.yaml
+++ b/base-kustomize/neutron/base/hpa-neutron-server.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/neutron/base/neutron-rabbitmq-queue.yaml
+++ b/base-kustomize/neutron/base/neutron-rabbitmq-queue.yaml
@@ -12,8 +12,8 @@ metadata:
     meta.helm.sh/release-namespace: "openstack"
 spec:
   tags:
-  - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
-  - policymaker
+    - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
+    - policymaker
   rabbitmqClusterReference:
     name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack

--- a/base-kustomize/nova/base/hpa-nova-api-metadata.yaml
+++ b/base-kustomize/nova/base/hpa-nova-api-metadata.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/nova/base/hpa-nova-api-osapi.yaml
+++ b/base-kustomize/nova/base/hpa-nova-api-osapi.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/nova/base/hpa-nova-conductor.yaml
+++ b/base-kustomize/nova/base/hpa-nova-conductor.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/nova/base/hpa-nova-novncproxy.yaml
+++ b/base-kustomize/nova/base/hpa-nova-novncproxy.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/nova/base/hpa-nova-scheduler.yaml
+++ b/base-kustomize/nova/base/hpa-nova-scheduler.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/nova/base/nova-rabbitmq-queue.yaml
+++ b/base-kustomize/nova/base/nova-rabbitmq-queue.yaml
@@ -12,8 +12,8 @@ metadata:
     meta.helm.sh/release-namespace: "openstack"
 spec:
   tags:
-  - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
-  - policymaker
+    - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
+    - policymaker
   rabbitmqClusterReference:
     name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
     namespace: openstack

--- a/base-kustomize/octavia/base/hpa-octavia-api.yaml
+++ b/base-kustomize/octavia/base/hpa-octavia-api.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/octavia/base/hpa-octavia-worker.yaml
+++ b/base-kustomize/octavia/base/hpa-octavia-worker.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/placement/base/hpa-placement-api.yaml
+++ b/base-kustomize/placement/base/hpa-placement-api.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/base-kustomize/placement/base/hpa-placement-api.yaml
+++ b/base-kustomize/placement/base/hpa-placement-api.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: cpu

--- a/base-kustomize/skyline/base/hpa-skyline-apiserver.yaml
+++ b/base-kustomize/skyline/base/hpa-skyline-apiserver.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -7,6 +8,13 @@ spec:
   maxReplicas: 9
   minReplicas: 2
   metrics:
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 80
+          type: Utilization
+      type: Resource
     - resource:
         name: memory
         target:

--- a/base-kustomize/skyline/base/hpa-skyline-apiserver.yaml
+++ b/base-kustomize/skyline/base/hpa-skyline-apiserver.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openstack
 spec:
   maxReplicas: 9
-  minReplicas: 1
+  minReplicas: 2
   metrics:
     - resource:
         name: memory

--- a/base-kustomize/skyline/base/hpa-skyline-apiserver.yaml
+++ b/base-kustomize/skyline/base/hpa-skyline-apiserver.yaml
@@ -8,7 +8,6 @@ spec:
   maxReplicas: 9
   minReplicas: 2
   metrics:
-  metrics:
     - resource:
         name: cpu
         target:

--- a/releasenotes/notes/hpa-refactor-c7dfb942d67c18b6.yaml
+++ b/releasenotes/notes/hpa-refactor-c7dfb942d67c18b6.yaml
@@ -1,20 +1,22 @@
 ---
 features:
   - |
-    HPA will now trigger off CPU as well as RAM.  OpenStack services ram
-    consumption is fairly static based on the number of workers, threads,
-    and processes.  With this change, CPU consumption will now also be
-    considered for horizontal auto scaling.
+    HPA will now trigger off CPU utilization as well as RAM consumption.
+    OpenStack services ram consumption is fairly static based on the number
+    of workers, threads, and processes.  With this change, CPU consumption
+    will now also be considered for horizontal auto scaling.
 
     In order to ensure that HPA has been properly tuned for a 3-node
     hyper-converged lab deployment (our recommended lab/testing deployment)
     this change will also standardize, across all OpenStack services, the
     number of workers to 2, the number or processes to 2, and the number of
-    threads per process to 1.  While this is NOT a breaking change, it will
-    change the resource consumption of any deployment going forward.
+    threads per process to 1.
+    Additionally, we will reduce the minReplicas from 3 to 2 to reduce
+    overall resource usage while still maintaining a fault tolerant cluster.
 
-    Finally, this change also reduces the minReplica's for HPA from 3 to 1.
-    This is to allow HPA to control resource utilization on a per-need basis.
+    While this is NOT a breaking change, it will change the resource consumption
+    of any deployment going forward.
+
 other:
   - |
     Current HPA values included in this change were determined using the,


### PR DESCRIPTION
A rework of the base HPA values to take into account the change from minReplicas of 3 to minReplicas to 2 first applied in pr: https://github.com/rackerlabs/genestack/pull/982
