### PR TITLE
fix(cinder): differentiate multipath networking and conf file

### DIFF
--- a/ansible/playbooks/deploy-cinder-netapp-volumes-reference.yaml
+++ b/ansible/playbooks/deploy-cinder-netapp-volumes-reference.yaml
@@ -8,7 +8,7 @@
     cinder_storage_network_interface: ansible_br_storage
     cinder_storage_network_interface_secondary: ansible_br_storage_secondary
     cinder_backend_name: "block-ha-performance-at-rest-encrypted,block-ha-standard-at-rest-encrypted,block-ha-performance-end-to-end-encrypted,block-ha-standard-end-to-end-encrypted"
-    custom_multipath: false
+    storage_network_multipath: false
   handlers:
     - name: Restart cinder-volume-netapp systemd services
       ansible.builtin.systemd:

--- a/ansible/playbooks/deploy-cinder-volumes-reference.yaml
+++ b/ansible/playbooks/deploy-cinder-volumes-reference.yaml
@@ -8,7 +8,7 @@
     cinder_storage_network_interface: ansible_br_storage
     cinder_storage_network_interface_secondary: ansible_br_storage_secondary
     cinder_backend_name: "lvmdriver-1"
-    custom_multipath: false
+    storage_network_multipath: false
   handlers:
     - name: Restart cinder-volume and cinder-backup systemd services
       ansible.builtin.systemd:
@@ -205,7 +205,7 @@
           {%   set default_backend = (_kubernetes_cinder_etc_secret.resources[0].data['backends.conf'] | b64decode | community.general.from_ini)[backend] %}
           {%   set network_interface = hostvars[inventory_hostname][cinder_storage_network_interface]['ipv4']['address'] | default(ansible_default_ipv4.address) %}
           {%   set _ = default_backend.__setitem__("target_ip_address", network_interface) %}
-          {%   if ("lvm" in backend) and (custom_multipath | bool) %}
+          {%   if ("lvm" in backend) and (storage_network_multipath | bool) %}
           {%       set network_interface_secondary = hostvars[inventory_hostname][cinder_storage_network_interface_secondary]['ipv4']['address'] %}
           {%       set _ = default_backend.__setitem__("iscsi_secondary_ip_addresses", network_interface_secondary) %}
           {%   endif %}

--- a/ansible/playbooks/host-setup.yml
+++ b/ansible/playbooks/host-setup.yml
@@ -53,10 +53,10 @@
         - multipathd.service
         - multipath-tools.service
       when:
-        - not (custom_multipath | default(false) | bool)
+        - not (storage_network_multipath | default(false) | bool)
     - name: Copy over multipath Round Robin configuration file
       when:
-        - custom_multipath | default(false) | bool
+        - storage_network_multipath | default(false) | bool
       block:
         - name: Install Packages
           ansible.builtin.package:

--- a/scripts/hyperconverged-lab.sh
+++ b/scripts/hyperconverged-lab.sh
@@ -407,7 +407,7 @@ all:
         openstack_compute_nodes:
           vars:
             enable_iscsi: true
-            custom_multipath: false
+            storage_network_multipath: false
           hosts:
             ${LAB_NAME_PREFIX}-0.${GATEWAY_DOMAIN}: null
             ${LAB_NAME_PREFIX}-1.${GATEWAY_DOMAIN}: null
@@ -416,7 +416,7 @@ all:
         storage_nodes:
           vars:
             enable_iscsi: true
-            custom_multipath: false
+            storage_network_multipath: false
           children:
             cinder_storage_nodes:
               hosts: {}
@@ -450,7 +450,7 @@ cat > /etc/genestack/helm-configs/barbican/barbican-helm-overrides.yaml <<EOF
 pod:
   resources:
     enabled: false
-  
+
 conf:
   barbican_api_uwsgi:
     uwsgi:


### PR DESCRIPTION
This PR updates documentation and playbooks to implement the inventory variable 'storage_network_multipath' updated in the flex-host-baseline PR:
https://github.com/rackerlabs/flex-host-baseline/pull/160. This variable more closely describes dual network storage interfaces being set up on the storage nodes rather than the overloaded inventory variable 'custom_multipath' which is used in host-setup.yml to primarily copy the multipath.conf.j2 template file for compute nodes.