### PR TITLE
fix: correct list override for exemplars

### DIFF
--- a/base-helm-configs/prometheus/prometheus-helm-overrides.yaml
+++ b/base-helm-configs/prometheus/prometheus-helm-overrides.yaml
@@ -3251,7 +3251,7 @@ prometheus:
 
     ## Exemplars related settings that are runtime reloadable.
     ## It requires to enable the exemplar storage feature to be effective.
-    exemplars: ""
+    exemplars: {}
       ## Maximum number of exemplars stored in memory for all series.
       ## If not set, Prometheus uses its default value.
       ## A value of zero or less than zero disables the storage.


### PR DESCRIPTION
Use the correct data type in the override to suppres the error:
"coalesce.go:286: warning: cannot overwrite table with non table for kube-prometheus-stack.prometheus.prometheusSpec.exemplars (map[])"

values pulled from here: https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml