### PR TITLE
feat (nova): allow for nested virtualization in the hyperconverged lab

### DIFF
--- a/scripts/hyperconverged-lab.sh
+++ b/scripts/hyperconverged-lab.sh
@@ -721,6 +721,10 @@ conf:
       workers: 1
     oslo_messaging_notifications:
       driver: noop
+    libvirt:
+      virt_type  = qemu
+      images_type = qcow2
+      images_path = /var/lib/nova/instances
   nova_api_uwsgi:
     uwsgi:
       processes: 1


### PR DESCRIPTION
This pr sets the libvirt virt_type to qemu inside the hyperconverged lab.  This will allow for nested virtualization and the creation of instances inside a hyperconverged lab deployment.  