### PR TITLE
Release 2025.2.6 rc (#1102)

### DIFF
--- a/base-helm-configs/barbican/barbican-helm-overrides.yaml
+++ b/base-helm-configs/barbican/barbican-helm-overrides.yaml
@@ -25,6 +25,14 @@ pod:
         memory: "256Mi"
         cpu: "100m"
       limits: {}
+  lifecycle:
+    upgrades:
+      deployments:
+        revision_history: 3
+        pod_replacement_strategy: RollingUpdate
+        rolling_update:
+          max_unavailable: 20%
+          max_surge: 3
 
 dependencies:
   static:

--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -1764,34 +1764,13 @@ endpoints:
 pod:
   resources:
     enabled: true
-    compute:
-      requests:
-        memory: {}
-        cpu: {}
-      limits:
-        memory: {}
-        cpu: {}
     notification:
       requests:
-        memory: {}
-        cpu: {}
+        memory: 256
+        cpu: 500
       limits:
-        memory: {}
-        cpu: {}
-    central:
-      requests:
-        memory: {}
-        cpu: {}
-      limits:
-        memory: {}
-        cpu: {}
-    ipmi:
-      requests:
-        memory: {}
-        cpu: {}
-      limits:
-        memory: {}
-        cpu: {}
+        memory: 2Gi
+        cpu: "2000m"
   replicas:
     central: 1
     notification: 1
@@ -1801,7 +1780,7 @@ pod:
         revision_history: 3
         pod_replacement_strategy: RollingUpdate
         rolling_update:
-          max_unavailable: 1
+          max_unavailable: 20%
           max_surge: 3
       daemonsets:
         pod_replacement_strategy: RollingUpdate
@@ -1809,6 +1788,12 @@ pod:
           enabled: true
           min_ready_seconds: 0
           max_unavailable: 20%
+    disruption_budget:
+      api:
+        min_available: 0
+    termination_grace_period:
+      api:
+        timeout: 600
 
 manifests:
   deployment_api: false

--- a/base-helm-configs/cinder/cinder-helm-overrides.yaml
+++ b/base-helm-configs/cinder/cinder-helm-overrides.yaml
@@ -30,6 +30,20 @@ images:
 # hyperconverged lab (/scripts/hyperconverged-lab.sh).
 # limit values based on defaults from the openstack-helm charts unless defined
 pod:
+  lifecycle:
+    upgrades:
+      deployments:
+        revision_history: 3
+        pod_replacement_strategy: RollingUpdate
+        rolling_update:
+          max_unavailable: 20%
+          max_surge: 3
+    disruption_budget:
+      api:
+        min_available: 0
+    termination_grace_period:
+      api:
+        timeout: 60
   resources:
     enabled: true
     api:
@@ -89,6 +103,8 @@ conf:
       volume_clear: zero
       volume_driver: cinder_rxt.rackspace.RXTLVM
       volume_group: cinder-volumes-1
+  policy:
+    "volume_extension:types_extra_specs:read_sensitive": "rule:xena_system_admin_or_project_reader"
   cinder:
     DEFAULT:
       allow_availability_zone_fallback: true

--- a/base-helm-configs/designate/designate-helm-overrides.yaml
+++ b/base-helm-configs/designate/designate-helm-overrides.yaml
@@ -121,7 +121,7 @@ pod:
         revision_history: 3
         pod_replacement_strategy: RollingUpdate
         rolling_update:
-          max_unavailable: 1
+          max_unavailable: 20%
           max_surge: 3
     disruption_budget:
       api:
@@ -138,9 +138,9 @@ pod:
         min_available: 0
     termination_grace_period:
       api:
-        timeout: 30
+        timeout: 60
       mdns:
-        timeout: 30
+        timeout: 60
   resources:
     enabled: true
     api:

--- a/base-helm-configs/glance/glance-helm-overrides.yaml
+++ b/base-helm-configs/glance/glance-helm-overrides.yaml
@@ -255,14 +255,14 @@ pod:
         revision_history: 3
         pod_replacement_strategy: RollingUpdate
         rolling_update:
-          max_unavailable: 1
+          max_unavailable: 20%
           max_surge: 3
     disruption_budget:
       api:
         min_available: 0
     termination_grace_period:
       api:
-        timeout: 30
+        timeout: 60
   probes:
     api:
       glance-api:

--- a/base-helm-configs/gnocchi/gnocchi-helm-overrides.yaml
+++ b/base-helm-configs/gnocchi/gnocchi-helm-overrides.yaml
@@ -45,7 +45,7 @@ conf:
   gnocchi_api_wsgi:
     wsgi:
       processes: 2
-      threads: 4
+      threads: 1
   paste:
     "app:gnocchiv1":
       paste.app_factory: "gnocchi.rest.app:app_factory"
@@ -100,14 +100,28 @@ pod:
       limits: {}
   lifecycle:
     upgrades:
-      daemonsets:
-        metricd:
-          enabled: true
-          max_unavailable: 20%
+      deployments:
+        revision_history: 3
         pod_replacement_strategy: RollingUpdate
-        statsd:
-          enabled: true
+        rolling_update:
           max_unavailable: 20%
+          max_surge: 3
+      daemonsets:
+        pod_replacement_strategy: RollingUpdate
+        metricd:
+          enabled: false
+          min_ready_seconds: 0
+          max_unavailable: 20%
+        statsd:
+          enabled: false
+          min_ready_seconds: 0
+          max_unavailable: 20%
+    disruption_budget:
+      api:
+        min_available: 0
+    termination_grace_period:
+      api:
+        timeout: 60
 
 endpoints:
   fluentd:

--- a/base-helm-configs/heat/heat-helm-overrides.yaml
+++ b/base-helm-configs/heat/heat-helm-overrides.yaml
@@ -23,6 +23,30 @@ images:
 # hyperconverged lab (/scripts/hyperconverged-lab.sh).
 # limit values based on defaults from the openstack-helm charts unless defined
 pod:
+  lifecycle:
+    upgrades:
+      deployments:
+        revision_history: 3
+        pod_replacement_strategy: RollingUpdate
+        rolling_update:
+          max_unavailable: 20%
+          max_surge: 3
+    disruption_budget:
+      api:
+        min_available: 0
+      cfn:
+        min_available: 0
+      cloudwatch:
+        min_available: 0
+    termination_grace_period:
+      api:
+        timeout: 60
+      cfn:
+        timeout: 60
+      cloudwatch:
+        timeout: 60
+      engine:
+        timeout: 60
   resources:
     enabled: true
     api:

--- a/base-helm-configs/keystone/keystone-helm-overrides.yaml
+++ b/base-helm-configs/keystone/keystone-helm-overrides.yaml
@@ -22,6 +22,20 @@ images:
 # hyperconverged lab (/scripts/hyperconverged-lab.sh).
 # limit values based on defaults from the openstack-helm charts unless defined
 pod:
+  lifecycle:
+    upgrades:
+      deployments:
+        revision_history: 3
+        pod_replacement_strategy: RollingUpdate
+        rolling_update:
+          max_unavailable: 20%
+          max_surge: 3
+    disruption_budget:
+      api:
+        min_available: 0
+    termination_grace_period:
+      api:
+        timeout: 60
   resources:
     enabled: true
     api:

--- a/base-helm-configs/libvirt/libvirt-helm-overrides.yaml
+++ b/base-helm-configs/libvirt/libvirt-helm-overrides.yaml
@@ -18,3 +18,12 @@ dependencies:
       ovn:
         libvirt:
           pod: []  # In a hybrid deployment, we don't want to run ovn-controller on the same node as libvirt
+pod:
+  lifecycle:
+    upgrades:
+      daemonsets:
+        pod_replacement_strategy: RollingUpdate
+        libvirt:
+          enabled: true
+          min_ready_seconds: 0
+          max_unavailable: 20%

--- a/base-helm-configs/magnum/magnum-helm-overrides.yaml
+++ b/base-helm-configs/magnum/magnum-helm-overrides.yaml
@@ -18,6 +18,20 @@ images:
 # hyperconverged lab (/scripts/hyperconverged-lab.sh).
 # limit values based on defaults from the openstack-helm charts unless defined
 pod:
+  lifecycle:
+    upgrades:
+      deployments:
+        revision_history: 3
+        pod_replacement_strategy: RollingUpdate
+        rolling_update:
+          max_unavailable: 20%
+          max_surge: 3
+    disruption_budget:
+      api:
+        min_available: 0
+    termination_grace_period:
+      api:
+        timeout: 60
   resources:
     enabled: true
     api:

--- a/base-helm-configs/masakari/masakari-helm-overrides.yaml
+++ b/base-helm-configs/masakari/masakari-helm-overrides.yaml
@@ -33,6 +33,30 @@ images:
 # hyperconverged lab (/scripts/hyperconverged-lab.sh).
 # limit values based on defaults from the openstack-helm charts unless defined
 pod:
+  lifecycle:
+    upgrades:
+      deployments:
+        revision_history: 3
+        pod_replacement_strategy: RollingUpdate
+        rolling_update:
+          max_unavailable: 20%
+          max_surge: 3
+      daemonsets:
+        pod_replacement_strategy: RollingUpdate
+        compute:
+          enabled: true
+          min_ready_seconds: 0
+          max_unavailable: 20%
+    disruption_budget:
+      masakari_api:
+        min_available: 0
+      masakari_engine:
+        min_available: 0
+    termination_grace_period:
+      masakari_api:
+        timeout: 60
+      masakari_engine:
+        timeout: 60
   resources:
     enabled: true
     masakari_api:

--- a/base-helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/base-helm-configs/neutron/neutron-helm-overrides.yaml
@@ -86,6 +86,62 @@ pod:
         cpu: "3000m"
   use_fqdn:
     neutron_agent: false
+  lifecycle:
+    upgrades:
+      deployments:
+        revision_history: 3
+        pod_replacement_strategy: RollingUpdate
+        rolling_update:
+          max_unavailable: 20%
+          max_surge: 3
+      daemonsets:
+        pod_replacement_strategy: RollingUpdate
+        dhcp_agent:
+          enabled: true
+          min_ready_seconds: 0
+          max_unavailable: 20%
+        l3_agent:
+          enabled: true
+          min_ready_seconds: 0
+          max_unavailable: 20%
+        lb_agent:
+          enabled: true
+          min_ready_seconds: 0
+          max_unavailable: 20%
+        metadata_agent:
+          enabled: true
+          min_ready_seconds: 0
+          max_unavailable: 20%
+        ovn_metadata_agent:
+          enabled: true
+          min_ready_seconds: 0
+          max_unavailable: 20%
+        ovn_vpn_agent:
+          enabled: true
+          min_ready_seconds: 0
+          max_unavailable: 20%
+        ovs_agent:
+          enabled: true
+          min_ready_seconds: 0
+          max_unavailable: 20%
+        sriov_agent:
+          enabled: true
+          min_ready_seconds: 0
+          max_unavailable: 20%
+        netns_cleanup_cron:
+          enabled: true
+          min_ready_seconds: 0
+          max_unavailable: 20%
+    disruption_budget:
+      server:
+        min_available: 0
+    termination_grace_period:
+      server:
+        timeout: 60
+      rpc_server:
+        timeout: 60
+      ironic_agent:
+        timeout: 60
 
 conf:
   dhcp_agent:

--- a/base-helm-configs/nova/nova-helm-overrides.yaml
+++ b/base-helm-configs/nova/nova-helm-overrides.yaml
@@ -32,12 +32,6 @@ images:
 network:
   backend:
     - ovn
-  lifecycle:
-    upgrades:
-      daemonsets:
-        compute:
-          enabled: true
-          max_unavailable: 20%
   ssh:
     enabled: true
 
@@ -106,6 +100,9 @@ conf:
       vif_plugging_timeout: 300
       cross_az_attach: true
       network_allocate_retries: 3
+    api:
+      vendordata_providers: ['StaticJSON']
+      vendordata_jsonfile_path: /etc/nova/vendor_data.json
     api_database:
       connection_debug: 0
       connection_recycle_time: 600
@@ -173,7 +170,7 @@ conf:
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617
       kombu_reconnect_delay: 0.5
-    schedule:
+    scheduler:
       workers: 2
     workarounds:
       skip_cpu_compare_at_startup: false
@@ -283,6 +280,30 @@ endpoints:
 # hyperconverged lab (/scripts/hyperconverged-lab.sh).
 # limit values based on defaults from the openstack-helm charts unless defined
 pod:
+  lifecycle:
+    upgrades:
+      deployments:
+        revision_history: 3
+        pod_replacement_strategy: RollingUpdate
+        rolling_update:
+          max_unavailable: 20%
+          max_surge: 3
+      daemonsets:
+        pod_replacement_strategy: RollingUpdate
+        compute:
+          enabled: true
+          min_ready_seconds: 0
+          max_unavailable: 20%
+    disruption_budget:
+      metadata:
+        min_available: 0
+      osapi:
+        min_available: 0
+    termination_grace_period:
+      metadata:
+        timeout: 60
+      osapi:
+        timeout: 60
   resources:
     enabled: true
     compute:
@@ -329,6 +350,19 @@ pod:
           readOnlyRootFilesystem: false
   use_fqdn:
     compute: false
+  mounts:
+    nova_api_metadata:
+      init_container: null
+      nova_api_metadata:
+        volumeMounts:
+          - name: metadata-api-static-vendordata
+            mountPath: /etc/nova/vendor_data.json
+            subPath: vendor_data.json
+            readOnly: true
+        volumes:
+          - name: metadata-api-static-vendordata
+            configMap:
+              name: static-vendor-data
 
 manifests:
   deployment_spiceproxy: false

--- a/base-helm-configs/octavia/octavia-helm-overrides.yaml
+++ b/base-helm-configs/octavia/octavia-helm-overrides.yaml
@@ -181,6 +181,26 @@ endpoints:
 # hyperconverged lab (/scripts/hyperconverged-lab.sh).
 # limit values based on defaults from the openstack-helm charts unless defined
 pod:
+  lifecycle:
+    upgrades:
+      deployments:
+        revision_history: 3
+        pod_replacement_strategy: RollingUpdate
+        rolling_update:
+          max_unavailable: 20%
+          max_surge: 3
+      daemonsets:
+        pod_replacement_strategy: RollingUpdate
+        health_manager:
+          enabled: true
+          min_ready_seconds: 0
+          max_unavailable: 20%
+    disruption_budget:
+      api:
+        min_available: 0
+    termination_grace_period:
+      api:
+        timeout: 60
   resources:
     enabled: true
     api:

--- a/base-helm-configs/placement/placement-helm-overrides.yaml
+++ b/base-helm-configs/placement/placement-helm-overrides.yaml
@@ -15,6 +15,20 @@ images:
 # hyperconverged lab (/scripts/hyperconverged-lab.sh).
 # limit values based on defaults from the openstack-helm charts unless defined
 pod:
+  lifecycle:
+    upgrades:
+      deployments:
+        revision_history: 3
+        pod_replacement_strategy: RollingUpdate
+        rolling_update:
+          max_unavailable: 20%
+          max_surge: 3
+    disruption_budget:
+      api:
+        min_available: 0
+    termination_grace_period:
+      api:
+        timeout: 60
   resources:
     enabled: true
     api:

--- a/base-kustomize/heat/base/kustomization.yaml
+++ b/base-kustomize/heat/base/kustomization.yaml
@@ -37,7 +37,7 @@ patches:
           failureThreshold: 3
           httpGet:
             path: /
-            port: 8004
+            port: 8000
             scheme: HTTP
           initialDelaySeconds: 10
           periodSeconds: 60

--- a/base-kustomize/nova/base/kustomization.yaml
+++ b/base-kustomize/nova/base/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - hpa-nova-novncproxy.yaml
   - hpa-nova-scheduler.yaml
   - policies.yaml
+  - static-vendordata-configmap.yaml

--- a/base-kustomize/nova/base/static-vendordata-configmap.yaml
+++ b/base-kustomize/nova/base/static-vendordata-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: static-vendor-data
+  namespace: openstack
+data:
+  vendor_data.json: '{}'

--- a/base-kustomize/octavia/base/kustomization.yaml
+++ b/base-kustomize/octavia/base/kustomization.yaml
@@ -21,6 +21,24 @@ resources:
 # To run the OVN driver, the octavia-api container must have an agent container within the same pod.
 patches:
   - target:
+      kind: Secret
+      name: octavia-etc
+    patch: |-
+      - op: add
+        path: /data/policy.yaml
+        value: b3NfbG9hZC1iYWxhbmNlcl9hcGk6Zmxhdm9yLXByb2ZpbGU6Z2V0X29uZTogcnVsZTpsb2FkLWJhbGFuY2VyOnJlYWQKb3NfbG9hZC1iYWxhbmNlcl9hcGk6Zmxhdm9yLXByb2ZpbGU6Z2V0X2FsbDogcnVsZTpsb2FkLWJhbGFuY2VyOnJlYWQ=
+  - target:
+      kind: Deployment
+      name: octavia-api
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/volumeMounts/-
+        value:
+          name: octavia-etc
+          mountPath: /etc/octavia/policy.yaml
+          subPath: policy.yaml
+          readOnly: true
+  - target:
       kind: Deployment
       name: octavia-api
     patch: |-

--- a/docs/openstack-vendordata.md
+++ b/docs/openstack-vendordata.md
@@ -1,0 +1,58 @@
+# Openstack Vendordata
+
+To read more about Openstack Vendordata see [upstream docs](https://docs.openstack.org/nova/latest/admin/vendordata.html)
+
+## Overview
+
+It is a feature that provides way to pass vendor-specific data to the instances at boot-time. It can be accessed 
+with one of the following ways:
+
+* [Metadata Service](https://docs.openstack.org/nova/latest/admin/metadata-service.html)
+* [Config Drives](https://docs.openstack.org/nova/latest/admin/config-drive.html)
+
+Also, Vendordata sources can be specified with two ways:
+
+* [StaticJSON](https://docs.openstack.org/nova/latest/admin/vendordata.html#staticjson)
+* [DynamicJSON](https://docs.openstack.org/nova/latest/admin/vendordata.html#dynamicjson)
+
+*StaticJSON* collects data from a JSON file that exits locally and is suitable when data remains same for all instances. 
+On the other hand *DynamicJSON* can collect data from external REST service and works well when that data does change for 
+instances.
+
+## Vendordata in genestack
+
+Genestack use *Metadata Service* to access Vendordata. It has StaticJSON enabled in nova.conf as default provider:
+
+```yaml
+api:
+  vendordata_providers: ['StaticJSON']
+  vendordata_jsonfile_path: /etc/nova/vendor_data.json
+```
+
+You can override the default configmap `/opt/genestack/base-kustomize/nova/base/static-vendordata-configmap` to pass 
+static vendor-data against `vendor_data.json` key, which is mounted at `/etc/nova/vendor_data.json` in metadata service 
+resources.
+
+For DynamicJSON you need to enable it amongst providers and have to specify dynamic target URL(s) in nova.conf as follows:
+
+```yaml
+api:
+  vendordata_providers: ['StaticJSON', 'DynamicJSON']
+  vendordata_jsonfile_path: /etc/nova/vendor_data.json
+  vendordata_dynamic_targets: ['target/url1', 'target/url2']
+```
+
+A POST request call will be made to these dynamic targets and you can expect the request body contains instance's context 
+e.g. *instance-id, image-id, hostname etc.* These targets should return a valid JSON in response.
+
+## Cloud-init and Vendordata
+
+Cloud-init instructions can be passed-in as string against key - `cloud-init` within Vendordata JSON as follows:
+
+```json
+{
+  "cloud-init": "#cloud-config\nruncmd:\n..."
+}
+```
+
+See [cloud-init docs](https://cloudinit.readthedocs.io/en/latest/reference/datasources/openstack.html) for more details.

--- a/etc/gateway-api/routes/custom-alertmanager-routes.yaml
+++ b/etc/gateway-api/routes/custom-alertmanager-routes.yaml
@@ -1,16 +1,17 @@
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: custom-alertmanger-gateway-route
+  name: custom-alertmanager-gateway-route
   namespace: prometheus
 spec:
   parentRefs:
-  - name: flex-gateway
-    sectionName: http
-    namespace: nginx-gateway
+    - name: flex-gateway
+      sectionName: http
+      namespace: nginx-gateway
   hostnames:
-  - "alertmanager.your.domain.tld"
+    - "alertmanager.your.domain.tld"
   rules:
     - backendRefs:
-      - name: kube-prometheus-stack-alertmanager
-        port: 9093
+        - name: kube-prometheus-stack-alertmanager
+          port: 9093

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -351,3 +351,6 @@ nav:
       - DFW3:
           - "<img src='https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fthe2hill%2Frs-flex-uptime-dfw%2Frefs%2Fheads%2Fmaster%2Fstatus.json'/>": https://status.api.dfw3.rackspacecloud.com
           - "<strong>Control Panel</strong>": https://skyline.api.dfw3.rackspacecloud.com
+      - IAD:
+          - "<img src='https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fthe2hill%2Frs-flex-uptime-iad%2Frefs%2Fheads%2Fmaster%2Fstatus.json'/>": https://status.api.iad3.rackspacecloud.com
+          - "<strong>Control Panel</strong>": https://keystone.api.iad3.rackspacecloud.com/v3/auth/OS-FEDERATION/websso/saml2?origin=https://skyline.api.iad3.rackspacecloud.com/api/openstack/skyline/api/v1/websso


### PR DESCRIPTION
* fix: nova schedule does not equal nova scheduler (#1073)

(cherry picked from commit 1550f7594fbc6630e95ffe526d6ff99f023c38bc)

* fix: correct gnocci baseline (#1074)

(cherry picked from commit 3a468b7e40f32feab73e59ca8b4c32746b137488)

* fix: only define values we are overriding (#1077)

* fix: only define values we are overriding

* fix: whitespace

(cherry picked from commit 321a0607112faffa83ab6f2ad541f930e3f31b0d)

* feat(policy): allow readers to retrieve flavor profiles in Octavia (#1081)

* fix: cinder service mapping in skyline configuration

* feat(policy): allow readers to retrieve flavor profiles in Octavia

(cherry picked from commit 193777a52bb564af498ded90f46dcb31177aaade)

* feat: allow extra_specs to be read by admin_or_reader

(cherry picked from commit 521a2eca1d6fd883193282831da29701c6482130)

* fix: (nova) correct where lifecycle lives

* Fix typo alertmanager route (#1100)

* fix: Fix typo in Alertmanager route

Renames 'custom-alertmanger-gateway-route' to 'custom-alertmanager-gateway-route'.



* fix: (yamllint) correct indents

---------



(cherry picked from commit 6a4c56d96bd9f74299d13d7fc0eb75605ef7a7e6)

* fix: (nova) lifecycel in the correct place merge conflict

* chore: fix heat liveness probe (#1056)


(cherry picked from commit fc27bed2a9d45291bc0e45bb7edebc61d424b730)

* fix: merge conflict on mkdocs

---------