### PR TITLE
fix: (docs) correct installation script documentation for some exporters

### DIFF
--- a/docs/prometheus-mysql-exporter.md
+++ b/docs/prometheus-mysql-exporter.md
@@ -29,8 +29,10 @@ password=$(kubectl --namespace openstack get secret mariadb-monitoring -o jsonpa
 Next, install the exporter
 
 ``` shell
-bin/install-chart.sh prometheus-mysql-exporter
+bin/install-prometheus-mysql-exporter.sh
 ```
+
+!!! note "Helm chart versions are defined in (opt)/genestack/helm-chart-versions.yaml and can be overridden in (etc)/genestack/helm-chart-versions.yaml"
 
 !!! success
     If the installation is successful, you should see the exporter pod in the openstack namespace.

--- a/docs/prometheus-postgres-exporter.md
+++ b/docs/prometheus-postgres-exporter.md
@@ -11,8 +11,8 @@ PostgresSQL Exporter is used to expose metrics from a running PostgresSQL deploy
 Install the PostgresSQL Exporter
 
 ``` shell
-bin/install-chart.sh prometheus-postgres-exporter
+bin/install-prometheus-postgres-exporter.sh
 ```
-
+!!! note "Helm chart versions are defined in (opt)/genestack/helm-chart-versions.yaml and can be overridden in (etc)/genestack/helm-chart-versions.yaml"
 !!! success
     If the installation is successful, you should see the exporter pod in the openstack namespace.

--- a/docs/prometheus-pushgateway.md
+++ b/docs/prometheus-pushgateway.md
@@ -11,8 +11,9 @@ the OVN backup _CronJob_.
 
 
 ``` shell
-bin/install-chart.sh prometheus-pushgateway
+bin/install-prometheus-pushgateway.sh
 ```
+!!! note "Helm chart versions are defined in (opt)/genestack/helm-chart-versions.yaml and can be overridden in (etc)/genestack/helm-chart-versions.yaml"
 
 !!! success
     If the installation is successful, you should see the prometheus-pushgateway pod running in the prometheus namespace.


### PR DESCRIPTION
When reworking the installation scripts in pr: https://github.com/rackerlabs/genestack/pull/1276 some doc's were missed updating them to the new installation script.  This pr cleans up the docs and points the user to the correct bin/install-<service>.sh script.  