### PR TITLE
Fix: Manila use genestack-images for manila by default

### DIFF
--- a/base-helm-configs/manila/manila-helm-overrides.yaml
+++ b/base-helm-configs/manila/manila-helm-overrides.yaml
@@ -21,10 +21,10 @@ images:
     ks_service: ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest
     ks_user: ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest
     manila_api: ghcr.io/rackerlabs/genestack-images/manila:2024.1-1758649489
-    manila_data: docker.io/openstackhelm/manila:2024.1-ubuntu_jammy
+    manila_data: ghcr.io/rackerlabs/genestack-images/manila:2024.1-1758649489
     manila_db_sync: ghcr.io/rackerlabs/genestack-images/manila:2024.1-1758649489
-    manila_scheduler: docker.io/openstackhelm/manila:2024.1-ubuntu_jammy
-    manila_share: docker.io/openstackhelm/manila:2024.1-ubuntu_jammy
+    manila_scheduler: ghcr.io/rackerlabs/genestack-images/manila:2024.1-1758649489
+    manila_share: ghcr.io/rackerlabs/genestack-images/manila:2024.1-1758649489
     manila_processor: ghcr.io/rackerlabs/genestack-images/manila:2024.1-1758649489
     manila_storage_init: ghcr.io/rackerlabs/genestack-images/manila:2024.1-1758649489
     rabbit_init: docker.io/rabbitmq:3.13-management


### PR DESCRIPTION
ghcr.io/rackerlabs/genestack-images/manila:2024.1-1758649489