### PR TITLE
fix: ensure no-tenant network leakage

### DIFF
--- a/ansible/roles/host_setup/handlers/main.yml
+++ b/ansible/roles/host_setup/handlers/main.yml
@@ -65,3 +65,9 @@
   ansible.builtin.apt:
     update_cache: yes
     cache_valid_time: 600
+
+- name: Restart lldpd
+  ansible.builtin.systemd:
+    name: "lldpd.service"
+    state: "restarted"
+    enabled: true

--- a/ansible/roles/host_setup/tasks/main.yml
+++ b/ansible/roles/host_setup/tasks/main.yml
@@ -137,6 +137,17 @@
   retries: 5
   delay: 2
 
+# NOTE(cloudnull): This configuration will ensure that LLDP is working on all interfaces
+#                  except our overlay and tenant networks.
+- name: Create base LLDPD configuration
+  ansible.builtin.copy:
+    content: |
+      DAEMON_ARGS="-c -I *,!tap*,!ovn*,!genev*,!mirror*,!o-hm*"
+    dest: /etc/default/lldpd
+    mode: "0644"
+  notify:
+    - Restart lldpd
+
 - name: Ensure timesyncd is running
   ansible.builtin.service:
     name: systemd-timesyncd

--- a/ansible/roles/host_setup/vars/debian.yml
+++ b/ansible/roles/host_setup/vars/debian.yml
@@ -41,8 +41,8 @@ _host_distro_packages:
   - apt-utils
   - bridge-utils
   - cgroup-tools
-  - curl
   - cryptsetup
+  - curl
   - dmeventd
   - dstat
   - ebtables
@@ -50,6 +50,7 @@ _host_distro_packages:
   - iptables
   - irqbalance
   - libkmod2
+  - lldpd
   - lsscsi
   - lvm2
   - nfs-client

--- a/ansible/roles/host_setup/vars/ubuntu.yml
+++ b/ansible/roles/host_setup/vars/ubuntu.yml
@@ -49,6 +49,7 @@ _host_distro_packages:
   - iptables
   - irqbalance
   - libkmod2
+  - lldpd
   - lsscsi
   - lvm2
   - nfs-client


### PR DESCRIPTION
The following configuration will ensure that we're not permitting LLDP traffic over tenant networks. In the before now we were not controlling the installation of LLDP, however, we were requiring it for QC tools. This change ensures that we're controlling the installation of LLDP and the config, which ensures that we're not leaking host information to tenants of the cloud platform.