### PR TITLE
Fixing the postgres operator config dir

### DIFF
--- a/bin/install-postgres-operator.sh
+++ b/bin/install-postgres-operator.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # shellcheck disable=SC2124,SC2145,SC2294
 # Directory to check for YAML files
-CONFIG_DIR="/etc/genestack/helm-configs/postgres-operator/base"
+CONFIG_DIR="/etc/genestack/helm-configs/postgres-operator"
 
 # Read postgres-operator version from helm-chart-versions.yaml
 VERSION_FILE="/etc/genestack/helm-chart-versions.yaml"


### PR DESCRIPTION
### Summary
This PR fixes incorrect CONFIG_DIR path in install-postgres-operator.sh to ensure user overrides in `/etc/genestack/helm-configs/postgres-operator/` are applied.

### Changes
- Corrected CONFIG_DIR path

### Linked Issue
Fixes #1230