### PR TITLE
Fix: Adds helm binary in Magnum image

### DIFF
--- a/Containerfiles/MagnumRXT-Containerfile
+++ b/Containerfiles/MagnumRXT-Containerfile
@@ -1,7 +1,7 @@
 ARG VERSION=master-ubuntu_jammy
-FROM openstackhelm/magnum:${VERSION} as build
+FROM openstackhelm/magnum:${VERSION} AS build
 ARG PLUGIN_VERSION=master
-RUN apt-get update && apt-get install -y git && apt clean
+RUN apt-get update && apt-get install -y git curl && apt clean
 RUN export ORIG_PLUGIN_VERSION="${PLUGIN_VERSION}"; \
 if [ "${PLUGIN_VERSION}" != 'master' ]; then export PLUGIN_VERSION=stable/${PLUGIN_VERSION}; fi; \
 /var/lib/openstack/bin/activate; \
@@ -9,6 +9,7 @@ if [ "${PLUGIN_VERSION}" != 'master' ]; then export PLUGIN_VERSION=stable/${PLUG
                                    git+https://opendev.org/openstack/magnum-capi-helm@${PLUGIN_VERSION}#egg=magnum_capi_helm
 RUN /var/lib/openstack/bin/pip install --upgrade --force-reinstall pip
 RUN find /var/lib/openstack -regex '^.*\(__pycache__\|\.py[co]\)$' -delete
+RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
 FROM openstackhelm/magnum:${VERSION}
 COPY --from=build /var/lib/openstack/. /var/lib/openstack/


### PR DESCRIPTION
Currently we are missing the helm command inside the image, which is needed to run mangnum-capi-helm driver.