### PR TITLE
nova_compute_ironic fixes

### DIFF
--- a/base-helm-configs/ironic/ironic-helm-overrides.yaml
+++ b/base-helm-configs/ironic/ironic-helm-overrides.yaml
@@ -34,12 +34,12 @@ conf:
       log_config_append: /etc/ironic/logging.conf
       tempdir: /tmp
       default_deploy_interface: "direct"
-      default_inspect_interface: "inspector"
+      default_inspect_interface: "agent"
       default_network_interface: "neutron"
       enabled_hardware_types: "ipmi,redfish"
       enabled_boot_interfaces: "pxe,ipxe"
       enabled_deploy_interfaces: "direct,ramdisk"
-      enabled_inspect_interfaces: "inspector,no-inspect"
+      enabled_inspect_interfaces: "agent,no-inspect,redfish"
       enabled_management_interfaces: "ipmitool,redfish"
       enabled_network_interfaces: "flat,neutron"
       enabled_power_interfaces: "ipmitool,redfish"

--- a/base-helm-configs/nova/nova-helm-overrides.yaml
+++ b/base-helm-configs/nova/nova-helm-overrides.yaml
@@ -14,7 +14,7 @@ images:
     nova_cell_setup: "ghcr.io/rackerlabs/genestack-images/nova:2024.1-latest"
     nova_cell_setup_init: "ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest"
     nova_compute: "ghcr.io/rackerlabs/genestack-images/nova:2024.1-latest"
-    nova_compute_ironic: "docker.io/kolla/ubuntu-source-nova-compute-ironic:wallaby"
+    nova_compute_ironic: "ghcr.io/rackerlabs/genestack-images/nova:2024.1-latest"
     nova_compute_ssh: "ghcr.io/rackerlabs/genestack-images/nova:2024.1-latest"
     nova_conductor: "ghcr.io/rackerlabs/genestack-images/nova:2024.1-latest"
     nova_db_sync: "ghcr.io/rackerlabs/genestack-images/nova:2024.1-latest"
@@ -362,6 +362,18 @@ pod:
           - name: metadata-api-static-vendordata
             configMap:
               name: static-vendor-data
+    nova_compute_ironic:
+      init_container: null
+      nova_compute_ironic:
+        volumeMounts:
+          - name: metadata-api-static-vendordata
+            mountPath: /etc/nova/vendor_data.json
+            subPath: vendor_data.json
+            readOnly: true
+        volumes:
+          - name: metadata-api-static-vendordata
+            configMap:
+              name: static-vendor-data
     nova_api_metadata:
       init_container: null
       nova_api_metadata:
@@ -391,3 +403,4 @@ manifests:
   service_ingress_osapi: false
   service_ingress_spiceproxy: false
   service_spiceproxy: false
+  statefulset_compute_ironic: false


### PR DESCRIPTION
- Updated nova_compute_ironic to use our Nova image
- Removing support for Ironic Inspector (deprecated/not-supported) in favor of Agent-based inspection
- To enable ironic compute support, set `statefulset_compute_ironic: true`.
- Docs still needed