### PR TITLE
Adding LVM configuration management

### DIFF
--- a/ansible/roles/host_setup/tasks/lvm_config.yml
+++ b/ansible/roles/host_setup/tasks/lvm_config.yml
@@ -1,0 +1,41 @@
+---
+# Copyright 2025, Rackspace Technology, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Discover current pv devices
+  ansible.builtin.shell: |
+    set -o pipefail
+    /sbin/pvdisplay | awk '/PV\ Name/ {print $3}' | sed 's/\/dev\///g'
+  args:
+    executable: /bin/bash
+  register: lvm_devices
+  changed_when: lvm_devices.rc != 0
+  failed_when: false
+
+- name: Ensure "/etc/lvm" directory
+  ansible.builtin.file:
+    state: "directory"
+    path: "/etc/lvm"
+    mode: "0755"
+  when: lvm_devices.rc == 0
+
+- name: Update lvm.conf
+  ansible.builtin.template:
+    src: "lvm.conf.j2"
+    dest: "/etc/lvm/lvm.conf"
+    owner: "root"
+    group: "root"
+    backup: "yes"
+    mode: "0644"
+  when: lvm_devices.rc == 0

--- a/ansible/roles/host_setup/tasks/main.yml
+++ b/ansible/roles/host_setup/tasks/main.yml
@@ -165,5 +165,8 @@
 - name: Configure custom multipath.conf
   ansible.builtin.include_tasks: custom_multipath.yml
 
+- name: Configure custom lvm.conf
+  ansible.builtin.include_tasks: lvm_config.yml
+
 - name: Install RAID controller CLI tools
   ansible.builtin.include_tasks: raid_cli_tools.yml

--- a/ansible/roles/host_setup/templates/lvm.conf.j2
+++ b/ansible/roles/host_setup/templates/lvm.conf.j2
@@ -1,0 +1,127 @@
+# {{ ansible_managed }}
+
+{% set used_lvm_devices = [] %}
+{% if host_lvm_devices_filter_override|length > 0 %}
+    {% set used_lvm_devices = host_lvm_devices_filter_override %}
+{% else %}
+    {% set lv_devices = lvm_devices.stdout.split('\n') %}
+    {% if lv_devices|length > 0 %}
+        {% for net in lv_devices %}
+            {% if net != '' %}
+                {% set lv_device = '"a/' + net + '/"' %}
+                {% if used_lvm_devices.append(lv_device) %}{% endif %}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+
+# Ansible Discovered LVM Devices {{ lv_devices }}
+{% endif %}
+
+{% if used_lvm_devices|length <= 0 %}
+    {# If there are no LVM devices present, allow all devices to be scanned #}
+    {% if used_lvm_devices.append('"a/.*/"') %}{% endif %}
+{% else %}
+    {# Append 'loop.*' to the list to help with AIO deployments. #}
+    {% if used_lvm_devices.append('"a/loop.*/"') %}{% endif %}
+    {# Disable scanning any other devices than the ones listed. #}
+    {% if used_lvm_devices.append('"r/.*/"') %}{% endif %}
+{% endif %}
+
+devices {
+    dir = "/dev"
+    scan = [ "/dev" ]
+    obtain_device_list_from_udev = 1
+    preferred_names = [ ]
+    filter = [ {{ used_lvm_devices|join(', ') }} ]
+    cache_dir = "/run/lvm"
+    cache_file_prefix = ""
+    write_cache_state = 1
+    sysfs_scan = 1
+    multipath_component_detection = 1
+    md_component_detection = 1
+    md_chunk_alignment = 1
+    data_alignment_detection = 1
+    data_alignment = 0
+    data_alignment_offset_detection = 1
+    ignore_suspended_devices = 0
+    disable_after_error_count = 0
+    require_restorefile_with_uuid = 1
+    pv_min_size = 2048
+    issue_discards = 1
+}
+allocation {
+    maximise_cling = 1
+    mirror_logs_require_separate_pvs = 0
+    thin_pool_metadata_require_separate_pvs = 0
+}
+log {
+    verbose = 0
+    silent = 0
+    syslog = 1
+    overwrite = 0
+    level = 0
+    indent = 1
+    command_names = 0
+    prefix = "  "
+}
+backup {
+    backup = 1
+    backup_dir = "/etc/lvm/backup"
+    archive = 1
+    archive_dir = "/etc/lvm/archive"
+    retain_min = 10
+    retain_days = 30
+}
+shell {
+    history_size = 100
+}
+global {
+    umask = 077
+    test = 0
+    units = "h"
+    si_unit_consistency = 1
+    activation = 1
+    proc = "/proc"
+    locking_type = 1
+    wait_for_locks = 1
+    fallback_to_clustered_locking = 1
+    fallback_to_local_locking = 1
+    locking_dir = "/run/lock/lvm"
+    prioritise_write_locks = 1
+    abort_on_internal_errors = 0
+    detect_internal_vg_cache_corruption = 0
+    metadata_read_only = 0
+    mirror_segtype_default = "mirror"
+    use_lvmetad = 0
+    thin_check_executable = "/usr/sbin/thin_check"
+    thin_check_options = [ "-q" ]
+}
+activation {
+    checks = 0
+    udev_sync = 1
+    udev_rules = 1
+    verify_udev_operations = 0
+    retry_deactivation = 1
+    missing_stripe_filler = "error"
+    use_linear_target = 1
+    reserved_stack = 64
+    reserved_memory = 8192
+    process_priority = -18
+    mirror_region_size = 512
+    readahead = "auto"
+    raid_fault_policy = "warn"
+    mirror_log_fault_policy = "allocate"
+    mirror_image_fault_policy = "remove"
+    snapshot_autoextend_threshold = 100
+    snapshot_autoextend_percent = 20
+    thin_pool_autoextend_threshold = 100
+    thin_pool_autoextend_percent = 20
+    use_mlockall = 0
+    monitoring = 0
+    polling_interval = 15
+}
+dmeventd {
+    mirror_library = "libdevmapper-event-lvm2mirror.so"
+    snapshot_library = "libdevmapper-event-lvm2snapshot.so"
+    thin_library = "libdevmapper-event-lvm2thin.so"
+}

--- a/ansible/roles/host_setup/vars/debian.yml
+++ b/ansible/roles/host_setup/vars/debian.yml
@@ -66,3 +66,5 @@ _host_distro_packages:
 _hosts_package_list:
   - name: ca-certificates
     state: latest
+
+host_lvm_devices_filter_override: []

--- a/ansible/roles/host_setup/vars/ubuntu.yml
+++ b/ansible/roles/host_setup/vars/ubuntu.yml
@@ -67,3 +67,5 @@ _hosts_package_list:
     state: "{{ host_package_state }}"
   - name: ca-certificates
     state: latest
+
+host_lvm_devices_filter_override: []


### PR DESCRIPTION
Ensures that only current or configured volumes are visible on the host. Once VMs utilize lvm and for example iSCSI block devices are used, the host can accidentially scan VM PVs and destroy exclusive device access. This typically prevents live migration if not otherwise prohibited by lvm filters.