### PR TITLE
Fix: Use default service_api policy

### DIFF
--- a/base-helm-configs/glance/glance-helm-overrides.yaml
+++ b/base-helm-configs/glance/glance-helm-overrides.yaml
@@ -122,7 +122,6 @@ conf:
     "admin_required": "role:admin or role:glance_admin"
     "default": "role:admin or role:glance_admin"
     "context_is_admin": "role:admin or role:glance_admin"
-    "service_api": "role:service"
     "publicize_image": "role:glance_admin"
     "communitize_image": "role:glance_admin"
   logging:


### PR DESCRIPTION
The service_api rule in glance policy is defined
for servcie to servcie api calls. The default policy is to allow servcie user and admin. This rule just by itself as it is defined removes admin user access, so this patch removes it to set it to its default value.