### PR TITLE
fix: correct list override for exemplars

### DIFF
--- a/base-helm-configs/prometheus/prometheus-helm-overrides.yaml
+++ b/base-helm-configs/prometheus/prometheus-helm-overrides.yaml
@@ -3251,7 +3251,7 @@ prometheus:
 
     ## Exemplars related settings that are runtime reloadable.
     ## It requires to enable the exemplar storage feature to be effective.
-    exemplars: ""
+    exemplars: {}
       ## Maximum number of exemplars stored in memory for all series.
       ## If not set, Prometheus uses its default value.
       ## A value of zero or less than zero disables the storage.


### PR DESCRIPTION
(cherry picked from commit 39356c740272ead513f3c4963e0c1af727f9a520)