### PR TITLE
Fix: Ensure multipath disabled on block nodes. Only enable iscsid

### DIFF
--- a/ansible/roles/host_setup/tasks/custom_multipath.yml
+++ b/ansible/roles/host_setup/tasks/custom_multipath.yml
@@ -16,6 +16,7 @@
 - name: Copy over multipath Round Robin configuration file
   when:
     - custom_multipath | default(false) | bool
+    - ('openstack_compute_nodes' in group_names)
   block:
     - name: Install Packages
       ansible.builtin.package:
@@ -36,6 +37,8 @@
 - name: Install open-iscsi and multipath on nova compute nodes
   when:
     - enable_iscsi | default(false) | bool
+    - custom_multipath | default(false) | bool
+    - ('openstack_compute_nodes' in group_names)
   block:
     - name: Install Packages
       ansible.builtin.package:
@@ -61,3 +64,32 @@
       notify:
         - Restart iscsid
         - Restart multipathd and multipath-tools service
+
+- name: Install open-iscsi on block nodes
+  when:
+    - enable_iscsi | default(false) | bool
+    - ('cinder_storage_nodes' in group_names)
+  block:
+    - name: Install Packages
+      ansible.builtin.package:
+        name:
+          - open-iscsi
+        state: "{{ iscsi_package_state | default('present') }}"
+        update_cache: true
+    - name: Determine initiator name
+      set_fact:
+        initiator_name: >
+          {% set _iqn = "iqn.2004-10.com." + ansible_distribution |lower() + ":" + ansible_hostname -%}
+          {% if ansible_iscsi_iqn is defined -%}
+          {% if (ansible_iscsi_iqn |length >= 15) -%}
+          {% set _iqn = ansible_iscsi_iqn  -%}
+          {% endif -%}
+          {% endif -%}
+          {{ _iqn }}
+    - name: Set iscsi initiator name
+      ansible.builtin.lineinfile:
+        path: /etc/iscsi/initiatorname.iscsi
+        regexp: '^InitiatorName=.*|^GenerateName=.*'
+        line: "InitiatorName={{ initiator_name }}"
+      notify:
+        - Restart iscsid

--- a/ansible/roles/host_setup/vars/debian.yml
+++ b/ansible/roles/host_setup/vars/debian.yml
@@ -50,6 +50,7 @@ _host_distro_packages:
   - iptables
   - irqbalance
   - libkmod2
+  - lsscsi
   - lvm2
   - nfs-client
   - nvme-cli

--- a/ansible/roles/host_setup/vars/ubuntu.yml
+++ b/ansible/roles/host_setup/vars/ubuntu.yml
@@ -49,6 +49,7 @@ _host_distro_packages:
   - iptables
   - irqbalance
   - libkmod2
+  - lsscsi
   - lvm2
   - nfs-client
   - nvme-cli

--- a/docs/openstack-cinder-lvmisci.md
+++ b/docs/openstack-cinder-lvmisci.md
@@ -79,7 +79,7 @@ Within the `inventory.yaml` file, ensure you have the following variables for yo
 openstack_compute_nodes:
   vars:
     enable_iscsi: true
-    storage_network_multipath: false  # optional -- enable when running multipath
+    custom_multipath: false  # optional -- enable when running multipath with custom multipath.conf
 storage_nodes:
   vars:
     enable_iscsi: true
@@ -111,7 +111,7 @@ ansible-playbook -i inventory.yaml playbooks/deploy-cinder-volumes-reference.yam
 
     ``` console
     ansible-playbook -i /etc/genestack/inventory/inventory.yaml deploy-cinder-volumes-reference.yaml \
-                    -e "cinder_storage_network_interface=ansible_br_storage_a cinder_storage_network_interface_secondary=ansible_br_storage_b storage_network_multipath=true storage_network_multipath=true cinder_backend_name=lvmdriver-1" \
+                    -e "cinder_storage_network_interface=ansible_br_storage_a cinder_storage_network_interface_secondary=ansible_br_storage_b storage_network_multipath=true cinder_backend_name=lvmdriver-1" \
                     --user ubuntu \
                     --become 'cinder_storage_nodes'
     ```
@@ -277,7 +277,7 @@ storage:
 
 ## 7  Verify Multipath Operations
 
-If multipath is enabled, you check the status of the multipath devices on the storage nodes.
+If multipath is enabled on compute nodes, you can verify dual iscsi targets on the storage nodes.
 
 ``` bash
 tgtadm --mode target --op show

--- a/docs/openstack-cinder-volume-provisioning-specs.md
+++ b/docs/openstack-cinder-volume-provisioning-specs.md
@@ -10,3 +10,24 @@ These specifications are set in the volume type. The following commands constrai
 root@openstack-node-0:~# kubectl --namespace openstack exec -ti openstack-admin-client -- openstack volume type set --property provisioning:min_vol_size=10 6af6ade2-53ca-4260-8b79-1ba2f208c91d
 root@openstack-node-0:~# kubectl --namespace openstack exec -ti openstack-admin-client -- openstack volume type set --property provisioning:max_vol_size=2048 6af6ade2-53ca-4260-8b79-1ba2f208c91d
 ```
+
+## Sample Provisioning Script
+
+``` shell
+#!/bin/bash
+
+openstack volume type create --description 'Capacity with LUKS encryption' --encryption-provider luks --encryption-cipher aes-xts-plain64 --encryption-key-size 256 --encryption-control-location front-end --property volume_backend_name=LVM_iSCSI --property provisioning:max_vol_size='2048' --property provisioning:min_vol_size='100' Capacity
+openstack volume type create --description 'Standard with LUKS encryption' --encryption-provider luks --encryption-cipher aes-xts-plain64 --encryption-key-size 256 --encryption-control-location front-end --property volume_backend_name=LVM_iSCSI --property provisioning:max_vol_size='2048' --property provisioning:min_vol_size='10' Standard
+openstack volume type create --description 'Performance with LUKS encryption' --encryption-provider luks --encryption-cipher aes-xts-plain64 --encryption-key-size 256 --encryption-control-location front-end --property volume_backend_name=LVM_iSCSI --property provisioning:max_vol_size='2048' --property provisioning:min_vol_size='10' Performance
+
+
+openstack volume qos create --property read_iops_sec_per_gb='1' --property write_iops_sec_per_gb='1' Capacity-Block
+openstack volume qos create --property read_iops_sec_per_gb='5' --property write_iops_sec_per_gb='5' Standard-Block
+openstack volume qos create --property read_iops_sec_per_gb='10' --property write_iops_sec_per_gb='10' Performance-Block
+
+openstack volume qos associate Capacity-Block Capacity
+openstack volume qos associate Standard-Block Standard
+openstack volume qos associate Performance-Block Performance
+
+openstack volume type set --private __DEFAULT__
+```

--- a/scripts/hyperconverged-lab.sh
+++ b/scripts/hyperconverged-lab.sh
@@ -407,7 +407,7 @@ all:
         openstack_compute_nodes:
           vars:
             enable_iscsi: true
-            storage_network_multipath: false
+            custom_multipath: false
           hosts:
             ${LAB_NAME_PREFIX}-0.${GATEWAY_DOMAIN}: null
             ${LAB_NAME_PREFIX}-1.${GATEWAY_DOMAIN}: null


### PR DESCRIPTION
This is a follow-up PR that further isolates host-setup multipath for compute nodes. It ensures multipath is disabled for block nodes and that no multipath.conf file is overwritten on block nodes.

Additionally, documentation has been revised to reflect that custom_multipath only pertains to compute nodes in the inventory.yaml file. Any reference to using multipath for LVM should condition people to think about two interfaces on the storage node; hence, the inventory.yaml variable 'storage_network_multipath' being used in the block nodes section. Block nodes ONLY need iscsid running with tgtadm package installed. NO multipathd.service should be running/enabled on block nodes.

A complimentary PR will be made to flex-host-baseline to ensure the correct variables are set in all inventory.yaml files.
