### PR TITLE
Update Ironic Helm Overrides and Conductor HPA Resource Configuration

### DIFF
--- a/base-helm-configs/ironic/ironic-helm-overrides.yaml
+++ b/base-helm-configs/ironic/ironic-helm-overrides.yaml
@@ -20,7 +20,7 @@ images:
     ironic_api: "ghcr.io/rackerlabs/genestack-images/ironic-api:2024.1-latest"
     ironic_conductor: "ghcr.io/rackerlabs/genestack-images/ironic-conductor:2024.1-latest"
     ironic_pxe: "ghcr.io/rackerlabs/genestack-images/ironic-pxe:2024.1-latest"
-    ironic_pxe_init: "ghcr.io/rackerlabs/genestack-images/ironic-api:2024.1-latest"
+    ironic_pxe_init: "ghcr.io/rackerlabs/genestack-images/ironic-pxe:2024.1-latest"
     ironic_pxe_http: "docker.io/nginx:1.13.3" # Retained from openstack-helm default
     ironic_inspector: "ghcr.io/rackerlabs/genestack-images/ironic-inspector:2024.1-latest"
     ironic_inspector_db_sync: "ghcr.io/rackerlabs/genestack-images/ironic-inspector:2024.1-latest"
@@ -87,6 +87,8 @@ conf:
       pxe_bootfile_name: "undionly.kpxe"
       uefi_pxe_bootfile_name: "ipxe.efi"
       ipxe_enabled: true
+    service_catalog:
+      valid_interfaces: public
   ironic_inspector:
     DEFAULT:
       processing_hooks: "$processing.default_hooks,ramdisk_error"
@@ -103,10 +105,10 @@ network:
   backend:
     - ovn
   pxe:
-    device: ironic-pxe
-    neutron_network_name: baremetal
-    neutron_subnet_name: baremetal
-    neutron_provider_network: ironic
+    device: br-host
+    neutron_network_name: baremetal-provisioning-network
+    neutron_subnet_name: baremetal-provisioning-network
+    neutron_provider_network: physnet2
     neutron_subnet_gateway: 172.24.6.1/24
     neutron_subnet_cidr: 172.24.6.0/24
     neutron_subnet_alloc_start: 172.24.6.100

--- a/base-kustomize/ironic/base/hpa-ironic-conductor.yaml
+++ b/base-kustomize/ironic/base/hpa-ironic-conductor.yaml
@@ -22,5 +22,5 @@ spec:
       type: Resource
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: StatefulSet
     name: ironic-conductor


### PR DESCRIPTION
This update corrects the Ironic PXE image reference and aligns the provisioning network and service catalog configurations in the Helm overrides. Additionally, it updates the Kustomize HPA target to match the current Ironic deployment model.

**Changes Included:**
- Fixed `ironic_pxe_init` image to use the correct `ironic-pxe` image. 
Previously, the incorrect image prevented the PXE binaries from being copied into the `ironic-conductor-pxe-init` container.
- Added `service_catalog.valid_interfaces: public` to ensure the Ironic Python Agent (IPA) can connect to the external API when a baremetal node boots with `initramfs`.  
  The internal or default API endpoints are not resolvable in this phase, so the external API must be used.
- Updated PXE provisioning network configuration to use:
  - `device: br-host`
  - `neutron_network_name: baremetal-provisioning-network`
  - `neutron_subnet_name: baremetal-provisioning-network`
  - `neutron_provider_network: physnet2`
- Corrected the Ironic Conductor HPA `scaleTargetRef` from `Deployment` to `StatefulSet`.

These changes ensure correct PXE booting behavior, consistent network alignment, and functional HPA scaling.
