### PR TITLE
Adjust requests for skyline API server

### DIFF
--- a/base-kustomize/skyline/base/deployment-apiserver.yaml
+++ b/base-kustomize/skyline/base/deployment-apiserver.yaml
@@ -362,7 +362,7 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
             requests:
-              memory: "256Mi"
+              memory: "512Mi"
               cpu: "100m"
             limits:
               memory: "4096Mi"


### PR DESCRIPTION
In lab and demo clusters out of the box, the skyline api server scales to max pods during idle use. average memory utilization around 345Mi while the standard requests are 256MI. Looking to bump it up to 512Mi to keep the HPA utilization average low.

Average pod mem utilization:

NAME                                                 CPU(cores)   MEMORY(bytes)
skyline-86d75cc747-597pm                   5m           345Mi
skyline-86d75cc747-gwkgd                   5m           344Mi