### PR TITLE
fix install-fluentbit.sh script to install fluentbit from openstack-helm repo

### DIFF
--- a/base-kustomize/fluentbit/base/kustomization.yaml
+++ b/base-kustomize/fluentbit/base/kustomization.yaml
@@ -1,0 +1,4 @@
+sortOptions:
+  order: fifo
+resources:
+  - all.yaml

--- a/bin/install-fluentbit.sh
+++ b/bin/install-fluentbit.sh
@@ -1,43 +1,96 @@
 #!/bin/bash
+# Description: Fetches the version for SERVICE_NAME from the specified
+# YAML file and executes a helm upgrade/install command with dynamic values files.
+
+# Disable SC2124 (unused array), SC2145 (array expansion issue), SC2294 (eval)
 # shellcheck disable=SC2124,SC2145,SC2294
-GLOBAL_OVERRIDES_DIR="/etc/genestack/helm-configs/global_overrides"
-SERVICE_CONFIG_DIR="/etc/genestack/helm-configs/fluentbit"
 
-# Read fluentbit version from helm-chart-versions.yaml
+# Service
+SERVICE_NAME="fluentbit"
+SERVICE_NAMESPACE="fluentbit"
+
+# Helm
+HELM_REPO_NAME="openstack-helm"
+HELM_REPO_URL="https://tarballs.opendev.org/openstack/openstack-helm"
+
+# Base directories provided by the environment
+GENESTACK_BASE_DIR="${GENESTACK_BASE_DIR:-/opt/genestack}"
+GENESTACK_OVERRIDES_DIR="${GENESTACK_OVERRIDES_DIR:-/etc/genestack}"
+
+# Define service-specific override directories based on the framework
+SERVICE_BASE_OVERRIDES="${SERVICE_BASE_OVERRIDES:-$GENESTACK_BASE_DIR/base-helm-configs/$SERVICE_NAME}"
+SERVICE_CUSTOM_OVERRIDES="${SERVICE_CUSTOM_OVERRIDES:-$GENESTACK_OVERRIDES_DIR/helm-configs/$SERVICE_NAME}"
+
+# Read the desired chart version from VERSION_FILE
 VERSION_FILE="/etc/genestack/helm-chart-versions.yaml"
+
 if [ ! -f "$VERSION_FILE" ]; then
-    echo "Error: helm-chart-versions.yaml not found at $VERSION_FILE"
+    echo "Error: helm-chart-versions.yaml not found at $VERSION_FILE" >&2
     exit 1
 fi
 
-# Extract fluentbit version using grep and sed
-FLUENTBIT_VERSION=$(grep 'fluentbit:' "$VERSION_FILE" | sed 's/.*fluentbit: *//')
+# Extract version dynamically using the SERVICE_NAME variable
+SERVICE_VERSION=$(grep "${SERVICE_NAME}:" "$VERSION_FILE" | sed "s/.*${SERVICE_NAME}: *//")
 
-if [ -z "$FLUENTBIT_VERSION" ]; then
-    echo "Error: Could not extract fluentbit version from $VERSION_FILE"
+if [ -z "$SERVICE_VERSION" ]; then
+    echo "Error: Could not extract version for '$SERVICE_NAME' from $VERSION_FILE" >&2
     exit 1
 fi
 
-HELM_CMD="helm upgrade --install \
-                       --version $FLUENTBIT_VERSION \
-                       --namespace fluentbit \
-                       --create-namespace fluentbit openstack-helm/fluentbit"
+echo "Found version for $SERVICE_NAME: $SERVICE_VERSION"
 
-HELM_CMD+=" -f /opt/genestack/base-helm-configs/fluentbit/fluentbit-helm-overrides.yaml"
+# Prepare an array to collect --values arguments
+values_args=()
 
-for dir in "$GLOBAL_OVERRIDES_DIR" "$SERVICE_CONFIG_DIR"; do
-    if compgen -G "${dir}/*.yaml" > /dev/null; then
-        for yaml_file in "${dir}"/*.yaml; do
-            HELM_CMD+=" -f ${yaml_file}"
-        done
+#  Include all YAML files from the BASE configuration directory
+if [[ -d "$SERVICE_BASE_OVERRIDES" ]]; then
+  echo "Including base overrides from directory: $SERVICE_BASE_OVERRIDES"
+  for file in "$SERVICE_BASE_OVERRIDES"/*.yaml; do
+    # Check that there is at least one match
+    if [[ -e "$file" ]]; then
+      echo " - $file"
+      values_args+=("--values" "$file")
     fi
-done
+  done
+else
+  echo "Warning: Base override directory not found: $SERVICE_BASE_OVERRIDES"
+fi
 
-HELM_CMD+=" $@"
+# Include all YAML files from the custom SERVICE configuration directory
+if [[ -d "$SERVICE_CUSTOM_OVERRIDES" ]]; then
+  echo "Including overrides from config directory:"
+  for file in "$SERVICE_CUSTOM_OVERRIDES"/*.yaml; do
+    if [[ -e "$file" ]]; then
+      echo " - $file"
+      values_args+=("--values" "$file")
+    fi
+  done
+else
+  echo "Warning: Config directory not found: $SERVICE_CUSTOM_OVERRIDES"
+fi
 
-helm repo add openstack-helm https://tarballs.opendev.org/openstack/openstack-helm
+echo
+
+# --- Helm Repository and Execution ---
+helm repo add "$HELM_REPO_NAME" "$HELM_REPO_URL"
 helm repo update
 
-echo "Executing Helm command:"
-echo "${HELM_CMD}"
-eval "${HELM_CMD}"
+helm_command=(
+    helm upgrade --install "$SERVICE_NAME" "$HELM_REPO_NAME"/"$SERVICE_NAME"
+    --create-namespace --namespace="$SERVICE_NAMESPACE" --timeout 10m
+    --version "${SERVICE_VERSION}"
+
+    "${values_args[@]}"
+
+    # Post-renderer configuration
+    --post-renderer "$GENESTACK_OVERRIDES_DIR/kustomize/kustomize.sh"
+    --post-renderer-args "$SERVICE_NAME/overlay"
+    "$@"
+)
+
+echo "Executing Helm command (arguments are quoted safely):"
+printf '%q ' "${helm_command[@]}"
+echo
+
+# Execute the command directly from the array
+"${helm_command[@]}"


### PR DESCRIPTION
the helm repo add command for the fluentbit script now points to the openstack-helm repo; modifying the install script slightly to use to openstack-helm repo to install the fluentbit helm chart