### PR TITLE
feat: (hpa) add limits to keystone-shib container (#1031)

### DIFF
--- a/base-kustomize/keystone/federation/kustomization.yaml
+++ b/base-kustomize/keystone/federation/kustomization.yaml
@@ -87,3 +87,10 @@ patches:
               - /var/run/shibboleth/shibd.sock
             initialDelaySeconds: 10
             periodSeconds: 10
+          resources:
+            limits:
+              cpu: "1"
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 64Mi


### PR DESCRIPTION
(cherry picked from commit 4c1667b6a5039b4af829ab970a5854d93b490f1a)