### PR TITLE
fix: Redis service uri in zaqar conf

### DIFF
--- a/base-helm-configs/zaqar/zaqar-helm-overrides.yaml
+++ b/base-helm-configs/zaqar/zaqar-helm-overrides.yaml
@@ -129,7 +129,7 @@ conf:
     cache:
       backend: dogpile.cache.memory
     drivers:message_store:redis:
-      uri: redis://redis-replication-headless.redis-systems.svc.cluster.local:6379
+      uri: redis://redis-replication-master.redis-systems.svc.cluster.local:6379
     drivers:transport:wsgi:
       bind: 0.0.0.0
       port: 8888


### PR DESCRIPTION
It fix the intermittent write failures by pointing to master uri 
of redis service in zaqar conf.