### PR TITLE
feat: add floatingip to flex billing metrics.

### DIFF
--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -509,7 +509,11 @@ conf:
       traits:
         <<: *network_traits
         resource_id:
-          fields: ["payload.floatingip.id", "payload.id"]
+          fields: payload.floatingip.id
+        ip_address:
+          fields: payload.floatingip.floating_ip_address
+        event_type:
+          fields: event_type
     - event_type: firewall.*
       traits:
         <<: *network_traits
@@ -1045,9 +1049,17 @@ conf:
         metrics:
           bandwidth:
           ip.floating:
+        event_create:
+          - floatingip.create.end
         event_delete: floatingip.delete.end
+        event_update:
+          - floatingip.update.end
         event_attributes:
           id: resource_id
+          user_id: user_id
+          project_id: project_id
+          floating_ip_address: ip_address
+          event_type: event_type
 
       - resource_type: stack
         metrics:


### PR DESCRIPTION
Modified the ceilometer helm chart to support collecting floatingip events for billing.

- Added a new trait "floating_ip_address"
- Modified the "network" resource_type to include the following attributes:
  - user_id
  - project_id
  - floating_ip_address
  - event_type