### PR TITLE
chore: Refining MariaDB and Magnum docs based on progressive work done

### DIFF
--- a/docs/mariadb-backuprestore-from-tempauth.md
+++ b/docs/mariadb-backuprestore-from-tempauth.md
@@ -1,30 +1,60 @@
 # MariaDB Restore Procedures with Swift Tempauth
 
-This document provides procedures to restore MariaDB backups stored in Rackspace's Swift object storage with tempauth for the production environments: DFW, SJC, and IAD as part of Jira:OSPC-1141. It details two methods: using theKubernetes Restore CRD with the MariaDB Operator and a manual restore using AWS S3 commands. These procedures ensure recovery from backups in the mariadb-backups container, based on the reference document present.
+This document provides procedures to restore MariaDB backups stored in Swift object storage with tempauth. It details two methods: using the Kubernetes Restore CRD with the MariaDB Operator and a manual restore using AWS S3 commands.
 
-## 1. Prerequisites 
-  ### Software:
-  - Kubernetes CLI (`kubectl`) installed and configured with access to the respective production   cluster (DFW, SJC, IAD).
-  - AWS CLI installed on the overseer node for each production environment (`pip install awscli awscli-plugin-endpoint`).
-  ### Credentials:
-  - Kubernetes secret (e.g., `dfw-credentials`, `sjc-credentials`, `iad-credentials`) with `access-key-id` and `secret-access-key` keys, generated via `openstack ec2 credentials create`.
-  - AWS CLI profiles (e.g., `dfw_admin`, `sjc_admin`, `iad_admin`) configured on the respective overseers.
-  ### Environment:
-  - Access to the Kubernetes cluster and overseer node for each production region.
-  - Network access to the region-specific Swift endpoint.
-  - MariaDB Operator deployed in each cluster with a `mariadb` resource.
+!!! abstract "Overview"
+    These procedures ensure recovery from backups in the `mariadb-backups` container for production environments (`Region-1`, `Region-2`, `Region-3`).
 
-## 2. Backup/Restore Flow
+---
+
+## :material-check-decagram: Prerequisites
+
+### :material-application: Software
+
+- Kubernetes CLI (`kubectl`) installed and configured with access to the respective production cluster
+- AWS CLI installed on the overseer node:
+
+    ```bash
+    pip install awscli awscli-plugin-endpoint
+    ```
+
+### :material-key: Credentials
+
+- Kubernetes secret (e.g., `region-1-credentials`, `region-2-credentials`, `region-3-credentials`) from cluster with `access-key-id` and `secret-access-key` keys, generated via:
+
+    ```bash
+    openstack ec2 credentials create
+    ```
+
+- AWS CLI profiles (e.g., `region-1_admin`, `region-2_admin`, `region-3_admin`) configured on the respective overseers
+
+    !!! info "Why AWS CLI for Swift?"
+        OpenStack Swift exposes an S3-compatible API (via `s3api` middleware), allowing the standard
+        AWS CLI to interact with Swift object storage. Each profile in `~/.aws/credentials` and
+        `~/.aws/config` stores the EC2-style access key, secret key, and the region-specific Swift
+        endpoint URL. The profile name encodes the site and role. From each overseer, use the
+        matching profile (`--profile <aws_cli_profile_name>`) to reach the local Swift endpoint.
+
+### :material-server-network: Environment
+
+- Access to the Kubernetes cluster and overseer node for each production region
+- Network access to the region-specific Swift endpoint
+- MariaDB Operator deployed in each cluster with a `mariadb` resource
+
+---
+
+## :material-swap-horizontal: Backup and Restore Flow
+
 ```mermaid
 graph TD
 
     subgraph Locations
-        I[DFW]
-        J[SJC]
-        K[IAD]
+        I[Region-1]
+        J[Region-2]
+        K[Region-3]
     end
 
-    A["Kubernetes Cluster<br>DFW, SJC, IAD"] --> B[MariaDB Instances]
+    A["Kubernetes Cluster<br>Region-1, Region-2, Region-3"] --> B[MariaDB Instances]
     B -->|Backup Data| C[MariaDB Operator]
     C -->|Create Backup| D[Backup CRD]
     D -->|Store Backup| E["Swift Object Storage<br>mariadb-backups"]
@@ -40,146 +70,214 @@ graph TD
     K --> A
 ```
 
-## 3. Restore Using Kubernetes `Restore` CRD
-### CRD(Custom Resource Definition)
-- The Restore CRD is a Custom Resource Definintion, a kubernetes feature that extend the API to define custom resources for managing restore operations. For detailed information on CRD, refers to the [Kubernetes Documentation on Custom Resources.](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
+---
+
+## :material-database-import: Restore Using Kubernetes Restore CRD
 
 This method automates the restore process using the MariaDB Operator, applicable to all production regions.
 
- ### 3.1 Backup and Restore of Specific Databases
-    Backup Context: Backups are created with the Backup resource, which by default includes all logical databases. To back up specific databases, the databases field can be used (e.g., db1, db2, db3), influencing the content available for restoration. For detailed backup creation, refer to the backup documentation or administrator.
+!!! info "What is a Restore CRD?"
+    The Restore CRD is a Custom Resource Definition — a Kubernetes feature that extends the API to define custom resources for managing restore operations. For detailed information, refer to the [Kubernetes Documentation on Custom Resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 
-    Restore Configuration: By default, all databases in the backup are restored. To restore a single database, specify the database field in the Restore resource:
- 
-   ``` yaml
-   apiVersion: k8s.mariadb.com/v1alpha1
-   kind: Restore
-   metadata:
-     name: restore
-   spec:
-     mariaDbRef:
-       name: mariadb
-     backupRef:
-       name: backup
-     database: db1
-   ```
- ### 3.2 Procedure
- #### 1. Configure the Restore CRD:
-      Create a file named `restore.yaml` with the following content, adjusting the region-specific details:
+### :material-database-search: Backup and Restore of Specific Databases
 
-      ``` yaml
-      apiVersion: k8s.mariadb.com/v1alpha1
-      kind: Restore
-      metadata:
-        name: maria-restore
-        namespace: <namespace>  # Replace with the actual namespace (e.g., default or mariadb)
-      spec:
-        mariaDbRef:
-          name: mariadb  # Must match the existing MariaDB resource name
-        s3:
-          bucket: mariadb-backups
-          prefix: cron
-          endpoint: <region-endpoint>  # See table below
-          accessKeyIdSecretKeyRef:
-            name: <region-credentials>  # e.g., dfw-credentials
-            key: access-key-id
-          secretAccessKeySecretKeyRef:
-            name: <region-credentials>  # e.g., dfw-credentials
-            key: secret-access-key
-        database: <database_name>  # e.g., nova
-      ```
+Backups are created with the Backup resource, which by default includes all logical databases. To back up specific databases, the `databases` field can be used (e.g., `db1`, `db2`, `db3`), influencing the content available for restoration.
 
-      Replace <namespace> and <region-credentials> with the appropriate values for each environment.
-      Use the following region-specific endpoints:
+By default, all databases in the backup are restored. To restore a single database, specify the `database` field in the Restore resource:
 
-      | Region | Environment | Endpoint                                      | Profile   | Credential Secret |
-      |--------|-------------|-----------------------------------------------|-----------|-------------------|
-      | DFW    | DFW         | https://swift.api.dfw3.rackspacecloud.com     | dfw_admin | dfw-credentials   |
-      | SJC    | SJC         | https://swift.api.sjc3.rackspacecloud.com     | sjc_admin | sjc-credentials   |
-      | IAD    | IAD         | https://swift.api.iad3.rackspacecloud.com     | iad_admin | iad-credentials   |
+```yaml
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Restore
+metadata:
+  name: restore
+spec:
+  mariaDbRef:
+    name: mariadb
+  backupRef:
+    name: backup
+  database: db1
+```
 
-  #### 2. Apply the CRD:
-     Execute the deployement:
-     ```shell
-     kubectl apply -f restore.yaml
-     ```
-  #### 3. Monitor the Restore:
-    Check the status:
-    ```shell
-    kubectl describe restore maria-restore -n <namespace>.
+### :material-cog: Procedure
+
+#### Step 1: Configure the Restore CRD
+
+Create a file named `restore.yaml` with the following content, adjusting the region-specific details:
+
+```yaml
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Restore
+metadata:
+  name: maria-restore
+  namespace: <namespace>  # Replace with the actual namespace (e.g., default or mariadb)
+spec:
+  mariaDbRef:
+    name: mariadb  # Must match the existing MariaDB resource name
+  s3:
+    bucket: mariadb-backups
+    prefix: cron
+    endpoint: <region-endpoint>  # See table below
+    accessKeyIdSecretKeyRef:
+      name: <region-credentials>  # e.g., Region-1 credentials
+      key: access-key-id
+    secretAccessKeySecretKeyRef:
+      name: <region-credentials>  # e.g., Region-1 credentials
+      key: secret-access-key
+  database: <database_name>  # e.g., nova
+```
+
+Replace `<namespace>` and `<region-credentials>` with the appropriate values for each environment.
+
+#### Step 2: Apply the CRD
+
+```bash
+kubectl apply -f restore.yaml
+```
+
+#### Step 3: Monitor the Restore
+
+=== "Check Status"
+
+    ```bash
+    kubectl describe restore maria-restore -n <namespace>
     ```
-    Here the resource type : restore
-    resource name : maria-restore
-    
-    Monitor logs:
-    ```shell
-    kubectl logs -f <operator-pod-name> -n <namespace> .
+
+=== "Monitor Logs"
+
+    ```bash
+    kubectl logs -f <operator-pod-name> -n <namespace>
     ```
-    Identify the pod with kubectl get pods
-    Wait for the status to change to Succeeded.
-  #### 4. Verify Restore:
-    Access the mariadb Pod:
-    ```shell
-    kubectl exec -it <mariadb-pod-name> -n <namespace> -- mysql -u root -p.
+
+    Identify the pod with `kubectl get pods`. Wait for the status to change to `Succeeded`.
+
+#### Step 4: Verify Restore
+
+```bash
+kubectl exec -it <mariadb-pod-name> -n <namespace> -- mysql -u root -p
+```
+
+Run a query to confirm data:
+
+```sql
+SELECT COUNT(*) FROM <table_name>;
+```
+
+!!! note
+    Ensure the region-specific credentials secret exists:
+
+    ```bash
+    kubectl get secret <region-credentials> -n <namespace> -o yaml
     ```
-    Run a query: SELECT COUNT(*) FROM <table_name>; (e.g., nova.instances) to confirm data.
-  
-  **Notes:**
-    Ensure the region-specific credentials secret exists: kubectl get secret <region-credentials> -n <namespace> -o yaml.
-  
-  **Note:** This procedure some reference present in <https://github.com/rackerlabs/genestack/blob/55dedc9b4217967e1efc2ec3182e67758cc056d4/docs/infrastructure-mariadb-ops.md?plain=1>
 
-## 4. Manual Restore Using AWS S3 Commands
-  This method retrieves the backup from the overseer and restores it manually, applicable to all production regions as a fallback.
-  
-  ### Steps:
-  #### 1. Access the Region-Specific Overseer:
-          Log in to the overseer node (e.g., ssh user@dfw-prod-overseer-ip or any available method which is allowed to login into DFW Prod in a secured manner).
-  #### 2.Verify AWS CLI Configuration:
-          Ensure the region-specific profile is set up (e.g., dfw_admin for DFW):
-          ```yaml
-          [profile dfw_admin]
-          region = dfw
-          s3 =
-          endpoint_url = https://swift.api.dfw.rackspacecloud.com
-          signature_version = s3v4
-         ```
-         ```yaml
-         [dfw_admin]
-         aws_access_key_id = YOUR_ACCESS_KEY
-         aws_secret_access_key = YOUR_SECRET_KEY
-        ```
-        Adjust for SJC (sjc_admin), IAD (iad_admin) with their endpoints (see table above).
-        Test with below command to list backups:
-        ```shell
-        aws --profile <region>_admin s3 ls s3://mariadb-backups/ .
-        ```
-   #### 3. Retrieve the Backup:
-        List available backups: aws --profile <region>_admin s3 ls s3://mariadb-backups/cron/.
-        Download a specific backup:
-        As a example given here:
-        ```shell
-         aws --profile dfw_admin s3 cp s3://mariadb-backups/cron/backup.2025-02-04T19:05:57Z.gzip.sql /tmp/backup.2025-02-04T19:05:57Z.gzip.sql
-        ```
-        Note: Need to replace the particular file to download as per the requirement. 
-   #### 4. Restore the Backup:
-        Access a test MariaDB instance (e.g., via kubectl exec or a local DB): mysql -u user -p < backup.2025-02-04T19:05:57Z.gzip.sql.
-  #### 5. Single Database Restore:
-        If the backup contains multiple databases, extract the desired database (e.g., nova) using a tool like sed or mysql filters, then restore: mysql -u user -p nova < nova_backup.sql.
-  #### 6. Verify:
-        Check the return code: echo $? (0 indicates success).
-        Query the database: mysql -u user -p -e "SELECT COUNT(*) FROM <table_name>;".
-    
-  **Notes:**
-     Ensure the overseer has network access to the region-specific Swift endpoint.
+!!! tip "Reference"
+    This procedure references the [MariaDB operations guide](https://github.com/rackerlabs/genestack/blob/main/docs/infrastructure-mariadb-ops.md).
 
- **Before applying/executing into Production, First need to apply these commands on DEV or staging environment.**
+---
 
-## 5. References
-  ### https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/BACKUP.md
-  ### https://docs.rackspacecloud.com/storage-object-store-s3-cli/
-  ### https://mariadb.com/docs/server/server-usage/backup-and-restore/backup-and-restore-overview
- 
-## 6. Escalation:
-  If validation fails, coordinate with Admin Team or Data Base team to resolve network or any related configuration  issues.\
-  **Note: This step might be extended further**
+## :material-console: Manual Restore Using AWS S3 Commands
+
+This method retrieves the backup from the overseer and restores it manually, applicable to all production regions as a fallback.
+
+!!! warning
+    Before applying or executing in production, first test these commands in a DEV or staging environment.
+
+### Step 1: Access the Region-Specific Overseer
+
+Log in to the overseer node for your region:
+
+```bash
+ssh user@<region>-overseer-ip
+```
+
+### Step 2: Verify AWS CLI Configuration
+
+Ensure the region-specific profile is set up:
+
+=== "Config (~/.aws/config)"
+
+    ```ini
+    [profile region-1_admin]
+    region = region-1
+    s3 =
+      endpoint_url = https://swift.api.region-1.rackspacecloud.com
+      signature_version = s3v4
+    ```
+
+=== "Credentials (~/.aws/credentials)"
+
+    ```ini
+    [region-1_admin]
+    aws_access_key_id = YOUR_ACCESS_KEY
+    aws_secret_access_key = YOUR_SECRET_KEY
+    ```
+
+Adjust for Region-2 (`region-2_admin`) and Region-3 (`region-3_admin`) with their respective endpoints from the table above.
+
+Test by listing backups:
+
+```bash
+aws --profile <region>_admin s3 ls s3://mariadb-backups/
+```
+
+### Step 3: Retrieve the Backup
+
+List available backups:
+
+```bash
+aws --profile <region>_admin s3 ls s3://mariadb-backups/cron/
+```
+
+Download a specific backup:
+
+```bash
+aws --profile region-1_admin s3 cp \
+  s3://mariadb-backups/cron/backup.2025-02-04T19:05:57Z.gzip.sql \
+  /tmp/backup.2025-02-04T19:05:57Z.gzip.sql
+```
+
+!!! note
+    Replace the filename with the specific backup you need to restore.
+
+### Step 4: Restore the Backup
+
+```bash
+mysql -u user -p < /tmp/backup.2025-02-04T19:05:57Z.gzip.sql
+```
+
+### Step 5: Single Database Restore (Optional)
+
+If the backup contains multiple databases, extract the desired database (e.g., `nova`) using `sed` or mysql filters, then restore:
+
+```bash
+mysql -u user -p nova < nova_backup.sql
+```
+
+### Step 6: Verify
+
+```bash
+# Check return code (0 indicates success)
+echo $?
+
+# Query the database
+mysql -u user -p -e "SELECT COUNT(*) FROM <table_name>;"
+```
+
+!!! note
+    Ensure the overseer has network access to the region-specific Swift endpoint.
+
+---
+
+## :material-book-open-variant: References
+
+- [MariaDB Operator Backup Documentation](https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/BACKUP.md)
+- [Rackspace Object Storage S3 CLI](https://docs.rackspacecloud.com/storage-object-store-s3-cli/)
+- [MariaDB Backup and Restore Overview](https://mariadb.com/docs/server/server-usage/backup-and-restore/backup-and-restore-overview)
+
+---
+
+## :material-phone: Escalation
+
+!!! danger "Validation Failure"
+    If validation fails, coordinate with the Admin Team or Database Team to resolve network or configuration issues.
+
+    This escalation step may be extended further as procedures evolve.

--- a/docs/openstack-magnum.md
+++ b/docs/openstack-magnum.md
@@ -59,28 +59,100 @@ graph TB
 
 #### Create Management Cluster VM's
 
-!!! note "Openstack as a Platform for Creating Management VM"
-    If these VM's are to be created as admin tenant on openstack, A relevant flavor needs to be created with the following recommendations.
+The management cluster infrastructure (project, network, instances, load balancer, etc.) can be provisioned automatically using the `capi_cluster` Ansible role included in Genestack, or manually if you prefer full control.
 
-- CPU: 12 vCPU per VM
-- Memory: 16 GB per VM
-- Disk: Minimum 100GB disk
+=== "Automated (Recommended)"
 
-Following Disk Size/Paritioning is an example only:
+    The `capi_cluster` Ansible role automates the entire infrastructure setup including:
 
-| Mount point      | Capacity | FS    | VG                       | LV           | Disk |
-|------------------|----------|-------|--------------------------|--------------|------|
-| `/boot`          | 1GB      | ext4  | -                        | -            | sda  |
-| `/boot/efi`      | 256MB    | fat32 | -                        | -            | sda  |
-| `/home`          | 10GB     | ext4  | vglocal00                | lv-home      | sda  |
-| `/`              | 100GB    | ext4  | vglocal00                | lv-root      | sda  |
-| `/opt`           | 10GB     | ext4  | vglocal00                | lv-opt       | sda  |
-| `/root`          | 20GB     | ext4  | vglocal00                | lv-home-root | sda  |
-| `/tmp`           | 10GB     | ext4  | vglocal00                | lv-tmp       | sda  |
-| `/var`           | 50GB     | ext4  | vglocal00                | lv-var       | sda  |
-| `/var/log`       | 50GB     | ext4  | vglocal00                | lv-log       | sda  |
-| `/var/lib/kubelet` | 50GB   | ext4  | vglocal00                | lv-kubelet   | sda  |
-| `/var/lib/etcd`  | 50GB     | ext4  | vglocal00                | -            | sdb  |
+    - OpenStack project and user creation (in the `service` domain)
+    - Network, subnet, router, and security group provisioning
+    - Flavor, image (Ubuntu 24.04), keypair, and volume creation
+    - Octavia load balancer for the Kubernetes API
+    - Boot-from-volume instance provisioning (3 nodes)
+    - Kubespray-based Kubernetes cluster installation
+    - CAPI component initialization and etcd backup configuration
+
+    !!! warning "Prerequisites for the Ansible Role"
+        - Cinder volume service must be enabled (role uses boot-from-volume instances)
+        - A pre-created shared external Neutron network (flat or VLAN)
+        - Keystone admin credentials
+        - Octavia service enabled (role creates a load balancer)
+        - DNS server reachable from the external network that can resolve OpenStack service endpoints
+        - OpenStack SDK installed on the Ansible control node (the Genestack venv is sufficient)
+        - Sufficient Glance storage for the Ubuntu 24.04 image upload
+        - If OpenStack endpoints are behind a TLS gateway, certificates must be signed by a well-known CA (self-signed certs will cause failures)
+
+    Run the playbook from the Genestack ansible playbooks directory:
+
+    ```bash
+    cd /opt/genestack/ansible/playbooks
+
+    ansible-playbook capi-mgmt-cluster-main.yaml \
+      -e os_admin_password=<keystone_admin_password> \
+      -e os_user_password=<capi_mgmt_user_password> \
+      -e ext_net_id='<external_network_uuid>'
+    ```
+
+    | Parameter | Description |
+    |-----------|-------------|
+    | `os_admin_password` | Keystone admin user password |
+    | `os_user_password` | Password for the new CAPI management user |
+    | `ext_net_id` | UUID of the pre-existing external Neutron network |
+
+    ??? info "Key Role Variables (Customizable)"
+        Override these via `-e` flags or by editing `ansible/roles/capi_cluster/defaults/main.yml`:
+
+        | Variable | Default | Description |
+        |----------|---------|-------------|
+        | `capi_mgmt_subnet_cidr` | `172.16.51.0/24` | Subnet CIDR for management network |
+        | `capi_mgmt_dns_servers` | `10.239.0.55` | DNS server for the management cluster |
+        | `capi_mgmt_cluster_flavor.vcpus` | `4` | vCPUs per management VM |
+        | `capi_mgmt_cluster_flavor.ram` | `4096` | RAM (MB) per management VM |
+        | `capi_mgmt_cluster_volume_type` | `lvmdriver-1` | Cinder volume type for boot volumes |
+        | `capi_mgmt_cluster_volumes[].size` | `15` | Boot volume size (GB) per instance |
+        | `capi_mgmt_etcd_backup_volume.size` | `5` | etcd backup volume size (GB) |
+        | `capi_boot_from_volume` | `true` | Boot instances from Cinder volumes |
+        | `capi_mgmt_dns_forwarders` | `[10.239.0.55]` | DNS forwarders for CoreDNS |
+
+        Refer to `ansible/roles/capi_cluster/defaults/main.yml` for the full list of variables.
+
+    The playbook will:
+
+    1. Create the `capi-mgmt-cluster-project` in the `service` domain with appropriate quotas
+    2. Provision all OpenStack infrastructure (network, LB, instances, etc.)
+    3. Install Kubernetes via Kubespray on the 3 management VMs
+    4. Copy the kubeconfig to `/var/tmp/capi_mgmt_cluster.kubeconfig` on the control node
+
+    !!! success "After Completion"
+        Once the playbook finishes, skip ahead to [Install clusterctl](#install-clusterctl) to continue with CAPI initialization. The Kubespray installation, Python venv setup, and cluster configuration steps below are handled by the role.
+
+=== "Manual"
+
+    If you prefer to provision the management cluster VMs manually, follow the steps below.
+
+    !!! note "OpenStack as a Platform for Creating Management VMs"
+        If these VMs are to be created as admin tenant on OpenStack, a relevant flavor needs to be created with the following recommendations.
+
+    - CPU: 12 vCPU per VM
+    - Memory: 16 GB per VM
+    - Disk: Minimum 100GB disk
+
+    Following Disk Size/Partitioning is an example only:
+
+    | Mount point      | Capacity | FS    | VG                       | LV           | Disk |
+    |------------------|----------|-------|--------------------------|--------------|------|
+    | `/boot`          | 1GB      | ext4  | -                        | -            | sda  |
+    | `/boot/efi`      | 256MB    | fat32 | -                        | -            | sda  |
+    | `/home`          | 10GB     | ext4  | vglocal00                | lv-home      | sda  |
+    | `/`              | 100GB    | ext4  | vglocal00                | lv-root      | sda  |
+    | `/opt`           | 10GB     | ext4  | vglocal00                | lv-opt       | sda  |
+    | `/root`          | 20GB     | ext4  | vglocal00                | lv-home-root | sda  |
+    | `/tmp`           | 10GB     | ext4  | vglocal00                | lv-tmp       | sda  |
+    | `/var`           | 50GB     | ext4  | vglocal00                | lv-var       | sda  |
+    | `/var/log`       | 50GB     | ext4  | vglocal00                | lv-log       | sda  |
+    | `/var/lib/kubelet` | 50GB   | ext4  | vglocal00                | lv-kubelet   | sda  |
+    | `/var/lib/etcd`  | 50GB     | ext4  | vglocal00                | -            | sdb  |
 
 #### Verify Python 3 is installed on all master nodes in the management cluster.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -278,6 +278,7 @@ nav:
           - MariaDB:
               - Operations: infrastructure-mariadb-ops.md
               - Restore with Swift Tempauth: mariadb-backuprestore-from-tempauth.md
+              - MariaDB Operator Upgrade Runbook: openstack-mariadb-operator-upgrade.md
           - Gateway API:
               - Creating Security Policies: infrastructure-envoy-gateway-api-security.md
       - Observability:


### PR DESCRIPTION
- Got rid of sensitive info from mariadb-backuprestore-tempauth doc
- Formated mariadb-tempauth as per mkdocs markdown
- Added info in magnum doc for [Ansible role-based CAPI Management Cluster VM creation](https://github.com/rackerlabs/genestack/pull/1465)