### PR TITLE
fix: add token permissions and write output to the pr as a comment

### DIFF
--- a/.github/workflows/smoke-deploy-lab.yaml
+++ b/.github/workflows/smoke-deploy-lab.yaml
@@ -1,5 +1,10 @@
 name: Running hyperconverged smoke tests
 
+permissions:
+  contents: read
+  actions: write
+  pull-requests: write # Add permissions to write to pull requests
+
 on:
   workflow_dispatch:
     inputs:
@@ -109,3 +114,17 @@ jobs:
       - name: Cleanup the lab
         if: ${{ always() && (github.event_name == 'pull_request' || contains(fromJSON('["cleanup", "test"]'), github.event.inputs.mode)) }}
         run: scripts/hyperconverged-lab-uninstall.sh
+
+      - name: Comment on PR with output
+        if: ${{ github.event_name == 'pull_request' && -s access-output.txt }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const comment = fs.readFileSync('access-output.txt', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });


### PR DESCRIPTION
This pr adds workflow permissions using the principle of least privilege by explicitly setting read or write access for "actions".  It will also post the output from 'access-output.txt' or the summary of the run.