### PR TITLE
fix: placement doesnt use rabbit

### DIFF
--- a/base-helm-configs/placement/placement-helm-overrides.yaml
+++ b/base-helm-configs/placement/placement-helm-overrides.yaml
@@ -53,26 +53,6 @@ conf:
       service_type: placement
     oslo_concurrency:
       lock_path: /tmp/placement
-    oslo_messaging_notifications:
-      driver: messagingv2
-    oslo_messaging_rabbit:
-      amqp_durable_queues: false
-      rabbit_ha_queues: false
-      rabbit_quorum_queue: true
-      rabbit_transient_quorum_queue: false
-      use_queue_manager: false
-      rabbit_interval_max: 10
-      # Send more frequent heartbeats and fail unhealthy nodes faster
-      # heartbeat_timeout / heartbeat_rate / 2.0 = 30 / 3 / 2.0 = 5
-      # https://opendev.org/openstack/oslo.messaging/commit/36fb5bceabe08a982ebd52e4a8f005cd26fdf6b8
-      heartbeat_rate: 3
-      heartbeat_timeout_threshold: 60
-      # NOTE (deprecation warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: true
-      # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
-      # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
-      # https://review.opendev.org/c/openstack/oslo.messaging/+/866617
-      kombu_reconnect_delay: 0.5
     placement:
       randomize_allocation_candidates: true
     placement_database:
@@ -109,11 +89,6 @@ endpoints:
       default: memcached.openstack.svc.cluster.local
     hosts:
       default: memcached
-  oslo_messaging:
-    host_fqdn_override:
-      default: rabbitmq.openstack.svc.cluster.local
-    hosts:
-      default: rabbitmq-nodes
 
 dependencies:
   static:


### PR DESCRIPTION
The openstack placement service is an api driven resource collection storehouse.  Therefore all services needing to talk to placement do so via its api, not through rabbit.  There are no mentions of oslo.messaging in the sample placement.conf found here: https://docs.openstack.org/placement/2024.1/configuration/sample-config.html

As such, remove the extra configs that are not being applied.