### PR TITLE
fix: only define values we are overriding

### DIFF
--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -1776,34 +1776,13 @@ endpoints:
 pod:
   resources:
     enabled: true
-    compute:
-      requests:
-        memory: {}
-        cpu: {}
-      limits:
-        memory: {}
-        cpu: {}
     notification:
       requests:
-        memory: {}
-        cpu: {}
+        memory: 256
+        cpu: 500
       limits:
-        memory: {}
-        cpu: {}
-    central:
-      requests:
-        memory: {}
-        cpu: {}
-      limits:
-        memory: {}
-        cpu: {}
-    ipmi:
-      requests:
-        memory: {}
-        cpu: {}
-      limits:
-        memory: {}
-        cpu: {}
+        memory: 2Gi
+        cpu: "2000m"    
   replicas:
     central: 1
     notification: 1

--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -1782,7 +1782,7 @@ pod:
         cpu: 500
       limits:
         memory: 2Gi
-        cpu: "2000m"    
+        cpu: "2000m"
   replicas:
     central: 1
     notification: 1


### PR DESCRIPTION
Correct an error where we were defining empty dicts for overrides to openstack-helm ceilometer chart on hpa requests/limits.  only override what we actually want to change and use the helm chart for all other defaults.