### PR TITLE
fix(gnocchi): Quote Ceph admin key

### DIFF
--- a/bin/install-gnocchi.sh
+++ b/bin/install-gnocchi.sh
@@ -32,7 +32,7 @@ for dir in "$GLOBAL_OVERRIDES_DIR" "$SERVICE_CONFIG_DIR"; do
     fi
 done
 
-HELM_CMD+=" --set conf.ceph.admin_keyring=\"$(kubectl get secret --namespace rook-ceph rook-ceph-admin-keyring -o jsonpath='{.data.keyring}' | base64 -d)\""
+HELM_CMD+=" --set conf.ceph.admin_keyring=\"\$(kubectl get secret --namespace rook-ceph rook-ceph-admin-keyring -o jsonpath='{.data.keyring}' | base64 -d)\""
 HELM_CMD+=" --set conf.gnocchi.keystone_authtoken.memcache_secret_key=\"$(kubectl --namespace openstack get secret os-memcached -o jsonpath='{.data.memcache_secret_key}' | base64 -d)\""
 HELM_CMD+=" --set endpoints.oslo_cache.auth.memcache_secret_key=\"$(kubectl --namespace openstack get secret os-memcached -o jsonpath='{.data.memcache_secret_key}' | base64 -d)\""
 HELM_CMD+=" --set endpoints.identity.auth.admin.password=\"$(kubectl --namespace openstack get secret keystone-admin -o jsonpath='{.data.password}' | base64 -d)\""


### PR DESCRIPTION
Regression since a226323: the multiline keyring was inlined via `--set` without proper quoting, so embedded newlines split the Helm command and Helm failed to parse the args. Quote/escape the value so it’s passed verbatim as a single argument.