### PR TITLE
fix: Replace decommed bitnami repository with legacy

### DIFF
--- a/base-helm-configs/kubernetes-event-exporter/kubernetes-event-exporter-helm-overrides.yaml
+++ b/base-helm-configs/kubernetes-event-exporter/kubernetes-event-exporter-helm-overrides.yaml
@@ -1,1 +1,5 @@
 ---
+image:
+  registry: docker.io
+  repository: bitnamilegacy/kubernetes-event-exporter
+  tag: 1.7.0-debian-12-r46


### PR DESCRIPTION
adjusting the image for kubernetes event exporter from the decomm'd bitnami registry for legacy 