### PR TITLE
Tech Preview: Add Manila to Genestack (#1284)

### DIFF
--- a/.original-images.json
+++ b/.original-images.json
@@ -16,6 +16,7 @@
   "docker.io/openstackhelm/magnum:2024.1-ubuntu_jammy",
   "docker.io/openstackhelm/masakari-monitors:2024.1-ubuntu_jammy",
   "docker.io/openstackhelm/masakari:2024.1-ubuntu_jammy",
+  "docker.io/openstackhelm/manila:2024.1-ubuntu_jammy",
   "docker.io/openstackhelm/neutron:2024.1-ubuntu_jammy",
   "docker.io/openstackhelm/osh-selenium:latest-ubuntu_jammy",
   "docker.io/openstackhelm/ospurge:latest",

--- a/base-helm-configs/manila/manila-helm-overrides.yaml
+++ b/base-helm-configs/manila/manila-helm-overrides.yaml
@@ -1,0 +1,314 @@
+---
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+images:
+  tags:
+    db_init: ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest
+    db_drop: ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest
+    dep_check: ghcr.io/rackerlabs/genestack-images/kubernetes-entrypoint:latest
+    image_repo_sync: docker.io/docker:17.07.0
+    ks_endpoints: ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest
+    ks_service: ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest
+    ks_user: ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest
+    manila_api: ghcr.io/rackerlabs/genestack-images/manila:2024.1-1758649489
+    manila_data: ghcr.io/rackerlabs/genestack-images/manila:2024.1-1758649489
+    manila_db_sync: ghcr.io/rackerlabs/genestack-images/manila:2024.1-1758649489
+    manila_scheduler: ghcr.io/rackerlabs/genestack-images/manila:2024.1-1758649489
+    manila_share: ghcr.io/rackerlabs/genestack-images/manila:2024.1-1758649489
+    manila_processor: ghcr.io/rackerlabs/genestack-images/manila:2024.1-1758649489
+    manila_storage_init: ghcr.io/rackerlabs/genestack-images/manila:2024.1-1758649489
+    rabbit_init: docker.io/rabbitmq:3.13-management
+  pull_policy: "IfNotPresent"
+
+# NOTE: (brew) requests cpu/mem values based on a three node
+# hyperconverged lab (/scripts/hyperconverged-lab.sh).
+# limit values based on defaults from the openstack-helm charts unless defined
+pod:
+  replicas:
+    api: 1
+    data: 1
+    scheduler: 1
+    share: 1
+  lifecycle:
+    upgrades:
+      deployments:
+        rolling_update:
+          max_unavailable: 20%
+  resources:
+    enabled: true
+    api:
+      requests:
+        memory: "128Mi"
+        cpu: "100m"
+      limits:
+        memory: "1024Mi"
+        cpu: "2000m"
+    data:
+      requests:
+        memory: "128Mi"
+        cpu: "100m"
+      limits:
+        memory: "1024Mi"
+        cpu: "2000m"
+    scheduler:
+      requests:
+        memory: "128Mi"
+        cpu: "100m"
+      limits:
+        memory: "1024Mi"
+        cpu: "2000m"
+    share:
+      requests:
+        memory: "128Mi"
+        cpu: "100m"
+      limits:
+        memory: "1024Mi"
+        cpu: "2000m"
+    jobs:
+      ks_endpoints:
+        requests:
+          memory: "128Mi"
+          cpu: "100m"
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+      ks_service:
+        requests:
+          memory: "128Mi"
+          cpu: "100m"
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+      ks_user:
+        requests:
+          memory: "128Mi"
+          cpu: "100m"
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+      tests:
+        requests:
+          memory: "128Mi"
+          cpu: "100m"
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+      image_repo_sync:
+        requests:
+          memory: "128Mi"
+          cpu: "100m"
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+
+endpoints:
+  fluentd:
+    namespace: fluentbit
+  oslo_db:
+    hosts:
+      default: mariadb-cluster-primary
+    host_fqdn_override:
+      default: mariadb-cluster-primary.openstack.svc.cluster.local
+  oslo_cache:
+    hosts:
+      default: memcached
+    host_fqdn_override:
+      default: memcached.openstack.svc.cluster.local
+  oslo_messaging:
+    hosts:
+      default: rabbitmq-nodes
+    host_fqdn_override:
+      default: rabbitmq.openstack.svc.cluster.local
+  share:
+    name: manila
+    hosts:
+      default: manila-api
+      public: manila
+    host_fqdn_override:
+      default: null
+    path:
+      default: '/v1'
+    scheme:
+      default: http
+      service: http
+    port:
+      api:
+        default: 8786
+        public: 80
+        service: 8786
+  sharev2:
+    name: manilav2
+    hosts:
+      default: manila-api
+      public: manila
+    host_fqdn_override:
+      default: null
+    path:
+      default: '/v2'
+    scheme:
+      default: http
+      service: http
+    port:
+      api:
+        default: 8786
+        public: 80
+        service: 8786
+
+dependencies:
+  static:
+    api:
+      jobs:
+        - manila-db-sync
+        - manila-ks-user
+        - manila-ks-endpoints
+    data:
+      jobs:
+        - manila-db-sync
+        - manila-ks-user
+        - manila-ks-endpoints
+    scheduler:
+      jobs:
+        - manila-db-sync
+        - manila-ks-user
+        - manila-ks-endpoints
+    share:
+      jobs:
+        - manila-db-sync
+        - manila-ks-user
+        - manila-ks-endpoints
+    db_sync:
+      jobs: []
+
+conf:
+  manila:
+    DEFAULT:
+      default_share_type: default
+      default_share_group_type: default
+      share_name_template: share-%s
+      rootwrap_config: /etc/manila/rootwrap.conf
+      api_paste_config: /etc/manila/api-paste.ini
+      enabled_share_backends: generic
+      enabled_share_protocols: NFS
+    keystone_authtoken:
+      auth_type: password
+      auth_version: v3
+      memcache_security_strategy: ENCRYPT
+      endpoint_type: internalURL
+      service_type: sharev2
+    neutron:
+      auth_type: password
+      auth_version: v3
+      memcache_security_strategy: ENCRYPT
+      endpoint_type: internalURL
+    nova:
+      auth_type: password
+      auth_version: v3
+      memcache_security_strategy: ENCRYPT
+      endpoint_type: internalURL
+    cinder:
+      auth_type: password
+      auth_version: v3
+      memcache_security_strategy: ENCRYPT
+      endpoint_type: internalURL
+    glance:
+      auth_type: password
+      auth_version: v3
+      memcache_security_strategy: ENCRYPT
+      endpoint_type: internalURL
+    database:
+      max_retries: -1
+    generic:
+      share_backend_name: GENERIC
+      share_driver: manila.share.drivers.generic.GenericShareDriver
+      driver_handles_share_servers: true
+      # manila-service-flavor
+      service_instance_flavor_id: 100
+      service_image_name: manila-service-image
+      service_instance_user: manila
+      service_instance_password: manila
+      # # Module path to the Virtual Interface (VIF) driver class. This option
+      # # is used only by drivers operating in
+      # # `driver_handles_share_servers=True` mode that provision OpenStack
+      # # compute instances as share servers. This option is only supported
+      # # with Neutron networking. Drivers provided in tree work with Linux
+      # # Bridge (manila.network.linux.interface.BridgeInterfaceDriver) and
+      # # OVS (manila.network.linux.interface.OVSInterfaceDriver). If the
+      # # manila-share service is running on a host that is connected to the
+      # # administrator network, a no-op driver
+      # # (manila.network.linux.interface.NoopInterfaceDriver) may be used.
+      # # (string value)
+      # interface_driver: manila.network.linux.interface.OVSInterfaceDriver
+    oslo_policy:
+      policy_file: /etc/manila/policy.yaml
+    oslo_concurrency:
+      lock_path: /var/lib/manila/tmp
+    oslo_messaging_notifications:
+      driver: messagingv2
+    oslo_middleware:
+      enable_proxy_headers_parsing: true
+    oslo_messaging_rabbit:
+      rabbit_ha_queues: true
+  manila_api_uwsgi:
+    uwsgi:
+      add-header: "Connection: close"
+      buffer-size: 65535
+      die-on-term: true
+      enable-threads: true
+      exit-on-reload: false
+      hook-master-start: unix_signal:15 gracefully_kill_them_all
+      lazy-apps: true
+      log-x-forwarded-for: true
+      master: true
+      procname-prefix-spaced: "manila-api:"
+      route-user-agent: '^kube-probe.* donotlog:'
+      thunder-lock: true
+      worker-reload-mercy: 80
+      wsgi-file: /var/lib/openstack/bin/manila-wsgi
+  logging:
+    logger_root:
+      level: WARNING
+      handlers: 'null'
+    logger_manila:
+      level: INFO
+      handlers:
+        - stdout
+      qualname: manila
+
+manifests:
+  certificates: false
+  configmap_bin: true
+  configmap_etc: true
+  deployment_api: true
+  deployment_scheduler: true
+  deployment_data: true
+  deployment_share: false
+  ingress_api: false
+  job_bootstrap: false
+  job_db_init: false
+  job_db_sync: true
+  job_db_drop: false
+  job_image_repo_sync: true
+  job_rabbit_init: false
+  job_ks_endpoints: true
+  job_ks_service: true
+  job_ks_user: true
+  pdb_api: true
+  pod_test: false
+  secret_db: true
+  network_policy: false
+  secret_ingress_tls: false
+  secret_keystone: true
+  secret_rabbitmq: true
+  secret_registry: true
+  service_ingress_api: false
+  service_api: true
+...

--- a/base-kustomize/manila/aio/kustomization.yaml
+++ b/base-kustomize/manila/aio/kustomization.yaml
@@ -1,0 +1,47 @@
+---
+sortOptions:
+  order: fifo
+resources:
+  - ../base
+
+patches:
+  - target:
+      kind: HorizontalPodAutoscaler
+      name: manila-api
+    patch: |-
+      - op: replace
+        path: /spec/minReplicas
+        value: 1
+      - op: replace
+        path: /spec/maxReplicas
+        value: 1
+  - target:
+      kind: HorizontalPodAutoscaler
+      name: manila-scheduler
+    patch: |-
+      - op: replace
+        path: /spec/minReplicas
+        value: 1
+      - op: replace
+        path: /spec/maxReplicas
+        value: 1
+  - target:
+      kind: HorizontalPodAutoscaler
+      name: manila-data
+    patch: |-
+      - op: replace
+        path: /spec/minReplicas
+        value: 1
+      - op: replace
+        path: /spec/maxReplicas
+        value: 1
+  - target:
+      kind: HorizontalPodAutoscaler
+      name: manila-share
+    patch: |-
+      - op: replace
+        path: /spec/minReplicas
+        value: 1
+      - op: replace
+        path: /spec/maxReplicas
+        value: 1

--- a/base-kustomize/manila/base/hpa-manila-api.yaml
+++ b/base-kustomize/manila/base/hpa-manila-api.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: manila-api
+  namespace: openstack
+spec:
+  maxReplicas: 9
+  minReplicas: 2
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 80
+          type: Utilization
+      type: Resource
+    - resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+      type: Resource
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: manila-api

--- a/base-kustomize/manila/base/hpa-manila-data.yaml
+++ b/base-kustomize/manila/base/hpa-manila-data.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: manila-data
+  namespace: openstack
+spec:
+  maxReplicas: 9
+  minReplicas: 2
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 80
+          type: Utilization
+      type: Resource
+    - resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+      type: Resource
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: manila-data

--- a/base-kustomize/manila/base/hpa-manila-scheduler.yaml
+++ b/base-kustomize/manila/base/hpa-manila-scheduler.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: manila-scheduler
+  namespace: openstack
+spec:
+  maxReplicas: 9
+  minReplicas: 2
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 80
+          type: Utilization
+      type: Resource
+    - resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+      type: Resource
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: manila-scheduler

--- a/base-kustomize/manila/base/hpa-manila-share.yaml
+++ b/base-kustomize/manila/base/hpa-manila-share.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: manila-share
+  namespace: openstack
+spec:
+  maxReplicas: 9
+  minReplicas: 2
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 80
+          type: Utilization
+      type: Resource
+    - resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+      type: Resource
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: manila-share

--- a/base-kustomize/manila/base/kustomization.yaml
+++ b/base-kustomize/manila/base/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+sortOptions:
+  order: fifo
+resources:
+  - manila-mariadb-database.yaml
+  - manila-rabbitmq-queue.yaml
+  - all.yaml
+  - hpa-manila-api.yaml
+  - hpa-manila-data.yaml
+  - hpa-manila-scheduler.yaml
+  - hpa-manila-share.yaml
+  - manila-rabbitmq-queue-policy.yaml

--- a/base-kustomize/manila/base/manila-mariadb-database.yaml
+++ b/base-kustomize/manila/base/manila-mariadb-database.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Database
+metadata:
+  name: manila
+  namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    helm.sh/resource-policy: keep
+    meta.helm.sh/release-name: "manila"
+    meta.helm.sh/release-namespace: "openstack"
+spec:
+  # If you want the database to be created with a different name than the resource name
+  # name: data-custom
+  mariaDbRef:
+    name: mariadb-cluster
+  characterSet: utf8
+  collate: utf8_general_ci
+  retryInterval: 5s
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: User
+metadata:
+  name: manila
+  namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    helm.sh/resource-policy: keep
+    meta.helm.sh/release-name: "manila"
+    meta.helm.sh/release-namespace: "openstack"
+spec:
+  # If you want the user to be created with a different name than the resource name
+  # name: user-custom
+  mariaDbRef:
+    name: mariadb-cluster
+  passwordSecretKeyRef:
+    name: manila-db-password
+    key: password
+  # This field is immutable and defaults to 10, 0 means unlimited.
+  maxUserConnections: 0
+  host: "%"
+  retryInterval: 5s
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Grant
+metadata:
+  name: manila-grant
+  namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    helm.sh/resource-policy: keep
+    meta.helm.sh/release-name: "manila"
+    meta.helm.sh/release-namespace: "openstack"
+spec:
+  mariaDbRef:
+    name: mariadb-cluster
+  privileges:
+    - "ALL"
+  database: "manila"
+  table: "*"
+  username: manila
+  grantOption: true
+  host: "%"
+  retryInterval: 5s

--- a/base-kustomize/manila/base/manila-rabbitmq-queue-policy.yaml
+++ b/base-kustomize/manila/base/manila-rabbitmq-queue-policy.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Policy
+metadata:
+  name: manila-quorum-three-replicas
+  namespace: openstack
+spec:
+  name: manila-quorum-three-replicas
+  vhost: "manila"
+  pattern: ".*"
+  applyTo: queues
+  definition:
+    target-group-size: 3
+  priority: 0
+  rabbitmqClusterReference:
+    name: rabbitmq

--- a/base-kustomize/manila/base/manila-rabbitmq-queue.yaml
+++ b/base-kustomize/manila/base/manila-rabbitmq-queue.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: User
+metadata:
+  name: manila
+  namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    helm.sh/resource-policy: keep
+    meta.helm.sh/release-name: "manila"
+    meta.helm.sh/release-namespace: "openstack"
+spec:
+  tags:
+    - management # available tags are 'management', 'policymaker', 'monitoring' and 'administrator'
+    - policymaker
+  rabbitmqClusterReference:
+    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
+    namespace: openstack
+  importCredentialsSecret:
+    name: manila-rabbitmq-password
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Vhost
+metadata:
+  name: manila-vhost
+  namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    helm.sh/resource-policy: keep
+    meta.helm.sh/release-name: "manila"
+    meta.helm.sh/release-namespace: "openstack"
+spec:
+  name: "manila" # vhost name; required and cannot be updated
+  defaultQueueType: quorum # default queue type for this vhost; require RabbitMQ version 3.11.12 or above
+  rabbitmqClusterReference:
+    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
+    namespace: openstack
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: manila-queue
+  namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    helm.sh/resource-policy: keep
+    meta.helm.sh/release-name: "manila"
+    meta.helm.sh/release-namespace: "openstack"
+spec:
+  name: manila-qq # name of the queue
+  vhost: "manila" # default to '/' if not provided
+  type: quorum # without providing a queue type, rabbitmq creates a classic queue
+  autoDelete: false
+  durable: true # seting 'durable' to false means this queue won't survive a server restart
+  rabbitmqClusterReference:
+    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
+    namespace: openstack
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Permission
+metadata:
+  name: manila-permission
+  namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    helm.sh/resource-policy: keep
+    meta.helm.sh/release-name: "manila"
+    meta.helm.sh/release-namespace: "openstack"
+spec:
+  vhost: "manila" # name of a vhost
+  userReference:
+    name: "manila" # name of a user.rabbitmq.com in the same namespace; must specify either spec.userReference or spec.user
+  permissions:
+    write: ".*"
+    configure: ".*"
+    read: ".*"
+  rabbitmqClusterReference:
+    name: rabbitmq # rabbitmqCluster must exist in the same namespace as this resource
+    namespace: openstack

--- a/bin/create-secrets.sh
+++ b/bin/create-secrets.sh
@@ -84,6 +84,11 @@ magnum_admin_password=$(generate_password 32)
 masakari_rabbitmq_password=$(generate_password 64)
 masakari_db_password=$(generate_password 32)
 masakari_admin_password=$(generate_password 32)
+manila_rabbitmq_password=$(generate_password 64)
+manila_db_password=$(generate_password 32)
+manila_admin_password=$(generate_password 32)
+manila_ssh_public_key=$(ssh-keygen -qt ed25519 -N '' -C "manila_ssh" -f manila_ssh_key && cat manila_ssh_key.pub)
+manila_ssh_private_key=$(cat manila_ssh_key)
 postgresql_identity_admin_password=$(generate_password 32)
 postgresql_db_admin_password=$(generate_password 32)
 postgresql_db_exporter_password=$(generate_password 32)
@@ -558,6 +563,44 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
+  name: manila-rabbitmq-password
+  namespace: openstack
+type: Opaque
+data:
+  username: $(echo -n "manila" | base64)
+  password: $(echo -n $manila_rabbitmq_password | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: manila-db-password
+  namespace: openstack
+type: Opaque
+data:
+  password: $(echo -n $manila_db_password | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: manila-admin
+  namespace: openstack
+type: Opaque
+data:
+  password: $(echo -n $manila_admin_password | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: manila-service-keypair
+  namespace: openstack
+type: Opaque
+data:
+  public_key: $(echo -n $manila_ssh_public_key | base64 -w0)
+  private_key: $(echo -n "$manila_ssh_private_key" | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
   name: postgresql-identity-admin
   namespace: openstack
 type: Opaque
@@ -693,5 +736,6 @@ data:
 EOF
 
 rm nova_ssh_key nova_ssh_key.pub
+rm manila_ssh_key manila_ssh_key.pub
 chmod 0640 ${OUTPUT_FILE}
 echo "Secrets YAML file created as ${OUTPUT_FILE}"

--- a/bin/install-manila.sh
+++ b/bin/install-manila.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Description: Fetches the version for SERVICE_NAME from the specified
+# YAML file and executes a helm upgrade/install command with dynamic values files.
+
+# Disable SC2124 (unused array), SC2145 (array expansion issue), SC2294 (eval)
+# shellcheck disable=SC2124,SC2145,SC2294
+
+# Service
+SERVICE_NAME="manila"
+SERVICE_NAMESPACE="openstack"
+
+# Helm
+HELM_REPO_NAME="openstack-helm"
+HELM_REPO_URL="https://tarballs.opendev.org/openstack/openstack-helm"
+
+# Base directories provided by the environment
+# Using provided defaults if not set in environment
+GENESTACK_BASE_DIR="${GENESTACK_BASE_DIR:-/opt/genestack}"
+GENESTACK_OVERRIDES_DIR="${GENESTACK_OVERRIDES_DIR:-/etc/genestack}"
+
+# Define service-specific override directories based on the framework
+SERVICE_BASE_OVERRIDES="${GENESTACK_BASE_DIR}/base-helm-configs/${SERVICE_NAME}"
+SERVICE_CUSTOM_OVERRIDES="${GENESTACK_OVERRIDES_DIR}/helm-configs/${SERVICE_NAME}"
+GLOBAL_OVERRIDES_DIR="${GENESTACK_OVERRIDES_DIR}/helm-configs/global_overrides"
+
+# Read the desired chart version from VERSION_FILE
+VERSION_FILE="${GENESTACK_OVERRIDES_DIR}/helm-chart-versions.yaml"
+
+if [ ! -f "$VERSION_FILE" ]; then
+    echo "Error: helm-chart-versions.yaml not found at $VERSION_FILE" >&2
+    exit 1
+fi
+
+# Extract version dynamically using the SERVICE_NAME variable
+SERVICE_VERSION=$(grep "^[[:space:]]*${SERVICE_NAME}:" "$VERSION_FILE" | sed "s/.*${SERVICE_NAME}: *//")
+
+if [ -z "$SERVICE_VERSION" ]; then
+    echo "Error: Could not extract version for '$SERVICE_NAME' from $VERSION_FILE" >&2
+    exit 1
+fi
+
+echo "Found version for $SERVICE_NAME: $SERVICE_VERSION"
+
+# Prepare an array to collect --values arguments
+values_args=()
+
+# --- Include all YAML files from the BASE configuration directory ---
+if [[ -d "$SERVICE_BASE_OVERRIDES" ]]; then
+    echo "Including base overrides from directory: $SERVICE_BASE_OVERRIDES"
+    # NOTE: The original manila script explicitly used manila-helm-overrides.yaml.
+    # This template includes all .yaml files in the directory like the nova script.
+    for file in "$SERVICE_BASE_OVERRIDES"/*.yaml; do
+        # Check that there is at least one match
+        if [[ -e "$file" ]]; then
+            echo " - $file"
+            values_args+=("--values" "$file")
+        fi
+    done
+else
+    echo "Warning: Base override directory not found: $SERVICE_BASE_OVERRIDES"
+fi
+
+# --- Include all YAML files from the GLOBAL configuration directory ---
+if [[ -d "$GLOBAL_OVERRIDES_DIR" ]]; then
+    echo "Including overrides from global config directory:"
+    for file in "$GLOBAL_OVERRIDES_DIR"/*.yaml; do
+        if [[ -e "$file" ]]; then
+            echo " - $file"
+            values_args+=("--values" "$file")
+        fi
+    done
+else
+    echo "Warning: Global config directory not found: $GLOBAL_OVERRIDES_DIR"
+fi
+
+# --- Include all YAML files from the custom SERVICE configuration directory ---
+if [[ -d "$SERVICE_CUSTOM_OVERRIDES" ]]; then
+    echo "Including overrides from service config directory:"
+    for file in "$SERVICE_CUSTOM_OVERRIDES"/*.yaml; do
+        if [[ -e "$file" ]]; then
+            echo " - $file"
+            values_args+=("--values" "$file")
+        fi
+    done
+else
+    echo "Warning: Service config directory not found: $SERVICE_CUSTOM_OVERRIDES"
+fi
+
+echo
+
+# --- Helm Repository and Execution ---
+helm repo add "$HELM_REPO_NAME" "$HELM_REPO_URL"
+helm repo update
+
+# Collect all --set arguments, executing commands and quoting safely
+set_args=(
+    --set "endpoints.identity.auth.admin.password=$(kubectl --namespace openstack get secret keystone-admin -o jsonpath='{.data.password}' | base64 -d)"
+    --set "endpoints.identity.auth.manila.password=$(kubectl --namespace openstack get secret manila-admin -o jsonpath='{.data.password}' | base64 -d)"
+    --set "endpoints.oslo_db.auth.admin.password=$(kubectl --namespace openstack get secret mariadb -o jsonpath='{.data.root-password}' | base64 -d)"
+    --set "endpoints.oslo_db.auth.manila.password=$(kubectl --namespace openstack get secret manila-db-password -o jsonpath='{.data.password}' | base64 -d)"
+    --set "endpoints.oslo_cache.auth.memcache_secret_key=$(kubectl --namespace openstack get secret os-memcached -o jsonpath='{.data.memcache_secret_key}' | base64 -d)"
+    --set "conf.manila.keystone_authtoken.memcache_secret_key=$(kubectl --namespace openstack get secret os-memcached -o jsonpath='{.data.memcache_secret_key}' | base64 -d)"
+    --set "endpoints.oslo_messaging.auth.admin.password=$(kubectl --namespace openstack get secret rabbitmq-default-user -o jsonpath='{.data.password}' | base64 -d)"
+    --set "endpoints.oslo_messaging.auth.manila.password=$(kubectl --namespace openstack get secret manila-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)"
+    --set "network.ssh.public_key=$(kubectl -n openstack get secret manila-service-keypair -o jsonpath='{.data.public_key}' | base64 -d)"
+    --set "network.ssh.private_key=$(kubectl -n openstack get secret manila-service-keypair -o jsonpath='{.data.private_key}' | base64 -d)"
+)
+
+
+helm_command=(
+    helm upgrade --install "$SERVICE_NAME" "$HELM_REPO_NAME/$SERVICE_NAME"
+    --version "${SERVICE_VERSION}"
+    --namespace="$SERVICE_NAMESPACE"
+    --timeout 120m
+    --create-namespace
+
+    "${values_args[@]}"
+    "${set_args[@]}"
+
+    # Post-renderer configuration
+    --post-renderer "$GENESTACK_OVERRIDES_DIR/kustomize/kustomize.sh"
+    --post-renderer-args "$SERVICE_NAME/overlay"
+
+    "$@"
+)
+
+echo "Executing Helm command (arguments are quoted safely):"
+printf '%q ' "${helm_command[@]}"
+echo
+
+# Execute the command directly from the array
+"${helm_command[@]}"

--- a/bin/setup-openstack.sh
+++ b/bin/setup-openstack.sh
@@ -57,6 +57,7 @@ EOF
     prompt_component "magnum" "Magnum (Container Orchestration)"
     prompt_component "octavia" "Octavia (Load Balancer)"
     prompt_component "masakari" "Masakari (Instance High Availability)"
+    prompt_component "manila" "Manila (Shared Filesystem)"
     prompt_component "ceilometer" "Ceilometer (Telemetry)"
     prompt_component "gnocchi" "Gnocchi (Time Series Database)"
     prompt_component "skyline" "Skyline (Dashboard)"
@@ -76,6 +77,7 @@ is_component_enabled "neutron" && runTrackErator /opt/genestack/bin/install-neut
 is_component_enabled "magnum" && runTrackErator /opt/genestack/bin/install-magnum.sh
 is_component_enabled "octavia" && runTrackErator /opt/genestack/bin/install-octavia.sh
 is_component_enabled "masakari" && runTrackErator /opt/genestack/bin/install-masakari.sh
+is_component_enabled "manila" && runTrackErator /opt/genestack/bin/install-manila.sh
 is_component_enabled "ceilometer" && runTrackErator /opt/genestack/bin/install-ceilometer.sh
 is_component_enabled "gnocchi" && runTrackErator /opt/genestack/bin/install-gnocchi.sh
 

--- a/docs/genestack-components.md
+++ b/docs/genestack-components.md
@@ -40,6 +40,7 @@ and largely deployed with Helm+Kustomize against the K8s API (v1.28 and up).
 | OpenStack  | Ironic (Helm)         | Optional |
 | OpenStack  | Magnum (Helm)         | Optional |
 | OpenStack  | Masakari (Helm)       | Optional |
+| OpenStack  | Manila (Helm)         | Optional |
 | OpenStack  | Blazar (Helm)         | Optional |
 | OpenStack  | metal3.io             | Planned  |
 | OpenStack  | PostgreSQL (Operator) | Included |

--- a/docs/openstack-manila.md
+++ b/docs/openstack-manila.md
@@ -1,0 +1,127 @@
+!!! banner "TECH PREVIEW"
+
+# Deploy Manila
+
+Manila is the Shared File Systems service for OpenStack. Manila provides
+coordinated access to shared or distributed file systems.
+
+This document outlines the deployment of OpenStack Manila using Genestack.
+
+The method in which the share is provisioned and consumed is determined
+by the Shared File Systems driver, or drivers in the case of a multi-backend
+configuration. A variety of available Shared File Systems drivers work with
+proprietary backend storage arrays and appliances, open source distributed
+file systems, as well as Linux NFS or Samba server.
+
+This tech preview will focus predominantly on the NetApp Clustered
+Data ONTAP driver with share server management enabled. The driver interfaces
+between OpenStack Manila to NetApp Clustered Data ONTAP storage controllers to
+create new storage virtual machines (SVMs) for each tenant share server that is
+requested by the Manila service. The driver also creates new data logical interfaces
+(LIFs) that provide access for OpenStack tenants on a specific share network to
+their shared file systems exported from the share server.
+
+Reference the full online [OpenStack Manila documentation](https://docs.openstack.org/manila/latest/) 
+
+## Create secrets
+
+!!! note "Information about the secrets used"
+!!! note "manila-service-keypair is only required for Generic share driver"
+
+    Manual secret generation is only required if you haven't run the
+    `create-secrets.sh` script located in `/opt/genestack/bin`.
+
+    ??? example "Example secret generation"
+
+        ``` shell
+        kubectl --namespace openstack \
+                create secret generic manila-admin \
+                --type Opaque \
+                --from-literal=password="$(< /dev/urandom tr -dc _A-Za-z0-9 | head -c${1:-32};echo;)"
+        kubectl --namespace openstack \
+                create secret generic manila-db-password \
+                --type Opaque \
+                --from-literal=password="$(< /dev/urandom tr -dc _A-Za-z0-9 | head -c${1:-32};echo;)"
+        kubectl --namespace openstack \
+                create secret generic manila-rabbitmq-password \
+                --type Opaque \
+                --from-literal=password="$(< /dev/urandom tr -dc _A-Za-z0-9 | head -c${1:-32};echo;)"
+        ssh-keygen -qt ed25519 -N '' -C "manila_ssh" -f manila_ssh_key && \
+        kubectl --namespace openstack \
+                create secret generic manila-service-keypair \
+                --type Opaque \
+                --from-literal=public_key="$(cat manila_ssh_key.pub)" \
+                --from-literal=private_key="$(cat manila_ssh_key)"
+        rm -f manila_ssh_key manila_ssh_key.pub
+        ```
+
+## NetApp Clustered Data ONTAP driver configuration
+
+Manila configuration values for the NetApp ONTAP driver should be edited
+for the specific values relevant to the NetApp cluster and the Genestack
+environment.
+
+``` yaml
+bootstrap:
+  enabled: false
+
+conf:
+  manila:
+    DEFAULT:
+      default_share_type: default
+      default_share_group_type: default
+      enabled_share_backends: netapp_aff_nfs
+      enabled_share_protocols: NFS
+      osapi_max_limit: 1000
+      osapi_share_use_ssl: true
+      share_name_template: share-%s
+      storage_availability_zone: az1
+    netapp_aff_nfs:
+      share_backend_name: netapp_aff_nfs
+      share_driver: manila.share.drivers.netapp.common.NetAppDriver
+      driver_handles_share_servers: true
+      driver_ssl_cert_verify: false
+      netapp_storage_family: ontap_cluster
+      netapp_transport_type: https
+      netapp_server_hostname: <cluster_FQDN>
+      netapp_server_port: 443
+      netapp_login: <admin_user>
+      netapp_password: <admin_pass>
+      netapp_aggregate_name_search_pattern: ^aggr01_n01_SSD$
+      netapp_root_volume_aggregate: aggr01_n01_SSD
+      netapp_root_volume: root
+      netapp_port_name_search_pattern: ^(a0e-402|a0f-403)$
+      netapp_vserver_name_template: mnl_%s
+      netapp_lif_name_template: mnl_%(net_allocation_id)s
+      netapp_volume_name_template: manila_%(share_id)s
+      netapp_enabled_share_protocols: nfs4.1
+      netapp_volume_snapshot_reserve_percent: 5
+  manila_api_uwsgi:
+    uwsgi:
+      processes: 4
+
+manifests:
+  deployment_share: false
+```
+
+
+## Run the package deployment
+
+!!! example "Run the Manila deployment Script `/opt/genestack/bin/install-manila.sh`"
+
+    ``` shell
+    --8<-- "bin/install-manila.sh"
+    ```
+
+!!! tip
+
+    You may need to provide custom values to configure your OpenStack services.
+    For a simple single region or lab deployment you can supply an additional
+    overrides flag using the example found at
+    `base-helm-configs/aio-example-openstack-overrides.yaml`.
+
+## Validate functionality
+
+``` shell
+kubectl --namespace openstack exec -ti openstack-admin-client -- openstack share service list
+```

--- a/etc/gateway-api/listeners/manila-https.json
+++ b/etc/gateway-api/listeners/manila-https.json
@@ -1,0 +1,27 @@
+[
+    {
+        "op": "add",
+        "path": "/spec/listeners/-",
+        "value": {
+            "name": "manila-https",
+            "port": 443,
+            "protocol": "HTTPS",
+            "hostname": "manila.your.domain.tld",
+            "allowedRoutes": {
+                "namespaces": {
+                    "from": "All"
+                }
+            },
+            "tls": {
+                "certificateRefs": [
+                    {
+                        "group": "",
+                        "kind": "Secret",
+                        "name": "manila-gw-tls-secret"
+                    }
+                ],
+                "mode": "Terminate"
+            }
+        }
+    }
+]

--- a/etc/gateway-api/routes/custom-manila-gateway-route.yaml
+++ b/etc/gateway-api/routes/custom-manila-gateway-route.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: custom-manila-gateway-route
+  namespace: openstack
+  labels:
+    application: gateway-api
+    service: HTTPRoute
+    route: manila
+spec:
+  parentRefs:
+    - name: flex-gateway
+      sectionName: manila-https
+      namespace: nginx-gateway
+  hostnames:
+    - "manila.your.domain.tld"
+  rules:
+    - backendRefs:
+        - name: manila-api
+          port: 8786

--- a/helm-chart-versions.yaml
+++ b/helm-chart-versions.yaml
@@ -18,6 +18,7 @@ charts:
   magnum: 2024.2.157+13651f45-628a320c
   mariadb-operator: 0.36.0
   masakari: 2024.2.17+13651f45-628a320c
+  manila: 2025.1.3+e6801dcd0
   memcached: 7.8.6
   metallb: v0.13.12
   neutron: 2024.2.529+13651f45-628a320c

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ ruamel.yaml==0.18.6
 ruamel.yaml.clib==0.2.12
 kubernetes>=24.2.0
 openstacksdk>=1.0.0
-python-openstackclient==7.4.0
+python-openstackclient==8.2.0
 dictdiffer==0.9.0

--- a/scripts/create-manila-secrets.sh
+++ b/scripts/create-manila-secrets.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# shellcheck disable=SC2086
+
+usage() {
+    echo "Usage: $0 [--region <region [RegionOne]>"
+    exit 1
+}
+
+region="RegionOne"
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --help)
+            usage
+            ;;
+        -h)
+            usage
+            ;;
+        --region)
+            region="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown parameter passed: $1"
+            usage
+            ;;
+    esac
+done
+
+# Check if the region argument is provided
+if [ -z "$region" ]; then
+    usage
+fi
+
+generate_password() {
+    < /dev/urandom tr -dc _A-Za-z0-9 | head -c${1:-32}
+}
+
+manila_ssh_public_key=$(ssh-keygen -qt ed25519 -N '' -C "manila_ssh" -f manila_ssh_key && cat manila_ssh_key.pub)
+manila_ssh_private_key=$(cat manila_ssh_key)
+manila_rabbitmq_password=$(generate_password 64)
+manila_db_password=$(generate_password 32)
+manila_admin_password=$(generate_password 32)
+
+OUTPUT_FILE="/etc/genestack/manila-kubesecrets.yaml"
+
+if [[ -f ${OUTPUT_FILE} ]]; then
+    echo "Error: ${OUTPUT_FILE} already exists. Please remove it before running this script."
+    echo "       This will replace an existing file and will lead to mass rotation, which is"
+    echo "       likely not what you want to do. If you really want to break your system, please"
+    echo "       make sure you know what you're doing."
+    exit 99
+fi
+
+cat <<EOF > $OUTPUT_FILE
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: manila-rabbitmq-password
+  namespace: openstack
+type: Opaque
+data:
+  username: $(echo -n "manila" | base64)
+  password: $(echo -n $manila_rabbitmq_password | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: manila-db-password
+  namespace: openstack
+type: Opaque
+data:
+  password: $(echo -n $manila_db_password | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: manila-admin
+  namespace: openstack
+type: Opaque
+data:
+  password: $(echo -n $manila_admin_password | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: manila-service-keypair
+  namespace: openstack
+type: Opaque
+data:
+  public_key: $(echo -n $manila_ssh_public_key | base64 -w0)
+  private_key: $(echo -n "$manila_ssh_private_key" | base64 -w0)
+EOF
+
+rm -f manila_ssh_key manila_ssh_key.pub
+chmod 0640 ${OUTPUT_FILE}
+echo "Secrets YAML file created as ${OUTPUT_FILE}"

--- a/scripts/hyperconverged-lab.sh
+++ b/scripts/hyperconverged-lab.sh
@@ -37,6 +37,7 @@ components:
   magnum: false
   octavia: false
   masakari: false
+  manila: false
   ceilometer: false
   gnocchi: false
   skyline: true
@@ -740,6 +741,21 @@ conf:
 EOF
 fi
 
+if [ ! -f "/etc/genestack/helm-configs/manila/manila-helm-overrides.yaml" ]; then
+cat > /etc/genestack/helm-configs/manila/manila-helm-overrides.yaml <<EOF
+---
+pod:
+  resources:
+    enabled: false
+bootstrap:
+  enabled: false
+conf:
+  manila:
+    oslo_messaging_notifications:
+      driver: noop
+EOF
+fi
+
 # This makes the services available from outside (thanks @busterswt for figuring this out)
 if [ ! -f "/etc/genestack/helm-configs/global_overrides/endpoints.yaml" ]; then
 cat > /etc/genestack/helm-configs/global_overrides/endpoints.yaml <<EOF
@@ -864,6 +880,8 @@ endpoints:
         region_name: *region
       magnum:
         region_name: *region
+      manila:
+        region_name: *region
       neutron:
         region_name: *region
       nova:
@@ -931,6 +949,26 @@ endpoints:
       public:
         tls: {}
         host: placement.${GATEWAY_DOMAIN}
+    port:
+      api:
+        public: 443
+    scheme:
+      public: https
+  share:
+    host_fqdn_override:
+      public:
+        tls: {}
+        host: manila.${GATEWAY_DOMAIN}
+    port:
+      api:
+        public: 443
+    scheme:
+      public: https
+  sharev2:
+    host_fqdn_override:
+      public:
+        tls: {}
+        host: manila.${GATEWAY_DOMAIN}
     port:
       api:
         public: 443

--- a/scripts/openstack-components.yaml
+++ b/scripts/openstack-components.yaml
@@ -11,6 +11,7 @@ components:
   magnum: false
   octavia: false
   masakari: false
+  manila: false
   ceilometer: false
   gnocchi: false
   skyline: true


### PR DESCRIPTION
Adding Manila installation to Genestack. This is OpenStack's shared file system service. This installation will focus on the Generic driver and the NetApp unified driver for ONTAP.