### PR TITLE
feat: allow extra_specs to be read by admin_or_reader

### DIFF
--- a/base-helm-configs/cinder/cinder-helm-overrides.yaml
+++ b/base-helm-configs/cinder/cinder-helm-overrides.yaml
@@ -103,6 +103,8 @@ conf:
       volume_clear: zero
       volume_driver: cinder_rxt.rackspace.RXTLVM
       volume_group: cinder-volumes-1
+  policy:
+    "volume_extension:types_extra_specs:read_sensitive": "rule:xena_system_admin_or_project_reader"
   cinder:
     DEFAULT:
       allow_availability_zone_fallback: true


### PR DESCRIPTION
To properly calculare the minimium system disk size for BFV instance, we need to expose the extra_specs on the cinder volume types to be able to read provisioning:min_vol_size.  Since there does not appear to be any deployment related specific data beyond volume_backend_name, i belive this PR does not compromise security in relation to cinder volume types.  
