### PR TITLE
Exempted wlp wireless interfaces from rx/tx queue changes

### DIFF
--- a/ansible/roles/host_setup/files/queue_max.sh
+++ b/ansible/roles/host_setup/files/queue_max.sh
@@ -16,7 +16,7 @@ set -e
 function ethernetDevs () {
     # Returns all physical devices
     ip -details -json link show | jq -r '.[] |
-        if .linkinfo.info_kind // .link_type == "loopback" or (.ifname | test("idrac+")) then
+        if .linkinfo.info_kind // .link_type == "loopback" or (.ifname | test("idrac+")) or (.ifname | test("wlp+")) then
             empty
         else
             .ifname


### PR DESCRIPTION
Wireless interfaces on low-end machines (ie. Intel NUC, Lenovo, etc) may fail to run the queue_max service due to some interfaces not having necessary properties. This patch exempts wireless interfaces prefaced with 'wlp'.