### PR TITLE
chore: Add blazar image to genestack repo

### DIFF
--- a/.original-images.json
+++ b/.original-images.json
@@ -46,5 +46,6 @@
   "quay.io/airshipit/kubernetes-entrypoint:latest-ubuntu_jammy",
   "quay.io/airshipit/porthole-postgresql-utility:latest-ubuntu_bionic",
   "quay.io/airshipit/freezer:2025.1-ubuntu_jammy",
-  "quay.io/airshipit/freezer-api:2025.1-ubuntu_jammy"
+  "quay.io/airshipit/freezer-api:2025.1-ubuntu_jammy",
+  "quay.io/airshipit/blazar:2025.1-ubuntu_jammy"
 ]


### PR DESCRIPTION
Adding blazer image to genestack repo so that we can use this image to setup blazer.