### PR TITLE
Fix: Update cinder-volume default release/branch in Ansible playbooks

### DIFF
--- a/ansible/playbooks/deploy-cinder-netapp-volumes-reference.yaml
+++ b/ansible/playbooks/deploy-cinder-netapp-volumes-reference.yaml
@@ -4,7 +4,7 @@
   gather_facts: true
   become: true
   vars:
-    cinder_release: "2024.1"
+    cinder_release_branch: "unmaintained/2024.1"
     cinder_storage_network_interface: ansible_br_storage
     cinder_storage_network_interface_secondary: ansible_br_storage_secondary
     cinder_backend_name: "block-ha-performance-at-rest-encrypted,block-ha-standard-at-rest-encrypted,block-ha-performance-end-to-end-encrypted,block-ha-standard-end-to-end-encrypted"
@@ -114,7 +114,7 @@
         name:
           - pip
           - pymysql
-          - "git+https://github.com/openstack/cinder@stable/{{ cinder_release }}"
+          - "git+https://github.com/openstack/cinder@{{ cinder_release_branch }}"
           - "git+https://github.com/rackerlabs/cinder-rxt.git"
         state: present
         virtualenv: "{{ virtualenv_path }}"

--- a/ansible/playbooks/deploy-cinder-volumes-reference.yaml
+++ b/ansible/playbooks/deploy-cinder-volumes-reference.yaml
@@ -4,7 +4,7 @@
   gather_facts: true
   become: true
   vars:
-    cinder_release: "2024.1"
+    cinder_release_branch: "unmaintained/2024.1"
     cinder_storage_network_interface: ansible_br_storage
     cinder_storage_network_interface_secondary: ansible_br_storage_secondary
     cinder_backend_name: "lvmdriver-1"
@@ -82,7 +82,7 @@
         name:
           - pip
           - pymysql
-          - "git+https://github.com/openstack/cinder@stable/{{ cinder_release }}"
+          - "git+https://github.com/openstack/cinder@{{ cinder_release_branch }}"
           - "git+https://github.com/rackerlabs/cinder-rxt.git"
         state: present
         virtualenv: /opt/cinder


### PR DESCRIPTION
Currently: running the playbook with default values result in failure due to cinder_release = '2024.1'. The playbook git clones the Cinder repo and uses cinder_release in the branch checkout. It specifically tries to checkout stable/2024.1. The upstream Cinder git repository has moved stable/2024.1 to unmaintained/2024.1. Our default value should be bumped to 2024.2.

This is a quick fix. My intention is to add dynamic Ansible logic to parse the cinder_release from the helm-chart-versions.yaml or pull the same helm chart version from Kubernetes and parse for YYYY.R where 'R' is the dot release. This will ensure that the default automatically matches the cinder-api and cinder-scheduler versions deployed in the control plane.