### PR TITLE
Remove max_queue for libvirt to autodetect

### DIFF
--- a/base-helm-configs/nova/nova-helm-overrides.yaml
+++ b/base-helm-configs/nova/nova-helm-overrides.yaml
@@ -150,7 +150,6 @@ conf:
       service_type: compute
     libvirt:
       cpu_mode: host-model
-      max_queues: 8
       num_pcie_ports: 16
     os_vif_ovs:
       ovsdb_connection: "tcp:127.0.0.1:6640"


### PR DESCRIPTION
Since kernel 3, the default setting for max queue per tap is 256. The nova code per https://bugs.launchpad.net/nova/+bug/1847367 is auto detecting this and sets it accordingly