### PR TITLE
fix: Remove v2 on non-public endpoints

### DIFF
--- a/base-helm-configs/freezer/freezer-helm-overrides.yaml
+++ b/base-helm-configs/freezer/freezer-helm-overrides.yaml
@@ -34,7 +34,7 @@ dependencies:
 conf:
   freezer:
     DEFAULT:
-      host_href: "http://freezer-api.openstack.svc.cluster.local:9090/v2"
+      host_href: "http://freezer-api.openstack.svc.cluster.local:9090"
     database:
       connection_debug: 0
       connection_recycle_time: 600


### PR DESCRIPTION
Already v2 is present in python-freezerclient code: 
[https://opendev.org/openstack/python-freezerclient/src/branch/master/freezerclient/v2/managers/sessions.py#L27](https://opendev.org/openstack/python-freezerclient/src/branch/master/freezerclient/v2/managers/sessions.py#L27) 
This was creating an incorrect url causing API calls to fail.