### PR TITLE
chore: set the VPNaaS target openstack-network-node

### DIFF
--- a/base-helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/base-helm-configs/neutron/neutron-helm-overrides.yaml
@@ -32,6 +32,9 @@ images:
     image_repo_sync: null
 
 labels:
+  agent:
+    ovn_vpn:
+      node_selector_key: openstack-network-node
   ovs:
     node_selector_key: openstack-network-node
 
@@ -183,7 +186,7 @@ conf:
       # NOTE(cloudnull): in 2025.1 we can enable this
       enabled: False
     agent:
-      extensions: vpnaas
+      extensions: vpnaas,metadata
       availability_zone: az1
     database:
       connection_debug: 0


### PR DESCRIPTION
The VPNaaS pods need to be deployed on network nodes, this change ensures that.