### PR TITLE
fix: Allows all members of the project to download images

### DIFF
--- a/base-helm-configs/glance/glance-helm-overrides.yaml
+++ b/base-helm-configs/glance/glance-helm-overrides.yaml
@@ -125,6 +125,8 @@ conf:
     "service_api": "role:service"
     "publicize_image": "role:glance_admin"
     "communitize_image": "role:glance_admin"
+    "download_image": "role:admin or role:member"
+    "get_image": "role:admin or role:member or role:reader"
   logging:
     logger_root:
       level: INFO


### PR DESCRIPTION
While doing a freezer VM restore operation when a glance image was attempted to be downloaded by nova, was getting below error:

```
ERROR nova.compute.manager [instance: <uuid>] nova.exception.ImageNotAuthorized: Not authorized for image <image-uuid>
```

This change allows nova to download image which is marked as `private` (default by freezer).
When this policy is missing - the freezer restore operation fails.