### PR TITLE
fix: temp removing glance download/get image policy

### DIFF
--- a/base-helm-configs/glance/glance-helm-overrides.yaml
+++ b/base-helm-configs/glance/glance-helm-overrides.yaml
@@ -125,8 +125,6 @@ conf:
     "service_api": "role:service"
     "publicize_image": "role:glance_admin"
     "communitize_image": "role:glance_admin"
-    "download_image": "rule:context_is_admin or rule:service_api or (role:member and (project_id:%(project_id)s or project_id:%(member_id)s))"
-    "get_image": "rule:context_is_admin or rule:service_api or (role:reader and (project_id:%(project_id)s or project_id:%(member_id)s or 'community':%(visibility)s or 'public':%(visibility)s or 'shared':%(visibility)s))"
   logging:
     logger_root:
       level: INFO


### PR DESCRIPTION
(cherry picked from commit f28f9ac1f68a10ad02123f3b8e397a1f0778951f)