### PR TITLE
OSPC-1636: Added changes to make ACME_EMAIL to default email

### DIFF
--- a/scripts/hyperconverged-lab.sh
+++ b/scripts/hyperconverged-lab.sh
@@ -89,8 +89,11 @@ done
 
 if [ -z "${ACME_EMAIL}" ]; then
   read -rp "Enter a valid email address for use with ACME, press enter to skip: " ACME_EMAIL
-  export ACME_EMAIL="${ACME_EMAIL:-}"
 fi
+
+# Use of ACME_EMAIL to default Email
+ACME_EMAIL="${ACME_EMAIL:-example@aol.com}"
+export ACME_EMAIL
 
 if [ -z "${GATEWAY_DOMAIN}" ]; then
   echo "The domain name for the gateway is required, if you do not have a domain name press enter to use the default"


### PR DESCRIPTION
Made the ACME_EMAI to be added by default to system if we are not providing manually.
Previously the build script was failing if we don't provide the ACME_EMAIL manually.
But after setting the default email to ACME_EMAIL, Even though user don't pass it , the build will be Successful.

I have ran and verified in my Local Environment with this changes.