### PR TITLE
OSPC-1403: added the script , values.yaml and docs for redis operator

### DIFF
--- a/base-helm-configs/redis-operator/redis-operator-helm-overrides.yaml
+++ b/base-helm-configs/redis-operator/redis-operator-helm-overrides.yaml
@@ -1,0 +1,227 @@
+# Redis Operator and Cluster Overrides
+# Defines custom settings to override defaults in base values.yaml
+
+# -- Cluster DNS name
+clusterName: ${CLUSTER_NAME}
+
+# Namespace configuration
+# Controls the namespace for the Redis operator and cluster
+namespace:
+  create: true
+  name: redis-systems
+
+# Redis Cluster Configuration Overrides
+redisCluster:
+  # -- Name of the Redis cluster (optional, defaults to empty)
+  name: "redis-cluster"
+  # -- Number of shards in the cluster (implied by leader/follower replicas)
+  clusterSize: 3
+  # -- Redis version to use
+  clusterVersion: v7
+  # -- Enable persistence for the cluster
+  persistenceEnabled: true
+  # -- Image configuration for Redis pods
+  image:
+    repository: quay.io/opstree/redis
+    tag: v7.0.15
+    pullPolicy: IfNotPresent
+  # -- Secrets for image pull (optional)
+  imagePullSecrets: []
+    # - name: Secret with Registry credentials
+  # -- Redis authentication secret (optional)
+  redisSecret:
+    secretName: ""
+    secretKey: ""
+  # -- Resource requests and limits (optional)
+  resources: {}
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+  # -- Minimum seconds a pod must be ready before considered available
+  minReadySeconds: 0
+  # -- Some fields of statefulset are immutable, such as volumeClaimTemplates.
+  # When set to true, the operator will delete the statefulset and recreate it.
+  #Default is false.
+  recreateStatefulSetOnUpdateInvalid: false
+  # -- Enable pod anti-affinity between leader and follower pods by adding the
+  # appropriate label.
+  # Notice that this requires the operator to have its mutating webhook enabled,
+  # otherwise it will only add an annotation to the RedisCluster CR. Default is
+  # false.
+  enableMasterSlaveAntiAffinity: false
+  # -- Leader configuration
+  leader:
+    replicas: 3
+    serviceType: ClusterIP
+    affinity: {}
+      # nodeAffinity:
+      #   requiredDuringSchedulingIgnoredDuringExecution:
+      #     nodeSelectorTerms:
+      #     - matchExpressions:
+      #       - key: disktype
+      #         operator: In
+      #         values:
+      #         - ssd
+    tolerations: []
+      # - key: "key"
+      #   operator: "Equal"
+      #   value: "value"
+      #   effect: "NoSchedule"
+    nodeSelector: {}
+      # memory: medium
+    securityContext: {}
+    pdb:
+      enabled: false
+      maxUnavailable: 1
+      minAvailable: 1
+    livenessProbe: {}
+      # timeoutSeconds: 30
+      # periodSeconds: 45
+      # successThreshold: 1
+      # failureThreshold: 4
+      # initialDelaySeconds: 15
+    readinessProbe: {}
+      # timeoutSeconds: 30
+      # periodSeconds: 45
+      # successThreshold: 1
+      # failureThreshold: 4
+      # initialDelaySeconds: 15
+  # -- Follower configuration
+  follower:
+    replicas: 3
+    serviceType: ClusterIP
+    affinity: {}
+      # nodeAffinity:
+      #   requiredDuringSchedulingIgnoredDuringExecution:
+      #     nodeSelectorTerms:
+      #     - matchExpressions:
+      #       - key: disktype
+      #         operator: In
+      #         values:
+      #         - ssd
+    tolerations: []
+      # - key: "key"
+      #   operator: "Equal"
+      #   value: "value"
+      #   effect: "NoSchedule"
+    nodeSelector: {}
+      # memory: medium
+    securityContext: {}
+    pdb:
+      enabled: false
+      maxUnavailable: 1
+      minAvailable: 1
+    livenessProbe: {}
+      # timeoutSeconds: 30
+      # periodSeconds: 45
+      # successThreshold: 1
+      # failureThreshold: 4
+      # initialDelaySeconds: 15
+    readinessProbe: {}
+      # timeoutSeconds: 30
+      # periodSeconds: 45
+      # successThreshold: 1
+      # failureThreshold: 4
+      # initialDelaySeconds: 15
+
+# -- Labels and Annotations
+labels: {}
+  # foo: bar
+  # test: echo
+
+# -- External Configuration
+externalConfig:
+  enabled: false
+  data: {}
+    # tcp-keepalive 400
+    # slowlog-max-len 158
+    # stream-node-max-bytes 2048
+
+# -- External Service Configuration
+externalService:
+  enabled: false
+  serviceType: {}
+  port: {}
+  annotations: {}
+    # foo: bar
+
+# -- Monitoring and Exporter
+serviceMonitor:
+  enabled: false
+  interval: {}
+  scrapeTimeout: {}
+  namespace: {}
+  extraLabels: {}
+    # foo: bar
+    # team: devops
+redisExporter:
+  enabled: false
+  image: {}
+  tag: {}
+  imagePullPolicy: {}
+  resources: {}
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+  env: []
+    # - name: VAR_NAME
+    #   value: "value1"
+  securityContext: {}
+
+# -- Sidecars and Init Containers
+sidecars: {}
+initContainer:
+  enabled: false
+  image: {}
+  imagePullPolicy: {}
+  resources: {}
+    # requests:
+    #   memory: "64Mi"
+    #   cpu: "250m"
+    # limits:
+    #   memory: "128Mi"
+    #   cpu: "500m"
+  env: []
+  command: []
+  args: []
+
+# -- Priority and Security
+priorityClassName: ""
+podSecurityContext: {}
+TLS:
+  ca: {}
+  cert: {}
+  key: {}
+  secret:
+    secretName: ""
+acl:
+  secret:
+    secretName: ""
+env: []
+  # - name: VAR_NAME
+  #   value: "value1"
+serviceAccountName: ""
+
+# -- Storage Specification
+storageSpec:
+  volumeClaimTemplate:
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 1Gi
+      # storageClassName: standard
+  nodeConfVolume: true
+  nodeConfVolumeClaimTemplate:
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 1Gi
+    # selector: {}

--- a/bin/install-redis-operator.sh
+++ b/bin/install-redis-operator.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# shellcheck disable=SC2124,SC2145,SC2294
+
+export VERSION="${VERSION:-0.21.0}"
+
+# Default parameter value
+export CLUSTER_NAME=${CLUSTER_NAME:-cluster.local}
+
+# Directory to check for YAML files
+CONFIG_DIR="/etc/genestack/helm-configs/redis-operator"
+
+# 'cluster.local' is the default value in base helm values file
+if [ "${CLUSTER_NAME}" != "cluster.local" ]; then
+    CONFIG_FILE="$CONFIG_DIR/redis-operator-helm-overrides.yaml"
+
+    mkdir -p "$CONFIG_DIR"
+    touch "$CONFIG_FILE"
+
+    # Check if the file is empty and add/modify content accordingly
+    if [ ! -s "$CONFIG_FILE" ]; then
+        echo "clusterName: $CLUSTER_NAME" > "$CONFIG_FILE"
+    else
+        # If the clusterName line exists, modify it, otherwise add it at the end
+        if grep -q "^clusterName:" "$CONFIG_FILE"; then
+            sed -i -e "s/^clusterName: .*/clusterName: ${CLUSTER_NAME}/" "$CONFIG_FILE"
+        else
+            echo "clusterName: $CLUSTER_NAME" >> "$CONFIG_FILE"
+        fi
+    fi
+fi
+
+# Add the redis-operator helm repository
+helm repo add ot-helm https://ot-container-kit.github.io/helm-charts/
+helm repo update
+
+# Install the CRDs that match the version defined
+helm upgrade --install --namespace=redis-systems --create-namespace redis-operator ot-helm/redis-operator --version "${VERSION}"
+
+# Helm command setup for Redis operator and cluster
+HELM_CMD="helm upgrade --install redis-operator ot-helm/redis-operator \
+    --namespace=redis-systems \
+    --timeout 120m \
+    -f /opt/genestack/base-helm-configs/redis-operator/redis-operator-helm-overrides.yaml"
+
+# Check if YAML files exist in the specified directory
+if compgen -G "${CONFIG_DIR}/*.yaml" > /dev/null; then
+    # Add all YAML files from the directory to the helm command
+    for yaml_file in "${CONFIG_DIR}"/*.yaml; do
+        HELM_CMD+=" -f ${yaml_file}"
+    done
+fi
+
+HELM_CMD+=" $@"
+
+# Run the helm command
+echo "Executing Helm command:"
+echo "${HELM_CMD}"
+eval "${HELM_CMD}"

--- a/docs/redis-setup-guide.md
+++ b/docs/redis-setup-guide.md
@@ -1,0 +1,57 @@
+Redis Cluster Setup with Helm (OT-Container-Kit Redis Operator 0.21.0)
+Redis Git hub Repository: https://github.com/OT-CONTAINER-KIT/redis-operator
+Overview
+Deploys a 6-pod Redis cluster (3 leaders, 3 followers) on an OpenStack Kubernetes cluster using Helm, integrated into Genestack base-helm-configs, distributed across 3 nodes.
+Prerequisites
+
+Kubernetes cluster with kubectl configured.
+Helm installed.
+Genestack repository cloned: git clone https://github.com/rackerlabs/genestack.git.
+
+Deployment Steps
+
+Ensure values.yaml is configured in genestack/base-helm-configs with:
+leader.replicas: 3
+follower.replicas: 3
+storageClassName: general
+persistenceEnabled: true
+
+
+Create the override file: Save redis-operator-helm-overrides.yaml in /etc/genestack/helm-configs/redis-operator/ with the provided content.
+Deploy the Redis operator and cluster:
+Run: ./bin/install-redis-operator.sh
+Optional: Customize CLUSTER_NAME: ./bin/install-redis-operator.sh CLUSTER_NAME=mycluster
+
+
+Verify deployment: kubectl get pods -n redis-systems -o wide
+
+Basic Testing
+
+Verify Pods: kubectl get pods -n redis-systems -o wide
+Expected: 6 pods across 3 nodes, e.g., redis-cluster-leader-0 on node-1, etc.
+
+
+Cluster Health: Inside a pod (e.g., kubectl exec -it redis-cluster-leader-0 -n redis-systems -- /bin/sh), run redis-cli --cluster check 127.0.0.1:6379
+Expected: cluster_state:ok
+
+
+Read/Write: redis-cli --cluster call 127.0.0.1:6379 SET testkey testvalue and GET testkey
+Expected: OK and testvalue
+
+
+Replication: Write to leader, check follower with redis-cli --cluster call 127.0.0.1:6379 GET repltest
+Expected: replvalue
+
+
+Persistence: Set persistkey, restart pod, verify with GET persistkey
+Expected: persistvalue
+
+
+Logs: kubectl logs redis-cluster-leader-0 -n redis-systems
+Expected: No critical errors
+
+
+Customization
+
+Use redis-operator-helm-overrides.yaml to adjust clusterName, namespace, or enable externalService for external access.
+Example: Set externalService.enabled: true and serviceType: LoadBalancer for external connectivity.


### PR DESCRIPTION
->Have got the the redis-operator from the Miguel Parada as https://github.com/OT-CONTAINER-KIT/redis-operator, which is used for a customer POC, and it went with that one because it seems to be the best bet for long term community support, they have deployed it on a platform9 cluster, and the customer deployed redis with it and they have not see any issues or failover scenarios.
->So , hence considered to use this redis operaor further, after discussed with Phillip.
->Customer using the standalone deployment, but I have used the cluster deployment, have used the redis-cluster for redis instance deployment.

->I have tested in my local cluster with these details, and shared the result in the attached file.

[Redis_Test_Result_On_Local_Cluster.zip](https://github.com/user-attachments/files/21628348/Redis_Test_Result_On_Local_Cluster.zip)
