### PR TITLE
feat: Decouple cert-manager from base kubespray installation

### DIFF
--- a/.github/workflows/helm-cert-manager.yaml
+++ b/.github/workflows/helm-cert-manager.yaml
@@ -1,0 +1,42 @@
+---
+name: Helm GitHub Actions for cert-manager
+
+on:
+  pull_request:
+    paths:
+      - base-kustomize/cert-manager/**
+      - base-helm-configs/cert-manager/**
+      - .github/workflows/helm-cert-manager.yaml
+jobs:
+  helm:
+    strategy:
+      matrix:
+        overlays:
+          - base
+    name: Helm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: azure/setup-helm@v3
+        with:
+          version: v3.14.3
+          token: ${{ secrets.GITHUB_TOKEN }}
+        id: helm
+      - name: Add jetstack repo to helm
+        run: |
+          ${{ steps.helm.outputs.helm-path }} repo add cert-manager https://charts.jetstack.io
+          ${{ steps.helm.outputs.helm-path }} repo update
+      - name: Run Helm Template
+        run: |
+          ${{ steps.helm.outputs.helm-path }} template cert-manager cert-manager/cert-manager \
+          --create-namespace \
+          --namespace=cert-manager \
+          -f ${{ github.workspace }}//base-helm-configs/cert-manager/cert-manager-helm-overrides.yaml \
+          --post-renderer ${{ github.workspace }}/base-kustomize/kustomize.sh \
+          --post-renderer-args cert-manager/${{ matrix.overlays }} > /tmp/rendered.yaml
+      - name: Return helm Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: helm-cert-manager-artifact-${{ matrix.overlays }}
+          path: /tmp/rendered.yaml

--- a/ansible/inventory/genestack/group_vars/k8s_cluster/addons.yml
+++ b/ansible/inventory/genestack/group_vars/k8s_cluster/addons.yml
@@ -135,7 +135,7 @@ ingress_alb_enabled: false
 # alb_ingress_aws_debug: "false"
 
 # Cert manager deployment
-cert_manager_enabled: true
+cert_manager_enabled: false
 cert_manager_namespace: "cert-manager"
 # cert_manager_tolerations:
 #   - key: node-role.kubernetes.io/control-plane

--- a/base-helm-configs/cert-manager/cert-manager-helm-overrides.yaml
+++ b/base-helm-configs/cert-manager/cert-manager-helm-overrides.yaml
@@ -1,0 +1,14 @@
+---
+global:
+  nodeSelector:
+    openstack-control-plane: enabled
+
+crds:
+  enabled: true
+  keep: true
+
+config:
+  enableGatewayAPI: true
+
+dns01RecursiveNameservers: "8.8.8.8:53, 1.1.1.1:53"
+dns01RecursiveNameserversOnly: true

--- a/base-kustomize/cert-manager/base/kustomization.yaml
+++ b/base-kustomize/cert-manager/base/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+sortOptions:
+  order: fifo
+resources:
+  - all.yaml

--- a/bin/install-cert-manager.sh
+++ b/bin/install-cert-manager.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# Description: Fetches the version for SERVICE_NAME_DEFAULT from the specified
+# YAML file and executes a helm upgrade/install command with dynamic values files.
+
+# Disable SC2124 (unused array), SC2145 (array expansion issue), SC2294 (eval)
+# shellcheck disable=SC2124,SC2145,SC2294
+
+# Service
+SERVICE_NAME_DEFAULT="cert-manager"
+SERVICE_NAMESPACE="cert-manager"
+
+# Helm
+HELM_REPO_NAME_DEFAULT="cert-manager"
+HELM_REPO_URL_DEFAULT="https://charts.jetstack.io"
+
+
+# Base directories provided by the environment
+GENESTACK_BASE_DIR="${GENESTACK_BASE_DIR:-/opt/genestack}"
+GENESTACK_OVERRIDES_DIR="${GENESTACK_OVERRIDES_DIR:-/etc/genestack}"
+
+# Define service-specific override directories based on the framework
+SERVICE_BASE_OVERRIDES="${GENESTACK_BASE_DIR}/base-helm-configs/${SERVICE_NAME_DEFAULT}"
+SERVICE_CUSTOM_OVERRIDES="${GENESTACK_OVERRIDES_DIR}/helm-configs/${SERVICE_NAME_DEFAULT}"
+
+# Define the Global Overrides directory used in the original script
+GLOBAL_OVERRIDES_DIR="${GENESTACK_OVERRIDES_DIR}/helm-configs/global_overrides"
+
+# Read the desired chart version from VERSION_FILE
+VERSION_FILE="${GENESTACK_OVERRIDES_DIR}/helm-chart-versions.yaml"
+
+if [ ! -f "$VERSION_FILE" ]; then
+    echo "Error: helm-chart-versions.yaml not found at $VERSION_FILE" >&2
+    exit 1
+fi
+
+# Extract version dynamically using the SERVICE_NAME_DEFAULT variable
+SERVICE_VERSION=$(grep "^[[:space:]]*${SERVICE_NAME_DEFAULT}:" "$VERSION_FILE" | sed "s/.*${SERVICE_NAME_DEFAULT}: *//")
+
+if [ -z "$SERVICE_VERSION" ]; then
+    echo "Error: Could not extract version for '$SERVICE_NAME_DEFAULT' from $VERSION_FILE" >&2
+    exit 1
+fi
+
+echo "Found version for $SERVICE_NAME_DEFAULT: $SERVICE_VERSION"
+
+# Load chart metadata from custom override YAML if defined
+for yaml_file in "${SERVICE_CUSTOM_OVERRIDES}"/*.yaml; do
+    if [ -f "$yaml_file" ]; then
+        HELM_REPO_URL=$(yq eval '.chart.repo_url // ""' "$yaml_file")
+        HELM_REPO_NAME=$(yq eval '.chart.repo_name // ""' "$yaml_file")
+        SERVICE_NAME=$(yq eval '.chart.service_name // ""' "$yaml_file")
+        break  # use the first match and stop
+    fi
+done
+
+# Fallback to defaults if variables not set
+: "${HELM_REPO_URL:=$HELM_REPO_URL_DEFAULT}"
+: "${HELM_REPO_NAME:=$HELM_REPO_NAME_DEFAULT}"
+: "${SERVICE_NAME:=$SERVICE_NAME_DEFAULT}"
+
+
+# Determine Helm chart path
+if [[ "$HELM_REPO_URL" == oci://* ]]; then
+    # OCI registry path
+    HELM_CHART_PATH="$HELM_REPO_URL/$HELM_REPO_NAME/$SERVICE_NAME"
+else
+    # --- Helm Repository and Execution ---
+    helm repo add "$HELM_REPO_NAME" "$HELM_REPO_URL"   # uncomment if needed
+    helm repo update
+    HELM_CHART_PATH="$HELM_REPO_NAME/$SERVICE_NAME"
+fi
+
+# Debug output
+echo "[DEBUG] HELM_REPO_URL=$HELM_REPO_URL"
+echo "[DEBUG] HELM_REPO_NAME=$HELM_REPO_NAME"
+echo "[DEBUG] SERVICE_NAME=$SERVICE_NAME"
+echo "[DEBUG] HELM_CHART_PATH=$HELM_CHART_PATH"
+
+# Prepare an array to collect -f arguments
+overrides_args=()
+
+# Include all YAML files from the BASE configuration directory
+# NOTE: Files in this directory are included first.
+if [[ -d "$SERVICE_BASE_OVERRIDES" ]]; then
+    echo "Including base overrides from directory: $SERVICE_BASE_OVERRIDES"
+    for file in "$SERVICE_BASE_OVERRIDES"/*.yaml; do
+        # Check that there is at least one match
+        if [[ -e "$file" ]]; then
+            echo " - $file"
+            overrides_args+=("-f" "$file")
+        fi
+    done
+else
+    echo "Warning: Base override directory not found: $SERVICE_BASE_OVERRIDES"
+fi
+
+# Include all YAML files from the custom SERVICE configuration directory
+# NOTE: Files here have the highest precedence.
+if [[ -d "$SERVICE_CUSTOM_OVERRIDES" ]]; then
+    echo "Including overrides from service config directory: $SERVICE_CUSTOM_OVERRIDES"
+    for file in "$SERVICE_CUSTOM_OVERRIDES"/*.yaml; do
+        if [[ -e "$file" ]]; then
+            echo " - $file"
+            overrides_args+=("-f" "$file")
+        fi
+    done
+else
+    echo "Warning: Service overrides directory not found: $SERVICE_CUSTOM_OVERRIDES"
+fi
+
+echo
+
+# Collect all --set arguments, executing commands and quoting safely
+set_args=()
+
+
+helm_command=(
+    helm upgrade --install "$SERVICE_NAME_DEFAULT" "$HELM_CHART_PATH"
+    --version "${SERVICE_VERSION}"
+    --namespace="$SERVICE_NAMESPACE"
+    --timeout 120m
+    --create-namespace
+
+    "${overrides_args[@]}"
+    "${set_args[@]}"
+
+    # Post-renderer configuration
+    # NOTE: Cert-Manager doesn't typically require a post-renderer, but we keep it
+    # for template compliance.
+    --post-renderer "$GENESTACK_OVERRIDES_DIR/kustomize/kustomize.sh"
+    --post-renderer-args "$SERVICE_NAME_DEFAULT/overlay"
+
+    "$@"
+)
+
+echo "Executing Helm command (arguments are quoted safely):"
+printf '%q ' "${helm_command[@]}"
+echo
+
+# Execute the command directly from the array
+"${helm_command[@]}"

--- a/bin/setup-infrastructure.sh
+++ b/bin/setup-infrastructure.sh
@@ -124,6 +124,9 @@ kubectl apply -f /etc/genestack/manifests/longhorn/longhorn-general-storageclass
 # Deploy prometheus
 /opt/genestack/bin/install-kube-prometheus-stack.sh
 
+# Deploy cert-manager
+/opt/genestack/bin/install-cert-manager.sh
+
 # Deploy metallb
 kubectl apply -f /etc/genestack/manifests/metallb/metallb-namespace.yaml
 /opt/genestack/bin/install-metallb.sh
@@ -140,9 +143,9 @@ echo "Waiting for the envoyproxy-gateway to be available"
 kubectl -n envoyproxy-gateway-system wait --timeout=5m deployments.apps/envoy-gateway --for=condition=available
 /opt/genestack/bin/setup-envoy-gateway.sh -e ${ACME_EMAIL} -d ${GATEWAY_DOMAIN}
 
-# Run a rollout for cert-manager
+# Run check of cert-manager to be in "Running/Ready" state
 echo "Waiting for the cert-manager to be available"
-kubectl -n cert-manager wait --timeout=5m deployments.apps cert-manager --for=condition=available
+kubectl -n cert-manager wait --timeout=5m deployments.apps/cert-manager --for=condition=available
 
 # Deploy the Genestack secrets
 /opt/genestack/bin/create-secrets.sh

--- a/docs/infrastructure-cert-manager.md
+++ b/docs/infrastructure-cert-manager.md
@@ -1,0 +1,29 @@
+# Deploy Cert-Manager
+
+Cert Manager integrates with the Envoy Gateway API to automate the issuance, renewal, and management of TLS/SSL certificates within a cluster. This installation includes envoy gateway-api support and custom DNS server forwarders in the helm chart config.
+
+## Configure custom cert-manager DNS forwarders
+
+View the upstream chart Documentation [cert-manager helm](https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml) to configure custom-values.
+
+!!! Edit /etc/genestack/helm-configs/cert-manager/cert-manager/cert-manager-helm-overrides.yaml
+
+   ```bash
+   ---
+   dns01RecursiveNameservers: "8.8.8.8:53, 1.1.1.1:53" <-----CHANGE
+   dns01RecursiveNameserversOnly: true
+   ```
+
+## Run Cert-Manager deployment
+
+!!! example "Run the cert-manager deployment Script `/opt/genestack/bin/install-cert-manager.sh`"
+
+    ``` shell
+    --8<-- "bin/install-cert-manager.sh"
+    ```
+
+## Verify readiness with the following command
+
+``` shell
+kubectl -n cert-manager deployments.apps/cert-manager -w
+```

--- a/helm-chart-versions.yaml
+++ b/helm-chart-versions.yaml
@@ -5,6 +5,7 @@ charts:
   barbican-exporter: 0.1.0
   blazar: 2025.1.3+95bf0bf6e
   ceilometer: 2024.2.115+13651f45-628a320c
+  cert-manager: v1.19.2
   cinder: 2024.2.409+13651f45-628a320c
   cloudkitty: 2025.1.2+ebb1488dc
   envoyproxy-gateway: v1.5.3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -179,6 +179,7 @@ nav:
               - Longhorn: storage-longhorn.md
           - Infrastructure:
               - infrastructure-overview.md
+              - Cert-Manager: infrastructure-cert-manager.md
               - Namespace: infrastructure-namespace.md
               - MetalLB: infrastructure-metallb.md
               - Gateway API:

--- a/releasenotes/notes/cert-manager-e5fb4f035daab865.yaml
+++ b/releasenotes/notes/cert-manager-e5fb4f035daab865.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Allow other kubernetes deployment models including Talos k8s stack to include a
+    managed cert-manager helm chart. Decouple the cert-manager installation from the
+    base kubespray ansible roles and allow the official upstream charts to provide
+    chart and CRD updates including patched image rollouts. This includes envoy
+    gateway-api support and custom DNS server forwarders.


### PR DESCRIPTION
In an effort to allow for other base k8s installation models including Talos k8s rollout. Rackspace team plan to decouple the cert-manager installation from the base kubespray ansible roles and allow the official upstream charts to provide updates and patched image rollouts. This includes gateway-api support and custom DNS server forwarders

issue link: https://github.com/rackerlabs/genestack/issues/1344

