### PR TITLE
chore: update federation doc

### DIFF
--- a/base-helm-configs/keystone/keystone-helm-overrides-saml.yaml.example
+++ b/base-helm-configs/keystone/keystone-helm-overrides-saml.yaml.example
@@ -6,7 +6,8 @@ conf:
         - shib
   keystone:
     auth:
-      methods: "password,token,saml2,application_credential,totp"
+      methods: "saml2,password,token,application_credential,totp"
+      saml2: "rxt"
     saml2:
       remote_id_attribute: Shib-Identity-Provider
     federation:

--- a/etc/keystone/Rackspace-Federation.json
+++ b/etc/keystone/Rackspace-Federation.json
@@ -1,0 +1,82 @@
+[
+    {
+        "local": [
+            {
+                "user": {
+                    "id": "{0}",
+                    "name": "{1}",
+                    "email": "{2}",
+                    "domain": {
+                        "name": "rackspace_cloud_domain"
+                    }
+                }
+            },
+            {
+                "projects": [
+                    {
+                        "name": "{3}",
+                        "domain": {
+                            "name": "rackspace_cloud_domain"
+                        },
+                        "description": "Project for DDI {4}",
+                        "metadata": [
+                            {
+                                "key": "ddi",
+                                "value": "{4}"
+                            }
+                        ],
+                        "tags": [
+                            {
+                                "project_tag": "{4}"
+                            }
+                        ],
+                        "roles": []
+                    }
+                ]
+            }
+        ],
+        "remote": [
+            {
+                "type": "uid"
+            },
+            {
+                "type": "REMOTE_USERNAME"
+            },
+            {
+                "type": "REMOTE_EMAIL"
+            },
+            {
+                "type": "REMOTE_PROJECTS"
+            },
+            {
+                "type": "REMOTE_DDI"
+            },
+            {
+                "type": "REMOTE_SESSION_CREATION"
+            },
+            {
+                "type": "REMOTE_SCOPED_TOKEN"
+            },
+            {
+                "type": "REMOTE_DOMAIN"
+            },
+            {
+                "type": "REMOTE_AUTH_URL"
+            },
+            {
+                "type": "REMOTE_AUTH_TOKEN"
+            },
+            {
+                "type": "REMOTE_ACCOUNT_NAME"
+            },
+            {
+                "type": "RXT_orgPersonType",
+                "any_one_of": [
+                    "creator",
+                    "member",
+                    "reader"
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
This change updates the federation docs to cleanup some sections and show how the OpenStack API can be used with Application credentials. The change also includes the Rackspace Federation JSON file, which is used for the RXT mapping.