### PR TITLE
OSPC-696:Added new default_domain config parameter for OSPC-696

### DIFF
--- a/base-kustomize/skyline/base/configmap-bin.yaml
+++ b/base-kustomize/skyline/base/configmap-bin.yaml
@@ -118,6 +118,7 @@ data:
       system_user_domain: 'Default'
       system_user_name: ""
       system_user_password: ""
+      default_domain: 'Default'
     setting:
       base_settings:
       - flavor_families


### PR DESCRIPTION
Added the new configuration parameter for the OSPC-696(Create a new Skyline option that allows an administrator to set the "default" domain).

-->Default value of the config parameter for 'default_domain' is 'Default' in cofigmap-bin.yaml - It allows the system to adapt to existing behaviour, which is 'Default' domain.
-->If admin wants to change the 'default_domain' parameter value to  to some other value during deployment, 
     For example : default_domain: 'rackspace_cloud_domain' has set inside the configmap-bin.yaml.
    Then the default domain will be changed to 'rackspace_cloud_domain'  from 'Default' value.
--> So the default value of config parameter 'default_domain' will be always set to 'Default' value, untill and unless we are
      changing it.
 