### PR TITLE
fix: Add zaqar doc reference into deployment guide

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -225,6 +225,7 @@ nav:
                   - Blazar: openstack-blazar.md
                   - Freezer: openstack-freezer.md
                   - Masakari: openstack-masakari.md
+                  - Zaqar: openstack-zaqar.md
           - Monitoring:
               - Monitoring Overview: prometheus-monitoring-overview.md
               - Getting Started: monitoring-getting-started.md


### PR DESCRIPTION
It adds the zaqar doc reference to Deployment Guide page 
in genestack docs.