### PR TITLE
feat: (hpa) add limits to keystone-shib container

### DIFF
--- a/base-kustomize/keystone/federation/kustomization.yaml
+++ b/base-kustomize/keystone/federation/kustomization.yaml
@@ -87,3 +87,10 @@ patches:
               - /var/run/shibboleth/shibd.sock
             initialDelaySeconds: 10
             periodSeconds: 10
+          resources:
+            limits:
+              cpu: "1"
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 64Mi


### PR DESCRIPTION
keystone in federation mode runs a shib pod in the keystone-api container.  This pr applies HPA limits and requests to the additional pod so HPA can work.