### PR TITLE
Set TMP directory to use pod /tmp; Enabled neutron network interface

### DIFF
--- a/base-helm-configs/ironic/ironic-helm-overrides.yaml
+++ b/base-helm-configs/ironic/ironic-helm-overrides.yaml
@@ -32,7 +32,7 @@ conf:
   ironic:
     DEFAULT:
       log_config_append: /etc/ironic/logging.conf
-      tempdir: /var/lib/openstack-helm/tmp # Matches openstack-helm default
+      tempdir: /tmp
       default_deploy_interface: "direct"
       default_inspect_interface: "inspector"
       default_network_interface: "neutron"
@@ -41,6 +41,7 @@ conf:
       enabled_deploy_interfaces: "direct,ramdisk"
       enabled_inspect_interfaces: "inspector,no-inspect"
       enabled_management_interfaces: "ipmitool,redfish"
+      enabled_network_interfaces: "flat,neutron"
       enabled_power_interfaces: "ipmitool,redfish"
       enabled_raid_interfaces: "no-raid"
     database:


### PR DESCRIPTION
Default network interface is Neutron, but it's not enabled. This patch enables it. Hard set /tmp path does not exist. We're mounting a /tmp, so why not use it?