### PR TITLE
Updating nova-compute Ironic HPA, Octavia amphora image config..

### DIFF
--- a/ansible/roles/octavia_preconf/defaults/main.yml
+++ b/ansible/roles/octavia_preconf/defaults/main.yml
@@ -34,6 +34,7 @@ amphora_ssh_key_name: amphora-ssh-key
 amphora_flavor_name: m1.amphora
 amphora_image_version: focal
 amphora_image_name: amphora-ubuntu-{{ amphora_image_version }}
+amphora_image_url: "https://tarballs.opendev.org/openstack/octavia/test-images/test-only-amphora-x64-haproxy-ubuntu-{{ amphora_image_version }}.qcow2"
 
 # these are the defaults for certs
 octavia_create_certs: true

--- a/ansible/roles/octavia_preconf/tasks/octavia_amphora_keypair_image_flavor.yml
+++ b/ansible/roles/octavia_preconf/tasks/octavia_amphora_keypair_image_flavor.yml
@@ -35,7 +35,7 @@
 
 - name: Get the image for amphora
   get_url:
-    url: https://tarballs.opendev.org/openstack/octavia/test-images/test-only-amphora-x64-haproxy-ubuntu-{{ amphora_image_version }}.qcow2
+    url: "{{ amphora_image_url }}"
     dest: /tmp/test-only-amphora-x64-haproxy-ubuntu-{{ amphora_image_version }}.qcow2
   register: download_amphora_image
   until: download_amphora_image is success

--- a/base-helm-configs/octavia/octavia-helm-overrides.yaml
+++ b/base-helm-configs/octavia/octavia-helm-overrides.yaml
@@ -14,6 +14,7 @@ images:
     octavia_health_manager: "ghcr.io/rackerlabs/genestack-images/octavia:2024.1-latest"
     octavia_health_manager_init: "ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest"
     octavia_housekeeping: "ghcr.io/rackerlabs/genestack-images/octavia:2024.1-latest"
+    octavia_worker_init: "ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest"
     octavia_worker: "ghcr.io/rackerlabs/genestack-images/octavia:2024.1-latest"
     openvswitch_vswitchd: "ghcr.io/rackerlabs/genestack-images/ovs:v3.5.1-latest"
     rabbit_init: null

--- a/base-kustomize/nova/base/hpa-nova-compute-ironic.yaml
+++ b/base-kustomize/nova/base/hpa-nova-compute-ironic.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: nova-compute-ironic
+  namespace: openstack
+spec:
+  maxReplicas: 9
+  minReplicas: 2
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 80
+          type: Utilization
+      type: Resource
+    - resource:
+        name: memory
+        target:
+          averageUtilization: 80
+          type: Utilization
+      type: Resource
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: nova-compute-ironic


### PR DESCRIPTION
#### Fix scaling policy in nova-compute-ironic HPA:
- CPU/Memory Utilization target set to 80%
- Replicas configured min=2, max=9

#### Octavia improvements:
- Add amphora_image_url variable in role defaults for custom image location
- Update role tasks to use amphora_image_url instead of hardcoded URL
- Add missing octavia_worker_init image in base helm overrides