### PR TITLE
fix: RPCOS-271: Using masakari image for masakari db_sync pod

### DIFF
--- a/base-helm-configs/masakari/masakari-helm-overrides.yaml
+++ b/base-helm-configs/masakari/masakari-helm-overrides.yaml
@@ -14,7 +14,7 @@
 images:
   tags:
     db_init: ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest
-    db_sync: ghcr.io/rackerlabs/genestack-images/masakari-monitors:2024.1-latest
+    db_sync: ghcr.io/rackerlabs/genestack-images/masakari:2024.1-latest
     db_drop: ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest
     ks_endpoints: ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest
     ks_service: ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest


### PR DESCRIPTION
Using masakari:2024.1-latest image instead of masakari-monitors:2024.1-latest  for masakari db_sync pod.