### PR TITLE
Update Freezer image tags to 2025.1-latest

### DIFF
--- a/base-helm-configs/freezer/freezer-helm-overrides.yaml
+++ b/base-helm-configs/freezer/freezer-helm-overrides.yaml
@@ -8,8 +8,8 @@ images:
     ks_user: "ghcr.io/rackerlabs/genestack-images/heat:2025.1-latest"
     ks_service: "ghcr.io/rackerlabs/genestack-images/heat:2025.1-latest"
     ks_endpoints: "ghcr.io/rackerlabs/genestack-images/heat:2025.1-latest"
-    freezer_db_sync: "ghcr.io/rackerlabs/genestack-images/freezer:2025.2-latest"
-    freezer_api: "ghcr.io/rackerlabs/genestack-images/freezer:2025.2-latest"
+    freezer_db_sync: "ghcr.io/rackerlabs/genestack-images/freezer:2025.1-latest"
+    freezer_api: "ghcr.io/rackerlabs/genestack-images/freezer:2025.1-latest"
     dep_check: "ghcr.io/rackerlabs/genestack-images/kubernetes-entrypoint:latest"
 
 endpoints:


### PR DESCRIPTION
matching the tags nomenclature to the ghcr repo. 
Earlier was using the nomenclature from airshipit repo which was breaking things.