### PR TITLE
Feat: Add SSL encryption between cinder-volume Ontap driver and NetAp…

### DIFF
--- a/ansible/playbooks/deploy-cinder-netapp-volumes-reference.yaml
+++ b/ansible/playbooks/deploy-cinder-netapp-volumes-reference.yaml
@@ -9,6 +9,11 @@
     cinder_storage_network_interface_secondary: ansible_br_storage_secondary
     cinder_backend_name: "block-ha-performance-at-rest-encrypted,block-ha-standard-at-rest-encrypted,block-ha-performance-end-to-end-encrypted,block-ha-standard-end-to-end-encrypted"
     storage_network_multipath: false
+    enable_netapp_ssl: false
+    netapp_cert_src_dir: "/opt/genestack/ansible/playbooks/templates/"
+    netapp_cert_filenames:
+      - "ontap-cluster-host.crt"
+      - "ontap-vserver-host.crt"
   handlers:
     - name: Restart cinder-volume-netapp systemd services
       ansible.builtin.systemd:
@@ -65,6 +70,44 @@
         regexp: '^InitiatorName=.*|^GenerateName=.*'
         line: "InitiatorName={{ initiator_name }}"
 
+    - name: Copy NetApp client certificates Debian
+      ansible.builtin.copy:
+        src: "{{ netapp_cert_src_dir }}/{{ item }}"
+        dest: "/usr/local/share/ca-certificates/{{ item }}"
+        owner: root
+        group: root
+        mode: '0644'
+      when:
+        - enable_netapp_ssl | bool
+        - ansible_os_family | lower == "debian"
+      loop: "{{ netapp_cert_filenames }}"
+
+    - name: Copy NetApp client certificates Redhat
+      ansible.builtin.copy:
+        src: "{{ netapp_cert_src_dir }}/{{ item }}"
+        dest: "/etc/pki/ca-trust/source/anchors/{{ item }}"
+        owner: root
+        group: root
+        mode: '0644'
+      when:
+        - enable_netapp_ssl | bool
+        - ansible_os_family | lower == "redhat"
+      loop: "{{ netapp_cert_filenames }}"
+
+    - name: Update CA certificate trust Debian
+      ansible.builtin.command:
+        cmd: /usr/sbin/update-ca-certificates
+      when:
+        - enable_netapp_ssl | bool
+        - ansible_os_family | lower == "debian"
+
+    - name: Update CA certificate trust Redhat
+      ansible.builtin.command:
+        cmd: /usr/sbin/update-ca-trust extract
+      when:
+        - enable_netapp_ssl | bool
+        - ansible_os_family | lower == "redhat"
+
     - name: Upgrade pip and install required packages
       ansible.builtin.pip:
         name:
@@ -75,6 +118,21 @@
         state: present
         virtualenv: /opt/cinder
         virtualenv_command: python3 -m venv
+
+    - name: Install eventlet SSL patch
+      ansible.builtin.copy:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        owner: root
+        group: root
+        mode: "{{ item.mode | default('0644') }}"
+      loop:
+        - src: "{{ playbook_dir }}/templates/zzz_eventlet_ssl_patch.pth"
+          dest: /opt/cinder/lib/python3.12/site-packages/zzz_eventlet_ssl_patch.pth
+          mode: "0644"
+        - src: "{{ playbook_dir }}/templates/eventlet_ssl_patch.py"
+          dest: /opt/cinder/lib/python3.12/site-packages/eventlet_ssl_patch.py
+          mode: "0644"
 
     - name: Create the cinder system user
       ansible.builtin.user:

--- a/ansible/playbooks/templates/eventlet_ssl_patch.py
+++ b/ansible/playbooks/templates/eventlet_ssl_patch.py
@@ -1,0 +1,13 @@
+import os, ssl
+
+os.environ.setdefault("EVENTLET_NO_GREENDNS", "yes")
+try:
+    from eventlet.green import ssl as gssl
+
+    def _safe_green_create_default_context(*a, **kw):
+        return ssl._create_default_https_context(*a, **kw)
+
+    gssl.green_create_default_context = _safe_green_create_default_context
+except Exception as e:
+    # don't crash the process if eventlet isn't here yet
+    pass

--- a/ansible/playbooks/templates/zzz_eventlet_ssl_patch.pth
+++ b/ansible/playbooks/templates/zzz_eventlet_ssl_patch.pth
@@ -1,0 +1,1 @@
+import eventlet_ssl_patch


### PR DESCRIPTION
…p (#1129)

This ensures that username/pass are not sent in clear text. This does NOT encrypt all traffic from virtual machines to attached NetApp volumes.

Adds variables and logic to playbook for SSL cert deployment to storage node. Correctly updates ca certificates on storage node based on Linux OS version. This assumes DNS resolution for the NetApp cluster hostname and NetApp vserver name.