### PR TITLE
feature: Grafana alert for catching Neutron IPAM Errors while attempt…

### DIFF
--- a/base-helm-configs/grafana/grafana-helm-overrides.yaml
+++ b/base-helm-configs/grafana/grafana-helm-overrides.yaml
@@ -125,7 +125,7 @@ alerting:
                 interferes with the function of the affected ports.
             labels: {}
             isPaused: false
-          # Generated UUID using 'uuidgen'  
+          # Generated UUID using 'uuidgen'
           - uid: c14dd8fd-54ec-4e15-9813-e02cc3269899
             title: Neutron IPAM Duplicate Entry Error
             condition: C


### PR DESCRIPTION
This is an alert when Neutron logs an error while attempting to assign an already assigned 
IP address to a VM.  Log entries on the nova log side look like below:

```
2025-03-20 03:19:13.009 9 ERROR oslo_db.api pymysql.err.IntegrityError: 
(1062, "Duplicate entry '<ip-address>-uuid-...' for key 'PRIMARY'")
```