### PR TITLE
fix: Removed "display_name" from network attributes.

### DIFF
--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -1066,7 +1066,6 @@ conf:
           project_id: project_id
           floating_ip_address: ip_address
           event_type: event_type
-          display_name: name
 
       - resource_type: stack
         metrics:


### PR DESCRIPTION
The [schema ](https://github.com/rackerlabs/standard-usage-schemas/blob/master/sample_product_schemas/osflex-network.xml)for the network payload does not include the "diplay_name" attribute, so it is not necessary to include it in the ceilometer configuration. Havng it here will cause an issue for ceilometer sending events to gnocchi since it won't be in the gnocchi schema.