### PR TITLE
fix: Masakari Monitors use master tag from recent bug fix

### DIFF
--- a/base-helm-configs/masakari/masakari-helm-overrides.yaml
+++ b/base-helm-configs/masakari/masakari-helm-overrides.yaml
@@ -21,10 +21,10 @@ images:
     ks_user: ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest
     masakari_api: ghcr.io/rackerlabs/genestack-images/masakari:2024.1-latest
     masakari_engine: ghcr.io/rackerlabs/genestack-images/masakari:2024.1-latest
-    masakari_host_monitor: ghcr.io/rackerlabs/genestack-images/masakari-monitors:2024.1-latest
-    masakari_process_monitor: ghcr.io/rackerlabs/genestack-images/masakari-monitors:2024.1-latest
-    masakari_instance_monitor: ghcr.io/rackerlabs/genestack-images/masakari-monitors:2024.1-latest
-    masakari_introspective_instance_monitor: ghcr.io/rackerlabs/genestack-images/masakari-monitors:2024.1-latest
+    masakari_host_monitor: ghcr.io/rackerlabs/genestack-images/masakari-monitors:master-latest
+    masakari_process_monitor: ghcr.io/rackerlabs/genestack-images/masakari-monitors:master-latest
+    masakari_instance_monitor: ghcr.io/rackerlabs/genestack-images/masakari-monitors:master-latest
+    masakari_introspective_instance_monitor: ghcr.io/rackerlabs/genestack-images/masakari-monitors:master-latest
     rabbit_init: docker.io/rabbitmq:3.13-management
     dep_check: ghcr.io/rackerlabs/genestack-images/kubernetes-entrypoint:latest
   pull_policy: "IfNotPresent"


### PR DESCRIPTION
recent upstream patching of masakari-monitors is needed for host-monitor to work correctly for kubernetes check script needs to have the master tag from the genestack ghcr registry, since bug patch hasent been backported to 2024.1 or 2025.1. 