### PR TITLE
fix: Fix typo in Alertmanager route

### DIFF
--- a/etc/gateway-api/routes/custom-alertmanager-routes.yaml
+++ b/etc/gateway-api/routes/custom-alertmanager-routes.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: custom-alertmanger-gateway-route
+  name: custom-alertmanager-gateway-route
   namespace: prometheus
 spec:
   parentRefs:


### PR DESCRIPTION
Renames 'custom-alertmanger-gateway-route' to 'custom-alertmanager-gateway-route'.