### PR TITLE
fix: OSPC-1358: Neutron server QueuePool limit exceeded

### DIFF
--- a/base-helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/base-helm-configs/neutron/neutron-helm-overrides.yaml
@@ -177,6 +177,8 @@ conf:
       idle_timeout: 3600
       mysql_sql_mode: {}
       use_db_reconnect: true
+      max_pool_size: 30
+      max_overflow: 60
       pool_timeout: 60
       max_retries: -1
     oslo_messaging_rabbit:


### PR DESCRIPTION
Increasing max_pool_size from 5 (default value) to 30, and max_overflow from 50 to 60.