### PR TITLE
fix: remove secondary sql connection for cinder

### DIFF
--- a/bin/install-cinder.sh
+++ b/bin/install-cinder.sh
@@ -97,7 +97,6 @@ set_args=(
     --set "endpoints.oslo_db.auth.cinder.password=$(kubectl --namespace openstack get secret cinder-db-password -o jsonpath='{.data.password}' | base64 -d)"
     --set "endpoints.oslo_cache.auth.memcache_secret_key=$(kubectl --namespace openstack get secret os-memcached -o jsonpath='{.data.memcache_secret_key}' | base64 -d)"
     --set "conf.cinder.keystone_authtoken.memcache_secret_key=$(kubectl --namespace openstack get secret os-memcached -o jsonpath='{.data.memcache_secret_key}' | base64 -d)"
-    --set "conf.cinder.database.slave_connection=mysql+pymysql://cinder:$(kubectl --namespace openstack get secret cinder-db-password -o jsonpath='{.data.password}' | base64 -d)@mariadb-cluster-secondary.openstack.svc.cluster.local:3306/cinder"
     --set "endpoints.oslo_messaging.auth.admin.password=$(kubectl --namespace openstack get secret rabbitmq-default-user -o jsonpath='{.data.password}' | base64 -d)"
     --set "endpoints.oslo_messaging.auth.cinder.password=$(kubectl --namespace openstack get secret cinder-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)"
 )

--- a/bin/install-cloudkitty.sh
+++ b/bin/install-cloudkitty.sh
@@ -97,7 +97,6 @@ set_args=(
     --set "endpoints.oslo_db.auth.cloudkitty.password=$(kubectl --namespace openstack get secret cloudkitty-db-password -o jsonpath='{.data.password}' | base64 -d)"
     --set "endpoints.oslo_cache.auth.memcache_secret_key=$(kubectl --namespace openstack get secret os-memcached -o jsonpath='{.data.memcache_secret_key}' | base64 -d)"
     --set "conf.cloudkitty.keystone_authtoken.memcache_secret_key=$(kubectl --namespace openstack get secret os-memcached -o jsonpath='{.data.memcache_secret_key}' | base64 -d)"
-    --set "conf.cloudkitty.database.slave_connection=mysql+pymysql://cloudkitty:$(kubectl --namespace openstack get secret cloudkitty-db-password -o jsonpath='{.data.password}' | base64 -d)@mariadb-cluster-secondary.openstack.svc.cluster.local:3306/cloudkitty"
     --set "endpoints.oslo_messaging.auth.admin.password=$(kubectl --namespace openstack get secret rabbitmq-default-user -o jsonpath='{.data.password}' | base64 -d)"
     --set "endpoints.oslo_messaging.auth.cloudkitty.password=$(kubectl --namespace openstack get secret cloudkitty-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)"
 )

--- a/bin/install-ironic.sh
+++ b/bin/install-ironic.sh
@@ -100,7 +100,6 @@ set_args=(
     --set "endpoints.oslo_db.auth.ironic.password=$(kubectl --namespace openstack get secret ironic-db-password -o jsonpath='{.data.password}' | base64 -d)"
     --set "endpoints.oslo_cache.auth.memcache_secret_key=$(kubectl --namespace openstack get secret os-memcached -o jsonpath='{.data.memcache_secret_key}' | base64 -d)"
     --set "conf.ironic.keystone_authtoken.memcache_secret_key=$(kubectl --namespace openstack get secret os-memcached -o jsonpath='{.data.memcache_secret_key}' | base64 -d)"
-    --set "conf.ironic.database.slave_connection=mysql+pymysql://ironic:$(kubectl --namespace openstack get secret ironic-db-password -o jsonpath='{.data.password}' | base64 -d)@mariadb-cluster-secondary.openstack.svc.cluster.local:3306/ironic"
     --set "endpoints.oslo_messaging.auth.admin.password=$(kubectl --namespace openstack get secret rabbitmq-default-user -o jsonpath='{.data.password}' | base64 -d)"
     --set "endpoints.oslo_messaging.auth.ironic.password=$(kubectl --namespace openstack get secret ironic-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)"
 )


### PR DESCRIPTION
This change removes all references to slave_connection (secondary_connection) from all install scripts.  