### PR TITLE
Update setup-openstack-rc.sh

### DIFF
--- a/bin/setup-openstack-rc.sh
+++ b/bin/setup-openstack-rc.sh
@@ -2,7 +2,7 @@
 set -e
 
 function installYq() {
-    export VERSION=v4.2.0
+    export VERSION=v4.47.2
     export BINARY=yq_linux_amd64
     wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY}.tar.gz -q -O - | tar xz && mv ${BINARY} /usr/local/bin/yq
 }


### PR DESCRIPTION
yq must be upgraded be in sync with the printf command during the openstack-exporter install instructions which use an updated command line