### PR TITLE
feat: [OSPC-1571] Use images from ghcr rackerlabs registry for Freezer

### DIFF
--- a/base-helm-configs/freezer/freezer-helm-overrides.yaml
+++ b/base-helm-configs/freezer/freezer-helm-overrides.yaml
@@ -1,4 +1,17 @@
 ---
+images:
+  pull_policy: IfNotPresent
+  tags:
+    bootstrap: "ghcr.io/rackerlabs/genestack-images/heat:2025.1-latest"
+    db_init: "ghcr.io/rackerlabs/genestack-images/heat:2025.1-latest"
+    db_drop: "ghcr.io/rackerlabs/genestack-images/heat:2025.1-latest"
+    ks_user: "ghcr.io/rackerlabs/genestack-images/heat:2025.1-latest"
+    ks_service: "ghcr.io/rackerlabs/genestack-images/heat:2025.1-latest"
+    ks_endpoints: "ghcr.io/rackerlabs/genestack-images/heat:2025.1-latest"
+    freezer_db_sync: "ghcr.io/rackerlabs/genestack-images/freezer:2025.2-latest"
+    freezer_api: "ghcr.io/rackerlabs/genestack-images/freezer:2025.2-latest"
+    dep_check: "ghcr.io/rackerlabs/genestack-images/kubernetes-entrypoint:latest"
+
 endpoints:
   backup:
     hosts:


### PR DESCRIPTION
replaced `quay.io` images with `ghcr/rackerlabs` images.
Originial Images: [https://opendev.org/openstack/openstack-helm/src/branch/master/freezer/values.yaml#L28-L36](https://opendev.org/openstack/openstack-helm/src/branch/master/freezer/values.yaml#L28-L36)