### PR TITLE
fix: standardize EOC in script

### DIFF
--- a/scripts/hyperconverged-lab.sh
+++ b/scripts/hyperconverged-lab.sh
@@ -994,7 +994,7 @@ HERE
 EOC
 
 echo "Installing k9s"
-ssh -o ForwardAgent=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -t ${SSH_USERNAME}@${JUMP_HOST_VIP} << 'EOC'
+ssh -o ForwardAgent=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -t ${SSH_USERNAME}@${JUMP_HOST_VIP} <<EOC
 set -e
 echo "Installing k9s"
 if [ ! -e "/usr/bin/k9s" ]; then
@@ -1009,7 +1009,7 @@ fi
 EOC
 
 echo "Installing Octavia preconf"
-ssh -o ForwardAgent=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -t ${SSH_USERNAME}@${JUMP_HOST_VIP} << 'EOC'
+ssh -o ForwardAgent=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -t ${SSH_USERNAME}@${JUMP_HOST_VIP} <<EOC
 set -e
 
 if [ ! -f ~/.config/openstack ]; then
@@ -1038,3 +1038,4 @@ The lab is now ready for use and took ${SECONDS} seconds to complete.
 This is the jump host address ${JUMP_HOST_VIP}, write this down.
 This is the VIP address internally ${METAL_LB_IP} with public address ${METAL_LB_VIP} within MetalLB, write this down.
 EOF
+


### PR DESCRIPTION
fix: ensure newline at end of script and standardize EOC

The POSIX standard for text files requires a final newline character. Many utilities, including compilers, linters, and text editors, can behave unexpectedly if this rule isn't followed. Adding the newline ensures that your script is properly terminated and that all of its content, including the delimiter, is correctly parsed. This consistency makes your script more portable and less prone to errors when processed by different tools or on different systems.