### PR TITLE
chore: Add zaqar reference

### DIFF
--- a/openstack-components.yaml
+++ b/openstack-components.yaml
@@ -19,3 +19,4 @@ components:
   ceilometer: false
   gnocchi: false
   skyline: true
+  zaqar: false


### PR DESCRIPTION
It adds zaqar reference to openstack-components.yaml to help 
determine whether it needs to be installed automatically or 
not in hyperconverged lab.