### PR TITLE
fix: Add freezer-keystone-service-password and v2 on non-public endpoints

### DIFF
--- a/base-helm-configs/freezer/freezer-helm-overrides.yaml
+++ b/base-helm-configs/freezer/freezer-helm-overrides.yaml
@@ -34,7 +34,7 @@ dependencies:
 conf:
   freezer:
     DEFAULT:
-      host_href: "http://freezer-api.openstack.svc.cluster.local:9090"
+      host_href: "http://freezer-api.openstack.svc.cluster.local:9090/v2"
     database:
       connection_debug: 0
       connection_recycle_time: 600

--- a/bin/create-secrets.sh
+++ b/bin/create-secrets.sh
@@ -109,6 +109,7 @@ blazar_keystone_test_password=$(generate_password 32)
 freezer_db_password=$(generate_password 32)
 freezer_admin_password=$(generate_password 32)
 freezer_keystone_test_password=$(generate_password 32)
+freezer_keystone_service_password=$(generate_password 32)
 
 OUTPUT_FILE="/etc/genestack/kubesecrets.yaml"
 
@@ -792,6 +793,15 @@ metadata:
 type: Opaque
 data:
   password: $(echo -n $freezer_keystone_test_password | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: freezer-keystone-service-password
+  namespace: openstack
+type: Opaque
+data:
+  password: $(echo -n $freezer_keystone_service_password | base64 -w0)
 ---
 apiVersion: v1
 kind: Secret

--- a/bin/install-freezer.sh
+++ b/bin/install-freezer.sh
@@ -37,6 +37,7 @@ done
 HELM_CMD+=" --set endpoints.identity.auth.admin.password=\"$(kubectl --namespace openstack get secret keystone-admin -o jsonpath='{.data.password}' | base64 -d)\""
 HELM_CMD+=" --set endpoints.identity.auth.freezer.password=\"$(kubectl --namespace openstack get secret freezer-admin -o jsonpath='{.data.password}' | base64 -d)\""
 HELM_CMD+=" --set endpoints.identity.auth.test.password=\"$(kubectl --namespace openstack get secret freezer-keystone-test-password -o jsonpath='{.data.password}' | base64 -d)\""
+HELM_CMD+=" --set endpoints.identity.auth.service.password=\"$(kubectl --namespace openstack get secret freezer-keystone-service-password -o jsonpath='{.data.password}' | base64 -d)\""
 HELM_CMD+=" --set endpoints.oslo_db.auth.admin.password=\"$(kubectl --namespace openstack get secret mariadb -o jsonpath='{.data.root-password}' | base64 -d)\""
 HELM_CMD+=" --set endpoints.oslo_db.auth.freezer.password=\"$(kubectl --namespace openstack get secret freezer-db-password -o jsonpath='{.data.password}' | base64 -d)\""
 HELM_CMD+=" --set endpoints.oslo_cache.auth.memcache_secret_key=\"$(kubectl --namespace openstack get secret os-memcached -o jsonpath='{.data.memcache_secret_key}' | base64 -d)\""


### PR DESCRIPTION
1. Making Freezer-Client VM to communicate explicitly over public endpoint using the service tenant - hence enabling the service-password for the freezer public endpoint.
2. On non-public endpoints, in my testing its seen freezer requires the backup api version to be set on endpoint urls.