### PR TITLE
feat: add metadata ratelimits

### DIFF
--- a/base-helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/base-helm-configs/neutron/neutron-helm-overrides.yaml
@@ -205,6 +205,13 @@ conf:
       ovn_l3_scheduler: leastloaded
       ovn_nb_connection: "tcp:127.0.0.1:6641"
       ovn_sb_connection: "tcp:127.0.0.1:6642"
+    metadata_rate_limiting:
+      rate_limit_enabled: true
+      ip_versions: 4
+      base_window_duration: 60
+      base_query_rate_limit: 6
+      burst_window_duration: 10
+      burst_query_rate_limit: 2
   neutron_api_uwsgi:
     uwsgi:
       processes: 2


### PR DESCRIPTION
This change adds limits to our metadata servers which will be essential to ensuring we maintain a stable environment.

Docs: https://docs.openstack.org/neutron/2024.1/admin/config-metadata-rate-limiting.html