### PR TITLE
chore: fix deprecated annotation

### DIFF
--- a/base-helm-configs/nginx-gateway-fabric/helm-overrides.yaml
+++ b/base-helm-configs/nginx-gateway-fabric/helm-overrides.yaml
@@ -88,8 +88,8 @@ service:
   externalTrafficPolicy: Cluster
   ## The annotations of the NGINX Gateway Fabric service.
   annotations:
-    "metallb.universe.tf/address-pool": "gateway-api-external"
-    "metallb.universe.tf/allow-shared-ip": "openstack-external-svc"
+    "metallb.io/address-pool": "gateway-api-external"
+    "metallb.io/allow-shared-ip": "openstack-external-svc"
 
   ## A list of ports to expose through the NGINX Gateway Fabric service. Update it to match the listener ports from
   ## your Gateway resource. Follows the conventional Kubernetes yaml syntax for service ports.

--- a/base-kustomize/envoyproxy-gateway/base/envoy-gateway.yaml
+++ b/base-kustomize/envoyproxy-gateway/base/envoy-gateway.yaml
@@ -11,7 +11,7 @@ spec:
   gatewayClassName: eg
   infrastructure:
     annotations:
-      metallb.universe.tf/address-pool: gateway-api-external
+      metallb.io/address-pool: gateway-api-external
   listeners:
     - name: cluster-http
       port: 80

--- a/base-kustomize/grafana/base/grafana-database.yaml
+++ b/base-kustomize/grafana/base/grafana-database.yaml
@@ -65,7 +65,7 @@ spec:
     type: LoadBalancer
     metadata:
       annotations:
-        metallb.universe.tf/address-pool: primary
+        metallb.io/address-pool: primary
   connection:
     secretName: mariadb-cluster-conn
     secretTemplate:
@@ -75,7 +75,7 @@ spec:
     type: LoadBalancer
     metadata:
       annotations:
-        metallb.universe.tf/address-pool: primary
+        metallb.io/address-pool: primary
   primaryConnection:
     secretName: mariadb-cluster-conn-primary
     secretTemplate:
@@ -85,7 +85,7 @@ spec:
     type: LoadBalancer
     metadata:
       annotations:
-        metallb.universe.tf/address-pool: primary
+        metallb.io/address-pool: primary
   secondaryConnection:
     secretName: mariadb-cluster-conn-secondary
     secretTemplate:

--- a/base-kustomize/mariadb-cluster/base/mariadb-replication.yaml
+++ b/base-kustomize/mariadb-cluster/base/mariadb-replication.yaml
@@ -54,7 +54,7 @@ spec:
     type: LoadBalancer
     metadata:
       annotations:
-        metallb.universe.tf/address-pool: primary
+        metallb.io/address-pool: primary
   connection:
     secretName: mariadb-cluster-conn
     secretTemplate:
@@ -64,7 +64,7 @@ spec:
     type: LoadBalancer
     metadata:
       annotations:
-        metallb.universe.tf/address-pool: primary
+        metallb.io/address-pool: primary
   primaryConnection:
     secretName: mariadb-cluster-conn-primary
     secretTemplate:
@@ -74,7 +74,7 @@ spec:
     type: LoadBalancer
     metadata:
       annotations:
-        metallb.universe.tf/address-pool: primary
+        metallb.io/address-pool: primary
   secondaryConnection:
     secretName: mariadb-cluster-conn-secondary
     secretTemplate:

--- a/base-kustomize/rabbitmq-cluster/base/rabbitmq-cluster.yaml
+++ b/base-kustomize/rabbitmq-cluster/base/rabbitmq-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   name: rabbitmq
   namespace: openstack
   annotations:
-    metallb.universe.tf/address-pool: primary
+    metallb.io/address-pool: primary
 spec:
   replicas: 3
   resources:


### PR DESCRIPTION
Resolves error.

```log
{"annotation":"metallb.universe.tf/ip-allocated-from-pool","caller":"main.go:106","event":"deprecatedAnnotation","level":"warn","msg":"The used annotation is deprecated. Support might get removed in future versions","ts":"2025-10-26T03:21:42Z"}
```