### PR TITLE
Adds magnum CAPI driver image to image list

### DIFF
--- a/.original-images.json
+++ b/.original-images.json
@@ -30,6 +30,7 @@
   "ghcr.io/rackerlabs/genestack/glance:2024.1-ubuntu_jammy-1740121591",
   "ghcr.io/rackerlabs/genestack/gnocchi:2024.1-ubuntu_jammy-1738626728",
   "ghcr.io/rackerlabs/genestack/heat:2024.1-ubuntu_jammy-1738626724",
+  "ghcr.io/rackerlabs/genestack/magnum:2024.1-ubuntu_jammy-1742991496",
   "ghcr.io/rackerlabs/genestack/neutron-oslodb:2024.1-ubuntu_jammy-1738626982",
   "ghcr.io/rackerlabs/genestack/neutron-oslodb:2024.1-ubuntu_jammy-1739651767",
   "ghcr.io/rackerlabs/genestack/neutron-oslodb:2024.1-ubuntu_jammy-1742943886",


### PR DESCRIPTION
We have a capi enabled magnum image build, this adds that image to be pushed to quay.io