### PR TITLE
OSPC-1482: Added the ttlSecondsAfterFinished as a patch for the completed jobs

### DIFF
--- a/bin/cleanup-openstack-completed-jobs.sh
+++ b/bin/cleanup-openstack-completed-jobs.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+NAMESPACE="openstack"
+TTL=180
+
+echo "Applying TTL=$TTL seconds to completed jobs in $NAMESPACE..."
+
+# Check if any jobs exist
+if ! kubectl get jobs -n "$NAMESPACE" &>/dev/null; then
+  echo "No jobs found in '$NAMESPACE'. Exiting."
+  exit 0
+fi
+
+# Process each job
+kubectl get jobs -n "$NAMESPACE" --no-headers | awk '{print $1}' | while read -r job; do
+  [[ -z "$job" ]] && continue
+
+  # Check if job is COMPLETED or NOT
+  status=$(kubectl get job "$job" -n "$NAMESPACE" \
+    -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' \
+    2>/dev/null || echo "Unknown")
+
+  if [ "$status" == "True" ]; then
+    if kubectl patch job "$job" -n "$NAMESPACE" --type=json \
+      -p="[{\"op\": \"add\", \"path\": \"/spec/ttlSecondsAfterFinished\", \"value\": $TTL}]" \
+      >/dev/null 2>&1; then
+      echo "Patched: $job → delete in $TTL sec"
+    else
+      echo "Failed: $job (patch error)"
+    fi
+  else
+    echo "Skipped: $job (not completed)"
+  fi
+done


### PR DESCRIPTION
Created the patching method to patch the attribute 'ttlSecondsAfterFinished' under the path Job spec to clean up the completed Jobs and resource list automatically on openstack namespace.

And attached output of the script here,
[Cleanup_completed_jobs_openstack_script_OP.zip](https://github.com/user-attachments/files/23208534/Cleanup_completed_jobs_openstack_script_OP.zip)

And the re installation of all these jobs I have tried, and all got successfully installed again,
1)barbican 2)Ceilometer 3)Cinder 4)glance 5)heat 6)keystone 7)magnum 8)neutron 9)nova
10)Octavia 11)placement
