### PR TITLE
fix(nova): Correct path for lifecycle overrides

### DIFF
--- a/base-helm-configs/nova/nova-helm-overrides.yaml
+++ b/base-helm-configs/nova/nova-helm-overrides.yaml
@@ -32,30 +32,6 @@ images:
 network:
   backend:
     - ovn
-  lifecycle:
-    upgrades:
-      deployments:
-        revision_history: 3
-        pod_replacement_strategy: RollingUpdate
-        rolling_update:
-          max_unavailable: 20%
-          max_surge: 3
-      daemonsets:
-        pod_replacement_strategy: RollingUpdate
-        compute:
-          enabled: true
-          min_ready_seconds: 0
-          max_unavailable: 20%
-    disruption_budget:
-      metadata:
-        min_available: 0
-      osapi:
-        min_available: 0
-    termination_grace_period:
-      metadata:
-        timeout: 60
-      osapi:
-        timeout: 60
   ssh:
     enabled: true
 
@@ -300,6 +276,30 @@ endpoints:
 # hyperconverged lab (/scripts/hyperconverged-lab.sh).
 # limit values based on defaults from the openstack-helm charts unless defined
 pod:
+  lifecycle:
+    upgrades:
+      deployments:
+        revision_history: 3
+        pod_replacement_strategy: RollingUpdate
+        rolling_update:
+          max_unavailable: 20%
+          max_surge: 3
+      daemonsets:
+        pod_replacement_strategy: RollingUpdate
+        compute:
+          enabled: true
+          min_ready_seconds: 0
+          max_unavailable: 20%
+    disruption_budget:
+      metadata:
+        min_available: 0
+      osapi:
+        min_available: 0
+    termination_grace_period:
+      metadata:
+        timeout: 60
+      osapi:
+        timeout: 60
   resources:
     enabled: true
     compute:


### PR DESCRIPTION
Aligns override structure with the base chart by moving lifecycle settings to the `pod` section. This fixes an issue where overrides were not being applied.