### PR TITLE
fix(placement): Correct incorrect oslo_concurrency lock_path (#1220)

### DIFF
--- a/base-helm-configs/placement/placement-helm-overrides.yaml
+++ b/base-helm-configs/placement/placement-helm-overrides.yaml
@@ -52,7 +52,7 @@ conf:
       service_token_roles_required: true
       service_type: placement
     oslo_concurrency:
-      lock_path: /tmp/octavia
+      lock_path: /tmp/placement
     oslo_messaging_notifications:
       driver: messagingv2
     oslo_messaging_rabbit:


### PR DESCRIPTION
The `oslo_concurrency.lock_path` in `placement-helm-overrides.yaml` was incorrectly set to `/tmp/octavia`. This appears to be a copy-paste error from the Octavia service configuration.

(cherry picked from commit 0c1f2a75ef549251cf414f2894124d2a0c75e779)