### PR TITLE
fix: add static vendordata mount point to nova-compute pods

### DIFF
--- a/base-helm-configs/nova/nova-helm-overrides.yaml
+++ b/base-helm-configs/nova/nova-helm-overrides.yaml
@@ -350,6 +350,18 @@ pod:
   use_fqdn:
     compute: false
   mounts:
+    nova_compute:
+      init_container: null
+      nova_compute:
+        volumeMounts:
+          - name: metadata-api-static-vendordata
+            mountPath: /etc/nova/vendor_data.json
+            subPath: vendor_data.json
+            readOnly: true
+        volumes:
+          - name: metadata-api-static-vendordata
+            configMap:
+              name: static-vendor-data
     nova_api_metadata:
       init_container: null
       nova_api_metadata:


### PR DESCRIPTION
Octavia when it creates an instance is forcing config_drive to be true.  When using static vendordata, the payload needs to live in the nova-compute pods when config_drive is true.  Enable the mount point into the nova-compute pods.