### PR TITLE
fix: unify the skyline limits

### DIFF
--- a/base-kustomize/skyline/base/deployment-apiserver.yaml
+++ b/base-kustomize/skyline/base/deployment-apiserver.yaml
@@ -339,7 +339,7 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             requests:
-              memory: "64Mi"
+              memory: "256Mi"
               cpu: "100m"
             limits:
               memory: "4096Mi"
@@ -361,11 +361,11 @@ spec:
           image: "ghcr.io/rackerlabs/genestack-images/skyline:2024.2-latest"
           imagePullPolicy: IfNotPresent
           resources:
-            limits:
-              memory: "1Gi"
             requests:
-              cpu: "0.25"
-              memory: "64Mi"
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "4096Mi"
           command:
             - bash
             - -c


### PR DESCRIPTION
The basic skyline limits were set so low that the HPA would scale to the max for no reason. This change sets the skyline limits to a more sane value for a typical small scale environment.