### PR TITLE
Fix: cinder-rootwrap provided by pip package

### DIFF
--- a/base-helm-configs/cinder/cinder-helm-overrides.yaml
+++ b/base-helm-configs/cinder/cinder-helm-overrides.yaml
@@ -203,16 +203,14 @@ conf:
         - volume
       content: |
         # cinder-rootwrap command filters for volume nodes
+        # Based on cinder 2025.1 pip-installed volume.filters
+        # with lvresize added for cinder-rxt LUKS header margin reclamation
         # This file should be owned by (and only-writeable by) the root user
 
         [Filters]
-        # cinder/volume/iscsi.py: iscsi_helper '--op' ...
-        ietadm: CommandFilter, ietadm, root
-        tgtadm: CommandFilter, tgtadm, root
+        # cinder/volume/targets/iscsi.py: target_helper '--op' ...
         iscsictl: CommandFilter, iscsictl, root
-        tgt-admin: CommandFilter, tgt-admin, root
         cinder-rtstool: CommandFilter, cinder-rtstool, root
-        scstadmin: CommandFilter, scstadmin, root
 
         # LVM related show commands
         pvs: EnvFilter, env, root, LC_ALL=C, pvs
@@ -221,40 +219,30 @@ conf:
         lvdisplay: EnvFilter, env, root, LC_ALL=C, lvdisplay
 
         # -LVM related show commands with suppress fd warnings
-        pvs_fdwarn: EnvFilter, env, root, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, pvs
-        vgs_fdwarn: EnvFilter, env, root, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, vgs
-        lvs_fdwarn: EnvFilter, env, root, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, lvs
-        lvdisplay_fdwarn: EnvFilter, env, root, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, lvdisplay
-
+        pvs2: EnvFilter, env, root, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, pvs
+        vgs2: EnvFilter, env, root, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, vgs
+        lvs2: EnvFilter, env, root, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, lvs
+        lvdisplay2: EnvFilter, env, root, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, lvdisplay
 
         # -LVM related show commands conf var
-        pvs_lvmconf: EnvFilter, env, root, LVM_SYSTEM_DIR=, LC_ALL=C, pvs
-        vgs_lvmconf: EnvFilter, env, root, LVM_SYSTEM_DIR=, LC_ALL=C, vgs
-        lvs_lvmconf: EnvFilter, env, root, LVM_SYSTEM_DIR=, LC_ALL=C, lvs
-        lvdisplay_lvmconf: EnvFilter, env, root, LVM_SYSTEM_DIR=, LC_ALL=C, lvdisplay
+        pvs3: EnvFilter, env, root, LC_ALL=C, LVM_SYSTEM_DIR=, pvs
+        vgs3: EnvFilter, env, root, LC_ALL=C, LVM_SYSTEM_DIR=, vgs
+        lvs3: EnvFilter, env, root, LC_ALL=C, LVM_SYSTEM_DIR=, lvs
+        lvdisplay3: EnvFilter, env, root, LC_ALL=C, LVM_SYSTEM_DIR=, lvdisplay
 
         # -LVM conf var with suppress fd_warnings
-        pvs_lvmconf: EnvFilter, env, root, LVM_SYSTEM_DIR=, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, pvs
-        vgs_lvmconf: EnvFilter, env, root, LVM_SYSTEM_DIR=, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, vgs
-        lvs_lvmconf: EnvFilter, env, root, LVM_SYSTEM_DIR=, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, lvs
-        lvdisplay_lvmconf: EnvFilter, env, root, LVM_SYSTEM_DIR=, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, lvdisplay
+        pvs4: EnvFilter, env, root, LC_ALL=C, LVM_SYSTEM_DIR=, LVM_SUPPRESS_FD_WARNINGS=, pvs
+        vgs4: EnvFilter, env, root, LC_ALL=C, LVM_SYSTEM_DIR=, LVM_SUPPRESS_FD_WARNINGS=, vgs
+        lvs4: EnvFilter, env, root, LC_ALL=C, LVM_SYSTEM_DIR=, LVM_SUPPRESS_FD_WARNINGS=, lvs
+        lvdisplay4: EnvFilter, env, root, LC_ALL=C, LVM_SYSTEM_DIR=, LVM_SUPPRESS_FD_WARNINGS=, lvdisplay
 
         # os-brick library commands
-        # os_brick.privileged.run_as_root oslo.privsep context
-        # This line ties the superuser privs with the config files, context name,
-        # and (implicitly) the actual python code invoked.
         privsep-rootwrap: RegExpFilter, privsep-helper, root, privsep-helper, --config-file, /etc/(?!\.\.).*, --privsep_context, os_brick.privileged.default, --privsep_sock_path, /tmp/.*
-        # The following and any cinder/brick/* entries should all be obsoleted
-        # by privsep, and may be removed once the os-brick version requirement
-        # is updated appropriately.
-        scsi_id: CommandFilter, /lib/udev/scsi_id, root
-        drbdadm: CommandFilter, drbdadm, root
 
-        # cinder/brick/local_dev/lvm.py: 'vgcreate', vg_name, pv_list
-        vgcreate: CommandFilter, vgcreate, root
+        # Privsep calls within cinder itself
+        privsep-rootwrap-sys_admin: RegExpFilter, privsep-helper, root, privsep-helper, --config-file, /etc/(?!\.\.).*, --privsep_context, cinder.privsep.sys_admin_pctxt, --privsep_sock_path, /tmp/.*
 
         # cinder/brick/local_dev/lvm.py: 'lvcreate', '-L', sizestr, '-n', volume_name,..
-        # cinder/brick/local_dev/lvm.py: 'lvcreate', '-L', ...
         lvcreate: EnvFilter, env, root, LC_ALL=C, lvcreate
         lvcreate_lvmconf: EnvFilter, env, root, LVM_SYSTEM_DIR=, LC_ALL=C, lvcreate
         lvcreate_fdwarn: EnvFilter, env, root, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, lvcreate
@@ -266,11 +254,7 @@ conf:
         # cinder/volume/driver.py: 'lvremove', '-f', %s/%s % ...
         lvremove: CommandFilter, lvremove, root
 
-        # cinder/volume/driver.py: 'lvrename', '%(vg)s', '%(orig)s' '(new)s'...
-        lvrename: CommandFilter, lvrename, root
-
-        # cinder/brick/local_dev/lvm.py: 'lvextend', '-L' '%(new_size)s', '%(lv_name)s' ...
-        # cinder/brick/local_dev/lvm.py: 'lvextend', '-L' '%(new_size)s', '%(thin_pool)s' ...
+        # cinder/brick/local_dev/lvm.py: 'lvextend', '-L' '%(new_size)s', ...
         lvextend: EnvFilter, env, root, LC_ALL=C, lvextend
         lvextend_lvmconf: EnvFilter, env, root, LVM_SYSTEM_DIR=, LC_ALL=C, lvextend
         lvextend_fdwarn: EnvFilter, env, root, LC_ALL=C, LVM_SUPPRESS_FD_WARNINGS=, lvextend
@@ -283,11 +267,7 @@ conf:
         # Used for LUKS header margin reclamation after encrypted image copy
         lvresize: CommandFilter, lvresize, root
 
-        # cinder/brick/local_dev/lvm.py: 'lvconvert', '--merge', snapshot_name
-        lvconvert: CommandFilter, lvconvert, root
-
         # cinder/volume/driver.py: 'iscsiadm', '-m', 'discovery', '-t',...
-        # cinder/volume/driver.py: 'iscsiadm', '-m', 'node', '-T', ...
         iscsiadm: CommandFilter, iscsiadm, root
 
         # cinder/volume/utils.py: utils.temporary_chown(path, 0)
@@ -298,22 +278,13 @@ conf:
         ionice_2: ChainingRegExpFilter, ionice, root, ionice, -c[0-3]
 
         # cinder/volume/utils.py: setup_blkio_cgroup()
-        cgcreate: CommandFilter, cgcreate, root
-        cgset: CommandFilter, cgset, root
         cgexec: ChainingRegExpFilter, cgexec, root, cgexec, -g, blkio:\S+
-
-        # cinder/volume/driver.py
-        dmsetup: CommandFilter, dmsetup, root
-        ln: CommandFilter, ln, root
 
         # cinder/image/image_utils.py
         qemu-img: EnvFilter, env, root, LC_ALL=C, qemu-img
         qemu-img_convert: CommandFilter, qemu-img, root
-
-        udevadm: CommandFilter, udevadm, root
-
-        # cinder/volume/driver.py: utils.read_file_as_root()
-        cat: CommandFilter, cat, root
+        qzip: CommandFilter, qzip, root
+        gzip: CommandFilter, gzip, root
 
         # cinder/volume/nfs.py
         stat: CommandFilter, stat, root
@@ -324,112 +295,55 @@ conf:
         chmod: CommandFilter, chmod, root
         rm: CommandFilter, rm, root
 
-        # cinder/volume/drivers/remotefs.py
-        mkdir: CommandFilter, mkdir, root
-
-        # cinder/volume/drivers/netapp/nfs.py:
+        # cinder/volume/drivers/netapp/dataontap/nfs_base.py:
         netapp_nfs_find: RegExpFilter, find, root, find, ^[/]*([^/\0]+(/+)?)*$, -maxdepth, \d+, -name, img-cache.*, -amin, \+\d+
 
-        # cinder/volume/drivers/glusterfs.py
+        # cinder/backup/drivers/nfs.py
+        # cinder/backup/drivers/glusterfs.py
         chgrp: CommandFilter, chgrp, root
-        umount: CommandFilter, umount, root
-        fallocate: CommandFilter, fallocate, root
-
-        # cinder/volumes/drivers/hds/hds.py:
-        hus-cmd: CommandFilter, hus-cmd, root
-        hus-cmd_local: CommandFilter, /usr/local/bin/hus-cmd, root
-
-        # cinder/volumes/drivers/hds/hnas_backend.py
-        ssc: CommandFilter, ssc, root
 
         # cinder/brick/initiator/connector.py:
         ls: CommandFilter, ls, root
-        tee: CommandFilter, tee, root
         multipath: CommandFilter, multipath, root
         multipathd: CommandFilter, multipathd, root
-        systool: CommandFilter, systool, root
-
-        # cinder/volume/drivers/block_device.py
-        blockdev: CommandFilter, blockdev, root
 
         # cinder/volume/drivers/ibm/gpfs.py
-        # cinder/volume/drivers/tintri.py
+        # cinder/volume/drivers/netapp/dataontap/nfs_base.py
         mv: CommandFilter, mv, root
 
         # cinder/volume/drivers/ibm/gpfs.py
         cp: CommandFilter, cp, root
-        mmgetstate: CommandFilter, /usr/lpp/mmfs/bin/mmgetstate, root
-        mmclone: CommandFilter, /usr/lpp/mmfs/bin/mmclone, root
-        mmlsattr: CommandFilter, /usr/lpp/mmfs/bin/mmlsattr, root
-        mmchattr: CommandFilter, /usr/lpp/mmfs/bin/mmchattr, root
-        mmlsconfig: CommandFilter, /usr/lpp/mmfs/bin/mmlsconfig, root
-        mmlsfs: CommandFilter, /usr/lpp/mmfs/bin/mmlsfs, root
-        mmlspool: CommandFilter, /usr/lpp/mmfs/bin/mmlspool, root
+        mmgetstate: CommandFilter, mmgetstate, root
+        mmclone: CommandFilter, mmclone, root
+        mmlsattr: CommandFilter, mmlsattr, root
+        mmchattr: CommandFilter, mmchattr, root
+        mmlsconfig: CommandFilter, mmlsconfig, root
+        mmlsfs: CommandFilter, mmlsfs, root
+        mmlspool: CommandFilter, mmlspool, root
         mkfs: CommandFilter, mkfs, root
-        mmcrfileset: CommandFilter, /usr/lpp/mmfs/bin/mmcrfileset, root
-        mmlinkfileset: CommandFilter, /usr/lpp/mmfs/bin/mmlinkfileset, root
-        mmunlinkfileset: CommandFilter, /usr/lpp/mmfs/bin/mmunlinkfileset, root
-        mmdelfileset: CommandFilter, /usr/lpp/mmfs/bin/mmdelfileset, root
-        mmcrsnapshot: CommandFilter, /usr/lpp/mmfs/bin/mmcrsnapshot, root
-        mmdelsnapshot: CommandFilter, /usr/lpp/mmfs/bin/mmdelsnapshot, root
+        mmcrfileset: CommandFilter, mmcrfileset, root
+        mmlsfileset: CommandFilter, mmlsfileset, root
+        mmlinkfileset: CommandFilter, mmlinkfileset, root
+        mmunlinkfileset: CommandFilter, mmunlinkfileset, root
+        mmdelfileset: CommandFilter, mmdelfileset, root
 
         # cinder/volume/drivers/ibm/gpfs.py
-        # cinder/volume/drivers/ibm/ibmnas.py
         find_maxdepth_inum: RegExpFilter, find, root, find, ^[/]*([^/\0]+(/+)?)*$, -maxdepth, \d+, -ignore_readdir_race, -inum, \d+, -print0, -quit
-
-        # cinder/brick/initiator/connector.py:
-        aoe-revalidate: CommandFilter, aoe-revalidate, root
-        aoe-discover: CommandFilter, aoe-discover, root
-        aoe-flush: CommandFilter, aoe-flush, root
-
-        # cinder/brick/initiator/linuxscsi.py:
-        sg_scan: CommandFilter, sg_scan, root
-
-        #cinder/backup/services/tsm.py
-        dsmc:CommandFilter,/usr/bin/dsmc,root
-
-        # cinder/volume/drivers/hitachi/hbsd_horcm.py
-        raidqry: CommandFilter, raidqry, root
-        raidcom: CommandFilter, raidcom, root
-        pairsplit: CommandFilter, pairsplit, root
-        paircreate: CommandFilter, paircreate, root
-        pairdisplay: CommandFilter, pairdisplay, root
-        pairevtwait: CommandFilter, pairevtwait, root
-        horcmstart.sh: CommandFilter, horcmstart.sh, root
-        horcmshutdown.sh: CommandFilter, horcmshutdown.sh, root
-        horcmgr: EnvFilter, env, root, HORCMINST=, /etc/horcmgr
-
-        # cinder/volume/drivers/hitachi/hbsd_snm2.py
-        auman: EnvFilter, env, root, LANG=, STONAVM_HOME=, LD_LIBRARY_PATH=, STONAVM_RSP_PASS=, STONAVM_ACT=, /usr/stonavm/auman
-        auluref: EnvFilter, env, root, LANG=, STONAVM_HOME=, LD_LIBRARY_PATH=, STONAVM_RSP_PASS=, STONAVM_ACT=, /usr/stonavm/auluref
-        auhgdef: EnvFilter, env, root, LANG=, STONAVM_HOME=, LD_LIBRARY_PATH=, STONAVM_RSP_PASS=, STONAVM_ACT=, /usr/stonavm/auhgdef
-        aufibre1: EnvFilter, env, root, LANG=, STONAVM_HOME=, LD_LIBRARY_PATH=, STONAVM_RSP_PASS=, STONAVM_ACT=, /usr/stonavm/aufibre1
-        auhgwwn: EnvFilter, env, root, LANG=, STONAVM_HOME=, LD_LIBRARY_PATH=, STONAVM_RSP_PASS=, STONAVM_ACT=, /usr/stonavm/auhgwwn
-        auhgmap: EnvFilter, env, root, LANG=, STONAVM_HOME=, LD_LIBRARY_PATH=, STONAVM_RSP_PASS=, STONAVM_ACT=, /usr/stonavm/auhgmap
-        autargetmap: EnvFilter, env, root, LANG=, STONAVM_HOME=, LD_LIBRARY_PATH=, STONAVM_RSP_PASS=, STONAVM_ACT=, /usr/stonavm/autargetmap
-        aureplicationvvol: EnvFilter, env, root, LANG=, STONAVM_HOME=, LD_LIBRARY_PATH=, STONAVM_RSP_PASS=, STONAVM_ACT=, /usr/stonavm/aureplicationvvol
-        auluadd: EnvFilter, env, root, LANG=, STONAVM_HOME=, LD_LIBRARY_PATH=, STONAVM_RSP_PASS=, STONAVM_ACT=, /usr/stonavm/auluadd
-        auludel: EnvFilter, env, root, LANG=, STONAVM_HOME=, LD_LIBRARY_PATH=, STONAVM_RSP_PASS=, STONAVM_ACT=, /usr/stonavm/auludel
-        auluchgsize: EnvFilter, env, root, LANG=, STONAVM_HOME=, LD_LIBRARY_PATH=, STONAVM_RSP_PASS=, STONAVM_ACT=, /usr/stonavm/auluchgsize
-        auchapuser: EnvFilter, env, root, LANG=, STONAVM_HOME=, LD_LIBRARY_PATH=, STONAVM_RSP_PASS=, STONAVM_ACT=, /usr/stonavm/auchapuser
-        autargetdef: EnvFilter, env, root, LANG=, STONAVM_HOME=, LD_LIBRARY_PATH=, STONAVM_RSP_PASS=, STONAVM_ACT=, /usr/stonavm/autargetdef
-        autargetopt: EnvFilter, env, root, LANG=, STONAVM_HOME=, LD_LIBRARY_PATH=, STONAVM_RSP_PASS=, STONAVM_ACT=, /usr/stonavm/autargetopt
-        autargetini: EnvFilter, env, root, LANG=, STONAVM_HOME=, LD_LIBRARY_PATH=, STONAVM_RSP_PASS=, STONAVM_ACT=, /usr/stonavm/autargetini
-        auiscsi: EnvFilter, env, root, LANG=, STONAVM_HOME=, LD_LIBRARY_PATH=, STONAVM_RSP_PASS=, STONAVM_ACT=, /usr/stonavm/auiscsi
-        audppool: EnvFilter, env, root, LANG=, STONAVM_HOME=, LD_LIBRARY_PATH=, STONAVM_RSP_PASS=, STONAVM_ACT=, /usr/stonavm/audppool
-        aureplicationlocal: EnvFilter, env, root, LANG=, STONAVM_HOME=, LD_LIBRARY_PATH=, STONAVM_RSP_PASS=, STONAVM_ACT=, /usr/stonavm/aureplicationlocal
-        aureplicationmon: EnvFilter, env, root, LANG=, STONAVM_HOME=, LD_LIBRARY_PATH=, STONAVM_RSP_PASS=, STONAVM_ACT=, /usr/stonavm/aureplicationmon
-
-        # cinder/volume/drivers/hgst.py
-        vgc-cluster: CommandFilter, vgc-cluster, root
 
         # cinder/volume/drivers/vzstorage.py
         pstorage-mount: CommandFilter, pstorage-mount, root
         pstorage: CommandFilter, pstorage, root
         ploop: CommandFilter, ploop, root
 
-        # initiator/connector.py:
-        drv_cfg: CommandFilter, /opt/emc/scaleio/sdc/bin/drv_cfg, root, /opt/emc/scaleio/sdc/bin/drv_cfg, --query_guid
+        # cinder/volume/drivers/quobyte.py
+        mount.quobyte: CommandFilter, mount.quobyte, root
+        umount.quobyte: CommandFilter, umount.quobyte, root
+
+        # cinder/volume/drivers/dell_emc/powerstore/nfs.py
+        dellfcopy: CommandFilter, dellfcopy, root
+
+        # cinder/volume/flows/manager/create_volume.py: LUKS operations
+        cryptsetup: CommandFilter, cryptsetup, root
 
 dependencies:
   static:


### PR DESCRIPTION
cinder-rootwrap command filters for volume nodes
Based on cinder 2025.1 pip-installed volume.filters. This is already being utilized. The volume filters provided by the Helm chart are outdated.

lvresize added for cinder-rxt LUKS header margin reclamation