### PR TITLE
chore: remove extraneous lines from prometheus blackbox exporter over…

### DIFF
--- a/base-helm-configs/prometheus-blackbox-exporter/prometheus-blackbox-exporter-helm-overrides.yaml
+++ b/base-helm-configs/prometheus-blackbox-exporter/prometheus-blackbox-exporter-helm-overrides.yaml
@@ -14,6 +14,3 @@ config:
           - 202
           - 204
           - 300
-
-selfMonitor:
-  enabled: true


### PR DESCRIPTION
…rides

the removed lines don't do anything, no value .selfMonitor exists as a top level override for this to have any effect.

Additionally, I verified that it doesn't just belong under some other key by looking at the previous overrides:
https://github.com/rackerlabs/genestack/blob/c2714f05275cdff06788d199fa64e650fd3faaae/base-helm-configs/prometheus-blackbox-exporter/values.yaml ^F/find selfMonitor, we didn't have any '.something.selfMonitor = enabled'

These just look like mysterious extraneous lines I got in there somehow since I previously verified that the pruned overrides produced an identical chart rendering in https://github.com/rackerlabs/genestack/pull/1280

JIRA:OSPC-1615