### PR TITLE
adjust masakari-monitors genestack image repo link

### DIFF
--- a/base-helm-configs/masakari/masakari-helm-overrides.yaml
+++ b/base-helm-configs/masakari/masakari-helm-overrides.yaml
@@ -23,8 +23,8 @@ images:
     masakari_engine: ghcr.io/rackerlabs/genestack-images/masakari:2024.1-latest
     # TEMP HOST-MONITOR IMAGE TO FIX: https://review.opendev.org/c/openstack/masakari-monitors/+/951336
     masakari_host_monitor: kernelpanic53/rackerlabs-masakari-monitors:zhmarvi-ubuntu_jammy_v1.0
-    masakari_process_monitor: ghcr.io/rackerlabs/genestack-images/masakari:2024.1-latest
-    masakari_instance_monitor: ghcr.io/rackerlabs/genestack-images/masakari:2024.1-latest
+    masakari_process_monitor: ghcr.io/rackerlabs/genestack-images/masakari-monitors:2024.1-latest
+    masakari_instance_monitor: ghcr.io/rackerlabs/genestack-images/masakari-monitors:2024.1-latest
     rabbit_init: docker.io/rabbitmq:3.13-management
     dep_check: ghcr.io/rackerlabs/genestack-images/kubernetes-entrypoint:latest
   pull_policy: "IfNotPresent"


### PR DESCRIPTION
Related to PR https://github.com/rackerlabs/genestack-images/pull/71

Fix broken image pull for masakari-monitors process and instance monitor when migrating from quay.io to ghcr.io registry.