### PR TITLE
Feat: Add predictable iscsi initiator name to Ansible playbooks

### DIFF
--- a/ansible/playbooks/deploy-cinder-netapp-volumes-reference.yaml
+++ b/ansible/playbooks/deploy-cinder-netapp-volumes-reference.yaml
@@ -48,6 +48,23 @@
         state: present
         update_cache: true
 
+    - name: Determine iscsi initiator name
+      set_fact:
+        initiator_name: >
+          {% set _iqn = "iqn.2004-10.com." + ansible_distribution |lower() + ":" + ansible_hostname -%}
+          {% if ansible_iscsi_iqn is defined -%}
+          {% if (ansible_iscsi_iqn |length >= 15) -%}
+          {% set _iqn = ansible_iscsi_iqn  -%}
+          {% endif -%}
+          {% endif -%}
+          {{ _iqn }}
+
+    - name: Set iscsi initiator name if not set
+      ansible.builtin.lineinfile:
+        path: /etc/iscsi/initiatorname.iscsi
+        regexp: '^InitiatorName=.*|^GenerateName=.*'
+        line: "InitiatorName={{ initiator_name }}"
+
     - name: Upgrade pip and install required packages
       ansible.builtin.pip:
         name:

--- a/ansible/playbooks/deploy-cinder-volumes-reference.yaml
+++ b/ansible/playbooks/deploy-cinder-volumes-reference.yaml
@@ -60,6 +60,23 @@
         state: present
         update_cache: true
 
+    - name: Determine iscsi initiator name
+      set_fact:
+        initiator_name: >
+          {% set _iqn = "iqn.2004-10.com." + ansible_distribution |lower() + ":" + ansible_hostname -%}
+          {% if ansible_iscsi_iqn is defined -%}
+          {% if (ansible_iscsi_iqn |length >= 15) -%}
+          {% set _iqn = ansible_iscsi_iqn  -%}
+          {% endif -%}
+          {% endif -%}
+          {{ _iqn }}
+
+    - name: Set iscsi initiator name if not set
+      ansible.builtin.lineinfile:
+        path: /etc/iscsi/initiatorname.iscsi
+        regexp: '^InitiatorName=.*|^GenerateName=.*'
+        line: "InitiatorName={{ initiator_name }}"
+
     - name: Upgrade pip and install required packages
       ansible.builtin.pip:
         name:


### PR DESCRIPTION
This update protects against the default ISO install initiator name being used. It also protects against any cloud image type installs that set GenerateName=yes prior to a restart of iscsid service. It predictably sets a unique initiator name. IF the initator name is already set correctly, no action is taken.