### PR TITLE
feat: Adding octavia worker port creation in octavia preconf

### DIFF
--- a/ansible/roles/octavia_preconf/files/create_worker_ports.sh
+++ b/ansible/roles/octavia_preconf/files/create_worker_ports.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# We need to create the ports with shell scripts
+# the ansible module currently doesn't provide
+# --host argument
+
+set -xe
+
+# Obtain the network_id and secgroup_id from and
+# cloud name from ansible task
+NET_ID=$1
+SECGRP_ID=$2
+CLOUD_NAME=$3
+
+export OS_CLOUD=$CLOUD_NAME
+
+# Obtain the list of kubernetes nodes with
+# "openstack-control-plane=enabled" label
+CONTROLLER_IP_PORT_LIST=()
+CTRLS=$(kubectl get nodes -l openstack-control-plane=enabled -o name | awk -F"/" '{print $2}')
+for node in $CTRLS
+do
+  node_short=$(echo "$node" | awk -F"." '{print $1}')
+  PORTNAME=octavia-worker-port-$node_short
+  if ! PORT_DATA=$(openstack port show "$PORTNAME" -c fixed_ips -f json); then
+    PORT_DATA=$(openstack port create "$PORTNAME" --security-group "$SECGRP_ID" \
+                                                  --device-owner Octavia:worker \
+                                                  --host="$node" \
+                                                  --network "$NET_ID" \
+                                                  -c fixed_ips \
+                                                  -f json)
+  fi
+  for IP in $(echo "$PORT_DATA" | awk 'BEGIN { FS = "\"" } /ip_address/ { print $(NF - 1) }'); do
+    CONTROLLER_IP_PORT_LIST+=("$IP:5555")
+  done
+done
+
+readarray -t sorted < <(for item in "${CONTROLLER_IP_PORT_LIST[@]}"; do echo "${item}"; done | sort)
+echo $(IFS=,; echo "${sorted[*]}") > /tmp/octavia_worker_controller_ip_port_list

--- a/ansible/roles/octavia_preconf/tasks/main.yml
+++ b/ansible/roles/octavia_preconf/tasks/main.yml
@@ -21,6 +21,11 @@
   tags:
     - always
 
+- name: import tasks to create worker ports
+  import_tasks: octavia_health_worker_ports.yml
+  tags:
+    - always
+
 - name: import tasks to create amphora image, flavor and ssh keypair
   import_tasks: octavia_amphora_keypair_image_flavor.yml
   tags:

--- a/ansible/roles/octavia_preconf/tasks/octavia_sec_group.yml
+++ b/ansible/roles/octavia_preconf/tasks/octavia_sec_group.yml
@@ -81,3 +81,27 @@
   until: lb_health_mgr_secgroup_r1 is success
   retries: 5
   delay: 5
+
+- name: Create security group for worker ports
+  openstack.cloud.security_group:
+    name: "{{ lb_worker_secgrp_name }}"
+    state: present
+    description: "security group for worker ports"
+    interface: public
+  register: create_lb_worker_secgroup
+  until: create_lb_worker_secgroup is success
+  retries: 5
+  delay: 5
+
+- name: Create Security group rule to allow traffic on port 5555 for worker
+  openstack.cloud.security_group_rule:
+    security_group: "{{ create_lb_worker_secgroup.security_group.id }}"
+    state: present
+    protocol: udp
+    port_range_min: 5555
+    port_range_max: 5555
+    interface: public
+  register: lb_worker_secgroup_r1
+  until: lb_worker_secgroup_r1 is success
+  retries: 5
+  delay: 5

--- a/ansible/roles/octavia_preconf/tasks/octavia_worker_ports.yml
+++ b/ansible/roles/octavia_preconf/tasks/octavia_worker_ports.yml
@@ -1,0 +1,22 @@
+---
+# These are the tasks for creating health_mgr
+# ports for octavia; the ports are created with
+# a shell script as the ansible modules currently
+# don't support all the required params for creating
+# ports
+- name: Obtain the UUID of the lb-mgmt-net
+  openstack.cloud.networks_info:
+    name: lb-mgmt-net
+    interface: public
+  register: lb_mgmt_info
+
+- name: Obtain the UUID of the worker secgroup
+  openstack.cloud.security_group_info:
+    name: "{{ lb_worker_secgrp_name }}"
+    interface: public
+  register: lb_worker_secgrp_info
+
+- name: run the shell script to create worker ports if required
+  script:
+    cmd: create_worker_ports.sh {{ lb_mgmt_info.networks[0].id }} {{ lb_worker_secgrp_info.security_groups[0].id }} {{ lookup('env', 'OS_CLOUD') | default('openstack_helm') }}
+    creates: /tmp/octavia_worker_controller_ip_port_list


### PR DESCRIPTION
updated versions of octavia helm chart require ports created for the worker nodes as well as the health managers. I've simply duplicated the port creation as this may be something we yank out if/when octavia helm decides to make it optional.