### PR TITLE
Restore standard oslo policies

### DIFF
--- a/base-helm-configs/cinder/cinder-helm-overrides.yaml
+++ b/base-helm-configs/cinder/cinder-helm-overrides.yaml
@@ -107,10 +107,7 @@ conf:
   #    volume_clear: zero
   #    volume_driver: cinder_rxt.rackspace.RXTLVM
   #    volume_group: cinder-volumes-1
-  policy:
-    "volume_extension:types_extra_specs:read_sensitive": "rule:xena_system_admin_or_project_reader"
-    "volume_extension:qos_specs_manage:get_all": "rule:xena_system_admin_or_project_member"
-    "volume_extension:qos_specs_manage:get": "rule:xena_system_admin_or_project_member"
+  policy: {}
   cinder:
     DEFAULT:
       allow_availability_zone_fallback: true

--- a/base-helm-configs/glance/glance-helm-overrides.yaml
+++ b/base-helm-configs/glance/glance-helm-overrides.yaml
@@ -28,9 +28,9 @@ bootstrap:
     images:
       cirros:
         id: null
-        name: "Cirros 0.6.2 64-bit"
-        source_url: "http://download.cirros-cloud.net/0.6.2/"
-        image_file: "cirros-0.6.2-x86_64-disk.img"
+        name: "Cirros 0.6.3 64-bit"
+        source_url: "http://download.cirros-cloud.net/0.6.3/"
+        image_file: "cirros-0.6.3-x86_64-disk.img"
         min_disk: 1
         image_type: qcow2
         container_format: bare
@@ -118,13 +118,7 @@ conf:
     uwsgi:
       processes: 2
       threads: 1
-  policy:
-    "admin_required": "role:admin or role:glance_admin"
-    "default": "role:admin or role:glance_admin"
-    "context_is_admin": "role:admin or role:glance_admin"
-    "service_api": "role:service"
-    "publicize_image": "role:glance_admin"
-    "communitize_image": "role:glance_admin"
+  policy: {}
   logging:
     logger_root:
       level: INFO

--- a/releasenotes/notes/revert-to-default-policies-4b5a063ccf08bc75.yaml
+++ b/releasenotes/notes/revert-to-default-policies-4b5a063ccf08bc75.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    The oslo policies for cinder and glance are reverted to standard
+    OpenStack policies. If the previous behavior is needed, please add them
+    into your local `/etc/genestack/helm-configs` overrides files.


### PR DESCRIPTION
The oslo policies for cinder and glance are reverted to standard OpenStack policies. If the previous behavior is needed, please add them into your local `/etc/genestack/helm-configs` overrides files.