### PR TITLE
feat: move static-vendor-data to a systemd unit file and shell script

### DIFF
--- a/base-kustomize/nova/base/static-vendordata-configmap.yaml
+++ b/base-kustomize/nova/base/static-vendordata-configmap.yaml
@@ -4,4 +4,10 @@ metadata:
   name: static-vendor-data
   namespace: openstack
 data:
+  # This ConfigMap is intentionally empty by default and is expected to be
+  # overridden from /etc/genestack for cloud-specific vendordata. When
+  # providing required cloud-init behavior, prefer a standalone cloud-init
+  # part such as a shell script or boothook rather than top-level cloud-config
+  # keys like packages, bootcmd, or runcmd, which are commonly replaced by
+  # user-supplied cloud-config.
   vendor_data.json: '{}'

--- a/docs/openstack-vendordata.md
+++ b/docs/openstack-vendordata.md
@@ -29,9 +29,11 @@ api:
   vendordata_jsonfile_path: /etc/nova/vendor_data.json
 ```
 
-You can override the default configmap `/opt/genestack/base-kustomize/nova/base/static-vendordata-configmap` to pass 
-static vendor-data against `vendor_data.json` key, which is mounted at `/etc/nova/vendor_data.json` in metadata service 
-resources.
+The tracked plumbing for this lives in
+`/opt/genestack/base-kustomize/nova/base/static-vendordata-configmap.yaml`.
+In deployed environments this is typically overridden from
+`/etc/genestack/kustomize/nova/base/static-vendordata-configmap.yaml` and then
+consumed by the Nova metadata service at `/etc/nova/vendor_data.json`.
 
 For DynamicJSON you need to enable it amongst providers and have to specify dynamic target URL(s) in nova.conf as follows:
 
@@ -54,5 +56,36 @@ Cloud-init instructions can be passed-in as string against key - `cloud-init` wi
   "cloud-init": "#cloud-config\nruncmd:\n..."
 }
 ```
+
+### Precedence and merge behavior
+
+When an instance uses the OpenStack datasource, cloud-init processes OpenStack
+vendordata before user-data. If both documents are `#cloud-config`, overlapping
+keys such as `packages`, `bootcmd`, and `runcmd` are user-overridable and are a
+poor place to encode required provider bootstrap.
+
+Because of this, Genestack vendordata overrides should treat provider bootstrap
+as a separate cloud-init part whenever it must coexist with arbitrary user
+cloud-config. The recommended pattern is:
+
+* Keep `vendor_data.json` as the Nova `StaticJSON` payload.
+* Set the `cloud-init` value to a standalone cloud-init part such as a shell
+  script or boothook.
+* Use that part to write any provider-owned files and start provider-owned
+  services.
+* Leave user-facing cloud-config keys such as `packages`, `bootcmd`, and
+  `runcmd` available for tenant customization.
+
+For example, the vendordata payload can contain a shell script instead of a
+cloud-config document:
+
+```json
+{
+  "cloud-init": "## template: jinja\n#!/bin/bash\nset -euxo pipefail\n\nif [ \"{{ v1.distro }}\" != \"ubuntu\" ]; then\n  exit 0\nfi\n\ncat >/usr/local/sbin/provider-bootstrap.sh <<'EOF'\n#!/bin/bash\nset -euxo pipefail\n# provider bootstrap here\nEOF\nchmod 0755 /usr/local/sbin/provider-bootstrap.sh\n/usr/local/sbin/provider-bootstrap.sh\n"
+}
+```
+
+This avoids the common case where a user-supplied `#cloud-config` replaces the
+provider's `runcmd` or `packages` content.
 
 See [cloud-init docs](https://cloudinit.readthedocs.io/en/latest/reference/datasources/openstack.html) for more details.


### PR DESCRIPTION
User supplied vs static vendor data were getting clobbered when both scripts use siliar cloud-init sections "packages, runcmd, etc".  To solve this, move static vendordata to a seperate shell script inside cloud-init.  