### PR TITLE
  feat: add manila_enablement_techpreview ansible role

### DIFF
--- a/ansible/playbooks/manila-enablement-techpreview.yaml
+++ b/ansible/playbooks/manila-enablement-techpreview.yaml
@@ -1,0 +1,70 @@
+- name: Pre-requisites for enabling Manila
+  hosts: localhost
+  vars:
+    manila_os_endpoint_type: internal
+    manila_os_interface: "{{ manila_os_endpoint_type }}"
+    manila_os_username: admin
+    manila_os_project_name: admin
+    manila_os_tenant_name: '{{ manila_os_project_name }}'
+    manila_os_auth_type: password
+    manila_os_auth_url: http://keystone-api.openstack.svc.cluster.local:5000/v3
+    manila_os_user_domain_name: default
+    manila_os_project_domain_name: "{{ manila_os_user_domain_name }}"
+    manila_os_region_name: RegionOne
+    manila_os_identity_api_version: 3
+    manila_os_auth_version: 3
+    manila_nova_endpoint_type: "{{ manila_os_endpoint_type }}"
+    manila_helm_values_file: "{{ manila_helm_file | default(lookup('env', 'HOME') ~ '/manila_provider.yaml') }}"
+  pre_tasks:
+    - name: Retrieve Keystone admin password from K8s secret
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Secret
+        name: keystone-admin
+        namespace: openstack
+      register: keystone_secret
+      no_log: true
+      tags:
+        - always
+
+    - name: Set manila_os_password from K8s secret
+      ansible.builtin.set_fact:
+        manila_os_password: "{{ keystone_secret.resources[0].data.password | b64decode }}"
+      no_log: true
+      when: keystone_secret.resources | length > 0
+      tags:
+        - always
+
+    - name: Check for credentials
+      ansible.builtin.fail:
+        msg: >-
+          Could not retrieve the Keystone admin password. Ensure the
+          keystone-admin secret exists in the openstack namespace, or
+          pass -e manila_os_password=<password> on the command line.
+      when: manila_os_password is undefined or manila_os_password | length == 0
+      tags:
+        - always
+
+    - name: Set OpenStack environment facts
+      ansible.builtin.set_fact:
+        manila_os_env:
+          OS_ENDPOINT_TYPE: "{{ manila_os_endpoint_type }}"
+          OS_INTERFACE: "{{ manila_os_interface }}"
+          OS_USERNAME: "{{ manila_os_username }}"
+          OS_PASSWORD: "{{ manila_os_password }}"
+          OS_PROJECT_NAME: "{{ manila_os_project_name }}"
+          OS_TENANT_NAME: 'admin'
+          OS_AUTH_TYPE: password
+          OS_AUTH_URL: "{{ manila_os_auth_url }}"
+          OS_USER_DOMAIN_NAME: "{{ manila_os_user_domain_name }}"
+          OS_PROJECT_DOMAIN_NAME: "{{ manila_os_project_domain_name }}"
+          OS_REGION_NAME: "{{ manila_os_region_name }}"
+          OS_IDENTITY_API_VERSION: "{{ manila_os_identity_api_version }}"
+          OS_AUTH_VERSION: "{{ manila_os_auth_version }}"
+          NOVA_ENDPOINT_TYPE: "{{ manila_nova_endpoint_type }}"
+      no_log: true
+      tags:
+        - always
+  roles:
+    - role: manila_enablement_techpreview
+      environment: "{{ manila_os_env }}"

--- a/ansible/roles/manila_enablement_techpreview/README.md
+++ b/ansible/roles/manila_enablement_techpreview/README.md
@@ -1,0 +1,117 @@
+# manila_enablement_techpreview
+
+End-to-end enablement of OpenStack Manila (Shared File Systems) for
+Genestack Kubernetes deployments. **Tech Preview** — suitable for lab and
+pre-production evaluation.
+
+## What It Does
+
+This role handles the full lifecycle of getting Manila operational:
+
+1. **K8s Secrets** — Generates and manages four Kubernetes secrets
+   (RabbitMQ password, DB password, admin password, SSH keypair).
+   Syncs passwords to RabbitMQ and MariaDB when secrets are recreated.
+
+2. **Service Image** — Builds an Ubuntu-based Manila service VM image
+   using upstream `manila-image-elements`, uploads it to Glance, and
+   shares it with the admin and service projects.
+
+3. **Gateway & Kustomize** — Generates Envoy gateway listener and
+   HTTPRoute for Manila HTTPS, creates kustomize overlay, and
+   deep-merges Manila endpoint stanzas (`share`, `sharev2`,
+   `identity.auth.manila`) into the global endpoints override file.
+   Patches the running envoy gateway config idempotently.
+
+4. **Helm Configuration** — Templates driver-specific config and
+   deep-merges it into the existing Manila Helm overrides. Injects
+   the service image ID, flavor ID, and admin password.
+
+5. **Share Type** (post-deploy) — Creates the `generic` share type
+   with appropriate extra-specs after Manila is running.
+
+## Requirements
+
+- Ansible >= 2.15.8
+- `kubernetes.core` collection (for K8s secret lookups)
+- `community.general` collection
+- Genestack environment with Keystone, Nova, Neutron, Cinder, Glance,
+  and Barbican deployed
+- Run from the jump host (localhost) where `kubectl` is available
+
+## Usage
+
+### Full run (pre-deploy + helm config)
+
+```bash
+ansible-playbook -i /etc/genestack/inventory/inventory.yaml \
+    ansible/playbooks/manila-enablement-techpreview.yaml
+```
+
+### Post-deploy only (share type creation)
+
+```bash
+ansible-playbook -i /etc/genestack/inventory/inventory.yaml \
+    ansible/playbooks/manila-enablement-techpreview.yaml \
+    --tags post_deploy
+```
+
+### Force modes
+
+```bash
+# Rebuild service image only
+ansible-playbook ... -e force_rebuild_image=true
+
+# Recreate keypair + rebuild image
+ansible-playbook ... -e force_recreate_keypair=true
+
+# Nuclear: regenerate ALL secrets, sync passwords, recreate everything
+ansible-playbook ... -e force_full_recreation=true
+```
+
+## Role Variables
+
+See `defaults/main.yml` for the full list. Key variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `manila_service_image_version` | `noble` | Ubuntu version for the service image |
+| `manila_service_image_name` | `manila-service-image` | Glance image name |
+| `manila_service_instance_flavor_name` | `m1.medium` | Flavor for share server VMs |
+| `manila_driver_config_template` | `manila_default_helm_config.yaml` | Helm driver template |
+| `manila_force_recreate_secrets` | `false` | Force-regenerate all K8s secrets |
+| `force_rebuild_image` | `false` | Rebuild and re-upload Glance image |
+| `force_recreate_keypair` | `false` | Recreate SSH keypair + rebuild image |
+| `force_full_recreation` | `false` | Full recreation of all resources |
+
+## Included Utility Scripts
+
+Located in `files/`:
+
+| Script | Purpose |
+|--------|---------|
+| `manage-test-tenants.sh` | Create/destroy/reset test tenant projects with networks |
+| `manage-test-tenant-shares.sh` | End-to-end share test: creates shares, VMs, routers, mounts |
+| `manila-full-teardown-and-test-tenants.sh` | Complete Manila teardown (Helm, K8s, OpenStack resources) |
+
+## Driver Templates
+
+| Template | Backend |
+|----------|---------|
+| `manila_default_helm_config.yaml` | Generic driver (Cinder-backed LVM) — lab/dev |
+| `manila_generic_driver_helm_config.yaml` | Driver-only overlay for customization |
+
+## Tags
+
+| Tag | Runs |
+|-----|------|
+| (no tag) | Full role: secrets, image, gateway/kustomize, helm config, share type |
+| `manila_gateway_kustomize` | Gateway listener, route, kustomize overlay, endpoints merge |
+| `post_deploy` | Share type creation only (requires running Manila API) |
+
+## License
+
+Apache-2.0
+
+## Author
+
+Dan With — Rackspace Technology

--- a/ansible/roles/manila_enablement_techpreview/defaults/main.yml
+++ b/ansible/roles/manila_enablement_techpreview/defaults/main.yml
@@ -1,0 +1,84 @@
+---
+# defaults file for manila_enablement_techpreview
+
+# =========================================================================
+# Manila service image
+# =========================================================================
+manila_service_image_version: noble
+manila_service_image_name: manila-service-image
+manila_service_image_id: ""
+manila_service_instance_flavor_id: ""
+manila_service_instance_flavor_name: m1.medium
+manila_service_instance_password: ""
+
+# =========================================================================
+# Manila networking
+# =========================================================================
+# The service network (manila-service-network) is created and managed
+# entirely by Manila's NeutronNetworkHelper at runtime.  It carves /28
+# subnets per share server from service_network_cidr (default 10.254.0.0/16).
+# No Ansible pre-provisioning is needed.
+
+# =========================================================================
+# Build paths and environment
+# =========================================================================
+manila_tmp_dir: /tmp
+manila_build_dir: "{{ manila_tmp_dir }}/manila-service-image-build"
+manila_venv_dir: "{{ manila_tmp_dir }}/manila-service-image-build/manila-tox-image-build"
+manila_keypair_name: manila-service-keypair
+genestack_rc: /opt/genestack/scripts/genestack.rc
+genestack_venv: /home/ubuntu/.venvs/genestack
+ubuntu_home: /home/ubuntu
+manila_os_auth_url: ""
+manila_region_name: RegionOne
+manila_os_endpoint_type: internal
+os_cloud: default
+manila_region: RegionOne
+
+# =========================================================================
+# Helm config — driver template to merge into the existing overrides file.
+# The selected template is deep-merged into the manila-helm-overrides.yaml
+# that already lives at /etc/genestack/helm-configs/manila/.
+# Switch this to a different template when using an alternate backend driver.
+# =========================================================================
+manila_driver_config_template: manila_default_helm_config.yaml
+
+# =========================================================================
+# Gateway and kustomize
+# =========================================================================
+# The region component used in gateway hostnames
+# (e.g. manila.api.<region_lower>.rackspacecloud.com).
+# Auto-detected from /etc/genestack/helm-configs/global_overrides/endpoints.yaml
+# at runtime; this default is the fallback.
+manila_gateway_region_lower: ""
+
+# =========================================================================
+# Secrets
+# =========================================================================
+manila_force_recreate_secrets: false
+
+# =========================================================================
+# Force / mode flags for image builder
+# =========================================================================
+# Default (no flags):
+#   Idempotent — skip keypair/image creation if they already exist.
+#
+# force_rebuild_image=true  (option 1):
+#   Verifies k8s secret fingerprint matches OpenStack keypair.
+#   Deletes existing Glance image, rebuilds, re-uploads.
+#
+# force_recreate_keypair=true  (option 2):
+#   Deletes and re-creates OpenStack keypair from k8s secret.
+#   Then rebuilds and re-uploads the image.
+#
+# force_full_recreation=true  (option 3 — nuclear):
+#   Deletes and regenerates ALL K8s secrets (rabbitmq, db, admin, keypair),
+#   syncs new RabbitMQ and MariaDB passwords to backing services,
+#   then performs all actions of options 1 and 2.
+#
+# Higher options are supersets of lower ones.
+# manila_force_recreate_secrets=true is equivalent to option 3 for secrets
+# only (no image rebuild unless cascaded via manila_secrets_recreated).
+force_rebuild_image: false
+force_recreate_keypair: false
+force_full_recreation: false

--- a/ansible/roles/manila_enablement_techpreview/files/build-tenant-ubuntu-test-image.sh
+++ b/ansible/roles/manila_enablement_techpreview/files/build-tenant-ubuntu-test-image.sh
@@ -1,0 +1,261 @@
+#!/bin/bash
+# ==========================================================================
+# Build an Ubuntu 24.04 Glance image with qemu-guest-agent pre-installed.
+#
+# Why: the default Ubuntu cloud image does not ship qemu-guest-agent, and
+# installing it at boot via cloud-init fails in labs where tenant VMs have
+# no working external DNS. Baking the package into the image avoids the
+# apt/DNS dependency entirely.
+#
+# Why offline install: the libguestfs appliance used by virt-customize has
+# no working DHCP/DNS in this environment (its /init never brings eth0 up),
+# so the usual --install path (apt-get update + install inside the appliance)
+# always fails with "Temporary failure resolving ..." — for every host, not
+# just the public Ubuntu archive. We work around this by pre-fetching the
+# qemu-guest-agent .deb from mirror.rackspace.com on the host (which has
+# working networking), copying it into the image, and running dpkg -i
+# offline inside the chroot. No appliance network needed.
+#
+# apt sources in the image are also rewritten to mirror.rackspace.com so
+# tenant VMs booted from this image can later apt-install additional
+# packages via the Rackspace mirror (reachable from the inner cloud)
+# instead of the unreachable public archive.ubuntu.com.
+#
+# Run on the overseer as ubuntu (sudo is used for apt + virt-customize).
+# Idempotent: skips work if the Glance image already exists with the right
+# property set.
+# ==========================================================================
+set -euo pipefail
+
+IMAGE_NAME="Ubuntu 24.04 Test Tenant"
+WORK_DIR=/tmp
+BASE_IMG="${WORK_DIR}/ubuntu24-base.img"   # pristine download, kept untouched
+LOCAL_IMG="${WORK_DIR}/ubuntu24-qga.img"   # working copy — recreated each run
+UPSTREAM_URL="https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
+
+MIRROR="http://mirror.rackspace.com/ubuntu"
+DEB_CACHE="${WORK_DIR}/qga-debs"
+
+# --------------------------------------------------------------------------
+# 1) Host prerequisites
+# --------------------------------------------------------------------------
+if ! command -v virt-customize >/dev/null 2>&1; then
+  echo ">>> Installing libguestfs-tools..."
+  sudo apt-get update -y
+  sudo apt-get install -y libguestfs-tools
+fi
+
+cd "${WORK_DIR}"
+
+# --------------------------------------------------------------------------
+# 2) If Glance already has the image, nothing to do
+# --------------------------------------------------------------------------
+source /opt/genestack/scripts/genestack.rc
+
+# genestack.rc may export OS_CLIENT_CONFIG_FILE pointing at a system-wide
+# clouds.yaml that doesn't contain the "default" cloud — in which case
+# `openstack --os-cloud default ...` fails with "Cloud default was not
+# found". Pin to the per-user clouds.yaml (the one the Ansible
+# setup-openstack-rc task creates), which the rest of this role relies on.
+export OS_CLIENT_CONFIG_FILE="${HOME}/.config/openstack/clouds.yaml"
+if [ ! -s "${OS_CLIENT_CONFIG_FILE}" ]; then
+  echo "ERROR: ${OS_CLIENT_CONFIG_FILE} is missing or empty." >&2
+  echo "       Run setup-openstack-rc.sh first as the current user." >&2
+  exit 1
+fi
+
+if openstack --os-cloud default image show "${IMAGE_NAME}" -f value -c id >/dev/null 2>&1; then
+  EXISTING_QGA=$(openstack --os-cloud default image show "${IMAGE_NAME}" -f json \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin).get("properties",{}).get("hw_qemu_guest_agent",""))')
+  if [ "${EXISTING_QGA}" = "yes" ]; then
+    echo ">>> Glance image '${IMAGE_NAME}' already exists with hw_qemu_guest_agent=yes. Nothing to do."
+    exit 0
+  fi
+  echo ">>> Glance image '${IMAGE_NAME}' exists but hw_qemu_guest_agent != yes; updating property only."
+  IMG_ID=$(openstack --os-cloud default image show "${IMAGE_NAME}" -f value -c id)
+  openstack --os-cloud default image set "${IMG_ID}" --property hw_qemu_guest_agent=yes
+  exit 0
+fi
+
+# --------------------------------------------------------------------------
+# 3a) Download pristine upstream cloud image (kept untouched)
+# --------------------------------------------------------------------------
+if [ ! -s "${BASE_IMG}" ]; then
+  echo ">>> Downloading upstream Ubuntu 24.04 cloud image..."
+  wget -q --show-progress -O "${BASE_IMG}" "${UPSTREAM_URL}"
+else
+  echo ">>> Reusing pristine base ${BASE_IMG}"
+fi
+
+# --------------------------------------------------------------------------
+# 3b) Create fresh working copy from pristine base.
+# virt-customize modifies in place, so a partially-failed prior run leaves
+# the working image in an inconsistent state. Always start from pristine.
+# --------------------------------------------------------------------------
+echo ">>> Creating working copy from pristine base..."
+cp -f "${BASE_IMG}" "${LOCAL_IMG}"
+
+# --------------------------------------------------------------------------
+# 3c) Pre-fetch qemu-guest-agent .deb plus any runtime deps not present in
+# the base cloud image.
+# Preferred source is mirror.rackspace.com, but if the Rackspace mirror's
+# Packages index doesn't carry a given package we fall back to the public
+# archive. The apt-sources rewrite in step 4 still points tenant VMs at
+# mirror.rackspace.com regardless of which mirror we fetched from here.
+#
+# Deps of qemu-guest-agent on Ubuntu 24.04 (main):
+#   - libc6 (>= 2.34)   — present in cloud image
+#   - liburing2 (>= 2.3) — NOT present, must be installed alongside
+# Passing both .debs to a single `dpkg -i` call lets dpkg resolve the
+# ordering between them.
+# --------------------------------------------------------------------------
+mkdir -p "${DEB_CACHE}"
+
+# Search one mirror for a package across suites + components.
+# Echoes the relative Filename: on stdout if found; returns 1 otherwise.
+# Packages indices are cached on disk so repeat calls for different
+# packages don't re-download the same indices.
+find_deb_in_mirror() {
+  local mirror_url="$1"
+  local pkg="$2"
+  local safe_name
+  safe_name=$(printf '%s' "${mirror_url}" | tr ':/' '__')
+  local suite component idx_file fn
+  for suite in noble-updates noble noble-security noble-backports; do
+    for component in main universe; do
+      idx_file="${DEB_CACHE}/Packages-${safe_name}-${suite}-${component}"
+      if [ ! -s "${idx_file}" ]; then
+        if ! curl -sfL "${mirror_url}/dists/${suite}/${component}/binary-amd64/Packages.gz" 2>/dev/null \
+             | gunzip > "${idx_file}" 2>/dev/null; then
+          rm -f "${idx_file}"
+          continue
+        fi
+      fi
+      # Sanity-check that the index actually looks like a Packages file.
+      [ -s "${idx_file}" ] || continue
+      grep -q '^Package: ' "${idx_file}" || continue
+      fn=$(awk -v pkg="${pkg}" '
+        $1=="Package:" {found=($2==pkg)}
+        found && $1=="Filename:" {print $2; exit}
+      ' "${idx_file}")
+      if [ -n "${fn}" ]; then
+        printf '%s' "${fn}"
+        return 0
+      fi
+    done
+  done
+  return 1
+}
+
+NEEDED_PKGS=(qemu-guest-agent liburing2)
+DEB_PATHS=()
+DEB_NAMES=()
+
+for pkg in "${NEEDED_PKGS[@]}"; do
+  FILENAME=""
+  MIRROR_USED=""
+  for candidate_mirror in "${MIRROR}" "http://archive.ubuntu.com/ubuntu"; do
+    echo ">>> Searching ${candidate_mirror} for ${pkg}..."
+    if fn=$(find_deb_in_mirror "${candidate_mirror}" "${pkg}"); then
+      FILENAME="${fn}"
+      MIRROR_USED="${candidate_mirror}"
+      echo ">>> Found in ${candidate_mirror}: ${fn}"
+      break
+    fi
+    echo ">>> Not found in ${candidate_mirror}."
+  done
+
+  if [ -z "${FILENAME}" ]; then
+    echo "ERROR: ${pkg} not found in any mirror" >&2
+    echo "Downloaded Packages indices (for diagnostics):" >&2
+    for f in "${DEB_CACHE}"/Packages-*; do
+      [ -f "$f" ] || continue
+      printf "  %s: %s lines, %s Package entries\n" \
+        "$(basename "$f")" \
+        "$(wc -l <"$f" | tr -d ' ')" \
+        "$(grep -c '^Package: ' "$f" 2>/dev/null || echo 0)" >&2
+    done
+    exit 1
+  fi
+
+  deb_url="${MIRROR_USED}/${FILENAME}"
+  deb_name=$(basename "${FILENAME}")
+  deb_path="${DEB_CACHE}/${deb_name}"
+  if [ ! -s "${deb_path}" ]; then
+    echo ">>> Downloading ${deb_url}"
+    curl -sfL -o "${deb_path}" "${deb_url}"
+  else
+    echo ">>> Reusing cached ${deb_path}"
+  fi
+  DEB_PATHS+=("${deb_path}")
+  DEB_NAMES+=("${deb_name}")
+done
+
+# --------------------------------------------------------------------------
+# 4) Inject qemu-guest-agent into the image (offline dpkg) and tune the
+#    image for lab use.
+#
+# No --network / --install: both are unusable here (the appliance has no
+# working DHCP, so apt-get can never reach any mirror). We use --copy-in
+# to stage the pre-downloaded .deb inside the image and dpkg -i to install
+# it offline. Runtime dependencies are already present in the cloud image.
+#
+# apt sources rewrite:
+#   Redirect archive.ubuntu.com / security.ubuntu.com (and any regional
+#   mirror like us.archive.ubuntu.com) to mirror.rackspace.com in the
+#   Ubuntu 24.04 deb822 source file so tenant VMs booted from this image
+#   can apt-install additional packages at runtime via the Rackspace
+#   mirror (reachable from the inner cloud) instead of the unreachable
+#   public archive.
+#
+# Disable unattended-upgrades:
+#   Tenant VMs in this lab have no reliable external DNS — periodic
+#   apt-daily / unattended-upgrades runs just fail repeatedly and can
+#   hold the apt lock while cloud-init or users are trying to install
+#   packages. Two belts-and-suspenders:
+#     - /etc/apt/apt.conf.d/20auto-upgrades set to all "0"; so even if
+#       the timers fire, the periodic scripts are no-ops.
+#     - apt-daily.timer / apt-daily-upgrade.timer / unattended-upgrades
+#       masked so the timers themselves never fire.
+#
+# --smp / --memsize: the default 1 vCPU / 512MB appliance is slow;
+#             bump it so this finishes in reasonable time.
+# --selinux-relabel: harmless on Ubuntu, keeps the option available if the
+#             same script is ever used on an SELinux-based image.
+# --------------------------------------------------------------------------
+# Build virt-customize argv: one --copy-in per .deb, single dpkg -i with all.
+COPY_IN_ARGS=()
+DPKG_TARGETS=""
+for i in "${!DEB_PATHS[@]}"; do
+  COPY_IN_ARGS+=(--copy-in "${DEB_PATHS[$i]}:/tmp")
+  DPKG_TARGETS="${DPKG_TARGETS} /tmp/${DEB_NAMES[$i]}"
+done
+
+echo ">>> Running virt-customize (offline dpkg install of qemu-guest-agent + deps)..."
+sudo virt-customize -a "${LOCAL_IMG}" \
+  --smp 2 \
+  --memsize 2048 \
+  --run-command 'sed -i -e "s|http://archive.ubuntu.com/ubuntu/\?|http://mirror.rackspace.com/ubuntu/|g" -e "s|http://security.ubuntu.com/ubuntu/\?|http://mirror.rackspace.com/ubuntu/|g" -e "s|http://[a-z0-9.-]*\.archive\.ubuntu\.com/ubuntu/\?|http://mirror.rackspace.com/ubuntu/|g" /etc/apt/sources.list.d/ubuntu.sources' \
+  "${COPY_IN_ARGS[@]}" \
+  --run-command "dpkg -i${DPKG_TARGETS}" \
+  --run-command 'systemctl enable qemu-guest-agent.service' \
+  --run-command "rm -f${DPKG_TARGETS}" \
+  --write '/etc/apt/apt.conf.d/20auto-upgrades:APT::Periodic::Update-Package-Lists "0";
+APT::Periodic::Unattended-Upgrade "0";
+APT::Periodic::Download-Upgradeable-Packages "0";
+APT::Periodic::AutocleanInterval "0";
+' \
+  --run-command 'systemctl mask apt-daily.timer apt-daily-upgrade.timer unattended-upgrades.service 2>/dev/null || true' \
+  --selinux-relabel
+
+# --------------------------------------------------------------------------
+# 5) Upload to Glance with hw_qemu_guest_agent=yes and shared visibility
+# --------------------------------------------------------------------------
+echo ">>> Uploading to Glance as '${IMAGE_NAME}'..."
+openstack --os-cloud default image create "${IMAGE_NAME}" \
+  --file "${LOCAL_IMG}" \
+  --disk-format qcow2 --container-format bare \
+  --property hw_qemu_guest_agent=yes \
+  --shared
+
+echo ">>> Done. Image '${IMAGE_NAME}' is ready."

--- a/ansible/roles/manila_enablement_techpreview/files/create_manila_k8s_secrets.sh
+++ b/ansible/roles/manila_enablement_techpreview/files/create_manila_k8s_secrets.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -xe
+
+cd /tmp
+
+REGION=$1
+
+generate_password() {
+    < /dev/urandom tr -dc _A-Za-z0-9 | head -c${1:-32}
+}
+
+manila_ssh_public_key=$(ssh-keygen -qt ed25519 -N '' -C "manila_ssh" -f manila_ssh_key && cat manila_ssh_key.pub)
+manila_ssh_private_key=$(cat manila_ssh_key)
+manila_rabbitmq_password=$(generate_password 64)
+manila_db_password=$(generate_password 32)
+manila_admin_password=$(generate_password 32)
+
+OUTPUT_FILE="/tmp/manila_secrets.yml"
+
+if [[ -f ${OUTPUT_FILE} ]]; then
+    echo "Error: ${OUTPUT_FILE} already exists. Please remove it before running this script."
+    echo "       This will replace an existing file and will lead to mass rotation, which is"
+    echo "       likely not what you want to do. If you really want to break your system, please"
+    echo "       make sure you know what you're doing."
+    exit 99
+fi
+
+cat <<EOF > $OUTPUT_FILE
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: manila-rabbitmq-password
+  namespace: openstack
+type: Opaque
+data:
+  username: $(echo -n "manila" | base64)
+  password: $(echo -n $manila_rabbitmq_password | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: manila-db-password
+  namespace: openstack
+type: Opaque
+data:
+  password: $(echo -n $manila_db_password | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: manila-admin
+  namespace: openstack
+type: Opaque
+data:
+  password: $(echo -n $manila_admin_password | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: manila-service-keypair
+  namespace: openstack
+type: Opaque
+data:
+  public_key: $(echo -n $manila_ssh_public_key | base64 -w0)
+  private_key: $(echo -n "$manila_ssh_private_key" | base64 -w0)
+EOF
+
+#Remove after VM image is built
+#rm -f manila_ssh_key manila_ssh_key.pub
+chmod 0640 ${OUTPUT_FILE}

--- a/ansible/roles/manila_enablement_techpreview/files/deep_merge_yaml.py
+++ b/ansible/roles/manila_enablement_techpreview/files/deep_merge_yaml.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Deep-merge a YAML fragment into an existing YAML file.
+
+Usage:
+    python3 deep_merge_yaml.py BASE_FILE FRAGMENT_FILE
+
+If BASE_FILE does not exist it is created. The fragment values win on conflict.
+"""
+import copy
+import os
+import sys
+import yaml
+
+
+def deep_merge(base, overlay):
+    """Recursively merge overlay into base. Overlay values win."""
+    result = copy.deepcopy(base)
+    for key, value in overlay.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = copy.deepcopy(value)
+    return result
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} BASE_FILE FRAGMENT_FILE", file=sys.stderr)
+        sys.exit(1)
+
+    base_file = sys.argv[1]
+    fragment_file = sys.argv[2]
+
+    if os.path.exists(base_file):
+        with open(base_file, "r") as fh:
+            base = yaml.safe_load(fh) or {}
+    else:
+        base = {}
+
+    with open(fragment_file, "r") as fh:
+        fragment = yaml.safe_load(fh) or {}
+
+    merged = deep_merge(base, fragment)
+
+    with open(base_file, "w") as fh:
+        yaml.dump(merged, fh, default_flow_style=False, sort_keys=False, width=200)
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible/roles/manila_enablement_techpreview/files/manage-test-tenant-shares.sh
+++ b/ansible/roles/manila_enablement_techpreview/files/manage-test-tenant-shares.sh
@@ -1,0 +1,591 @@
+#!/bin/bash
+# ==========================================================================
+# test-tenant-shares.sh
+#
+# End-to-end Manila share test for each tenant: creates shares, VMs,
+# routers with external gateway, floating IPs, and mounts the share.
+#
+#   Usage:
+#     test-tenant-shares.sh create  [--size <GB>] [--flavor <name>] [--image <name>]
+#     test-tenant-shares.sh destroy
+#
+#   Options:
+#     --size <GB>        Share size in GB (default: 5)
+#     --flavor <name>    VM flavor (default: m1.medium)
+#     --image <name>     VM image (default: amphora-ubuntu-noble)
+#
+# Run as: ubuntu@controller
+# Requires: genestack venv, yq, ~/customers/clouds.yaml
+# ==========================================================================
+
+ACTION="${1:-}"
+SHARE_SIZE=5
+VM_FLAVOR="m1.medium"
+VM_IMAGE="Ubuntu 24.04 Test Tenant"
+EXTERNAL_NETWORK="${EXTERNAL_NETWORK:-PUBLICNET}"
+
+# Parse arguments
+shift 2>/dev/null || true
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --size)   SHARE_SIZE="${2:-5}"; shift 2 ;;
+    --flavor) VM_FLAVOR="${2}"; shift 2 ;;
+    --image)  VM_IMAGE="${2}"; shift 2 ;;
+    *)        echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+if [[ "$ACTION" != "create" && "$ACTION" != "destroy" ]]; then
+  echo "Usage: $0 {create|destroy} [--size <GB>] [--flavor <name>] [--image <name>]"
+  echo ""
+  echo "  create   — Create shares, VMs, routers, floating IPs, and mount shares"
+  echo "  destroy  — Tear down everything created by this script"
+  echo ""
+  echo "Options:"
+  echo "  --size <GB>        Share size in GB (default: 5)"
+  echo "  --flavor <name>    VM flavor (default: m1.medium)"
+  echo "  --image <name>     VM image (default: amphora-ubuntu-noble)"
+  exit 1
+fi
+
+# --------------------------------------------------------------------------
+# Environment setup
+# --------------------------------------------------------------------------
+source /home/ubuntu/.venvs/genestack/bin/activate
+set -a
+source /opt/genestack/scripts/genestack.rc
+set +a
+export HOME=/home/ubuntu
+
+# Remember where this script lives so we can call its sibling builder later.
+# (`create` needs it; `destroy` does not.)
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+CUSTOMER_DIR=/home/ubuntu/customers
+CLOUDS_YAML="${CUSTOMER_DIR}/clouds.yaml"
+export OS_CLIENT_CONFIG_FILE="${CLOUDS_YAML}"
+
+# Admin commands need the system clouds.yaml, not the tenant one.
+# Use a function wrapper so OS_CLIENT_CONFIG_FILE is overridden per-call.
+ADMIN_CLOUDS="${HOME}/.config/openstack/clouds.yaml"
+os_admin() {
+  OS_CLIENT_CONFIG_FILE="$ADMIN_CLOUDS" openstack --os-cloud=default "$@"
+}
+
+if [ ! -f "$CLOUDS_YAML" ]; then
+  echo "ERROR: ${CLOUDS_YAML} not found."
+  echo "       Run manage-test-tenants.sh create first."
+  exit 1
+fi
+
+TENANTS=$(yq '.clouds | keys | .[]' "$CLOUDS_YAML")
+
+if [ -z "$TENANTS" ]; then
+  echo "ERROR: No tenants found in ${CLOUDS_YAML}"
+  exit 1
+fi
+
+# ==========================================================================
+# CREATE
+# ==========================================================================
+if [ "$ACTION" = "create" ]; then
+
+  echo "============================================================"
+  echo "  END-TO-END MANILA SHARE TEST"
+  echo "  Share size: ${SHARE_SIZE}GB  Flavor: ${VM_FLAVOR}  Image: ${VM_IMAGE}"
+  echo "============================================================"
+
+  # ----------------------------------------------------------------------
+  # Build the tenant VM image (qemu-guest-agent baked in) if needed.
+  # The builder script is idempotent: it returns quickly if Glance already
+  # has an image by the right name with hw_qemu_guest_agent=yes.
+  # ----------------------------------------------------------------------
+  echo ""
+  echo ">>> Ensuring tenant VM image is built and uploaded..."
+  "${SCRIPT_DIR}/build-tenant-ubuntu-test-image.sh"
+
+  # ----------------------------------------------------------------------
+  # Ensure the VM image is accessible to all tenants
+  # ----------------------------------------------------------------------
+  echo ""
+  echo ">>> Ensuring VM image is accessible to tenants..."
+
+  IMAGE_ID=$(os_admin image show "${VM_IMAGE}" -f json 2>/dev/null \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' 2>/dev/null) || true
+
+  if [ -z "$IMAGE_ID" ]; then
+    echo "ERROR: Image '${VM_IMAGE}' not found."
+    exit 1
+  fi
+
+  IMAGE_VIS=$(os_admin image show "${VM_IMAGE}" -f json 2>/dev/null \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin).get("visibility",""))' 2>/dev/null) || true
+
+  if [ "$IMAGE_VIS" != "public" ] && [ "$IMAGE_VIS" != "shared" ]; then
+    echo "  Image is '${IMAGE_VIS}', setting to shared..."
+    os_admin image set "${IMAGE_ID}" --shared 2>/dev/null || true
+  fi
+
+  # Ensure hw_qemu_guest_agent=yes is set so nova attaches the virtio-serial
+  # channel for qemu-ga. Without this property the guest has no way to receive
+  # `openstack server set --password` or other QGA commands.
+  QGA_PROP=$(os_admin image show "${IMAGE_ID}" -f json 2>/dev/null \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin).get("properties",{}).get("hw_qemu_guest_agent",""))' 2>/dev/null) || true
+  if [ "$QGA_PROP" != "yes" ]; then
+    echo "  Setting hw_qemu_guest_agent=yes on image..."
+    os_admin image set "${IMAGE_ID}" --property hw_qemu_guest_agent=yes 2>/dev/null || true
+  fi
+
+  # Share image with each tenant project and accept membership as the tenant
+  for tenant in $TENANTS; do
+    PROJECT_ID=$(os_admin project show "$tenant" -f json 2>/dev/null \
+      | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' 2>/dev/null) || true
+    if [ -n "$PROJECT_ID" ]; then
+      # Add the project as an image member (admin operation)
+      os_admin image add project "${IMAGE_ID}" "${PROJECT_ID}" >/dev/null 2>&1 || true
+      # Accept the membership as the tenant (must be done by the tenant)
+      openstack --os-cloud="${tenant}" image set --accept "${IMAGE_ID}" 2>/dev/null || true
+      echo "  Shared with ${tenant} (${PROJECT_ID})"
+    fi
+  done
+  echo "  Image shared and accepted by all tenants."
+
+  # ----------------------------------------------------------------------
+  # Per-tenant setup
+  # ----------------------------------------------------------------------
+  for tenant in $TENANTS; do
+    echo ""
+    echo "============================================================"
+    echo "  TENANT: ${tenant}"
+    echo "============================================================"
+
+    TENANT_OS="openstack --os-cloud=${tenant}"
+    SHARE_NAME="${tenant}-test-share"
+    SHARE_NET_NAME="${tenant}-share-network"
+    NETWORK_NAME="${tenant}-network"
+    SUBNET_NAME="${tenant}-subnet"
+    ROUTER_NAME="${tenant}-router"
+    SG_NAME="${tenant}-test-sg"
+    KEYPAIR_NAME="${tenant}-keypair"
+    VM_NAME="${tenant}-test-vm"
+    KEY_DIR="${CUSTOMER_DIR}/${tenant}"
+    mkdir -p "${KEY_DIR}"
+
+    # ------------------------------------------------------------------
+    # 1) SSH keypair
+    # ------------------------------------------------------------------
+    echo ">>> [1/8] SSH keypair..."
+    if $TENANT_OS keypair show "${KEYPAIR_NAME}" -f json >/dev/null 2>&1; then
+      echo "  (keypair exists)"
+    else
+      ssh-keygen -t ed25519 -f "${KEY_DIR}/id_ed25519" -N "" -C "${KEYPAIR_NAME}" -q 2>/dev/null || true
+      $TENANT_OS keypair create --public-key "${KEY_DIR}/id_ed25519.pub" "${KEYPAIR_NAME}" >/dev/null 2>&1
+      echo "  Created keypair, private key at ${KEY_DIR}/id_ed25519"
+    fi
+
+    # ------------------------------------------------------------------
+    # 2) Router with external gateway
+    # ------------------------------------------------------------------
+    echo ">>> [2/8] Router..."
+    if $TENANT_OS router show "${ROUTER_NAME}" -f json >/dev/null 2>&1; then
+      echo "  (router exists)"
+    else
+      $TENANT_OS router create "${ROUTER_NAME}" >/dev/null 2>&1
+      echo "  Created router ${ROUTER_NAME}"
+    fi
+
+    # Set external gateway
+    $TENANT_OS router set "${ROUTER_NAME}" --external-gateway "${EXTERNAL_NETWORK}" 2>/dev/null || true
+
+    # Add tenant subnet to router
+    $TENANT_OS router add subnet "${ROUTER_NAME}" "${SUBNET_NAME}" 2>/dev/null || true
+    echo "  External gateway: ${EXTERNAL_NETWORK}, subnet: ${SUBNET_NAME}"
+
+    # ------------------------------------------------------------------
+    # 3) Security group
+    # ------------------------------------------------------------------
+    echo ">>> [3/8] Security group..."
+    if $TENANT_OS security group show "${SG_NAME}" -f json >/dev/null 2>&1; then
+      echo "  (security group exists)"
+    else
+      $TENANT_OS security group create "${SG_NAME}" \
+        --description "Test SG for ${tenant}" >/dev/null 2>&1
+
+      # SSH
+      $TENANT_OS security group rule create "${SG_NAME}" \
+        --protocol tcp --dst-port 22 --ingress >/dev/null 2>&1
+      # ICMP
+      $TENANT_OS security group rule create "${SG_NAME}" \
+        --protocol icmp --ingress >/dev/null 2>&1
+      # NFS (TCP 2049)
+      $TENANT_OS security group rule create "${SG_NAME}" \
+        --protocol tcp --dst-port 2049 --ingress >/dev/null 2>&1
+      # NFS mountd (TCP 20048)
+      $TENANT_OS security group rule create "${SG_NAME}" \
+        --protocol tcp --dst-port 20048 --ingress >/dev/null 2>&1
+      # NFS portmapper (TCP/UDP 111)
+      $TENANT_OS security group rule create "${SG_NAME}" \
+        --protocol tcp --dst-port 111 --ingress >/dev/null 2>&1
+      $TENANT_OS security group rule create "${SG_NAME}" \
+        --protocol udp --dst-port 111 --ingress >/dev/null 2>&1
+      # Allow all egress (default, but explicit)
+      $TENANT_OS security group rule create "${SG_NAME}" \
+        --protocol any --egress >/dev/null 2>&1 || true
+
+      echo "  Created security group with SSH, ICMP, NFS rules"
+    fi
+
+    # ------------------------------------------------------------------
+    # 4) Share network
+    # ------------------------------------------------------------------
+    echo ">>> [4/8] Share network..."
+    NETWORK_ID=$($TENANT_OS network show "${NETWORK_NAME}" -f value -c id 2>/dev/null) || true
+    SUBNET_ID=$($TENANT_OS subnet show "${SUBNET_NAME}" -f value -c id 2>/dev/null) || true
+
+    if [ -z "$NETWORK_ID" ] || [ -z "$SUBNET_ID" ]; then
+      echo "  ERROR: Could not find ${NETWORK_NAME} or ${SUBNET_NAME}. Skipping tenant."
+      continue
+    fi
+
+    SHARE_NET_ID=$($TENANT_OS share network show "${SHARE_NET_NAME}" -f value -c id 2>/dev/null) || true
+
+    if [ -z "$SHARE_NET_ID" ]; then
+      CREATE_OUT=$($TENANT_OS share network create \
+        --name "${SHARE_NET_NAME}" \
+        --neutron-net-id "${NETWORK_ID}" \
+        --neutron-subnet-id "${SUBNET_ID}" \
+        --description "Share network for ${tenant}" \
+        -f value -c id 2>&1)
+      # Extract UUID from output (skip error text)
+      SHARE_NET_ID=$(echo "$CREATE_OUT" | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1)
+      if [ -z "$SHARE_NET_ID" ]; then
+        echo "  ERROR: Failed to create share-network:"
+        echo "    $CREATE_OUT"
+        echo "  Skipping tenant."
+        continue
+      fi
+      echo "  Created share-network ${SHARE_NET_NAME} (${SHARE_NET_ID})"
+    else
+      echo "  (share-network exists: ${SHARE_NET_ID})"
+    fi
+
+    # ------------------------------------------------------------------
+    # 5) Create NFS share
+    # ------------------------------------------------------------------
+    echo ">>> [5/8] NFS share (${SHARE_SIZE}GB)..."
+    SHARE_ID=$($TENANT_OS share show "${SHARE_NAME}" -f value -c id 2>/dev/null) || true
+
+    if [ -z "$SHARE_ID" ]; then
+      CREATE_OUT=$($TENANT_OS share create NFS "${SHARE_SIZE}" \
+        --name "${SHARE_NAME}" \
+        --share-network "${SHARE_NET_ID}" \
+        --description "Test share for ${tenant}" \
+        --share-type generic \
+        -f value -c id 2>&1)
+      SHARE_ID=$(echo "$CREATE_OUT" | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1)
+      if [ -z "$SHARE_ID" ]; then
+        echo "  ERROR: Failed to create share:"
+        echo "    $CREATE_OUT"
+        echo "  Skipping tenant."
+        continue
+      fi
+      echo "  Created share ${SHARE_NAME} (${SHARE_ID})"
+    else
+      echo "  (share exists: ${SHARE_ID})"
+    fi
+
+    # ------------------------------------------------------------------
+    # 6) Boot VM
+    # ------------------------------------------------------------------
+    echo ">>> [6/8] VM..."
+    if $TENANT_OS server show "${VM_NAME}" -f json >/dev/null 2>&1; then
+      echo "  (VM exists)"
+    else
+      # Cloud-init user-data:
+      #   - Installs & enables qemu-guest-agent so `openstack server set
+      #     --password` and other QGA commands work.
+      #   - Installs NFS/CIFS client packages so the VM can mount Manila shares.
+      USER_DATA_FILE=$(mktemp /tmp/${tenant}-user-data.XXXXXX)
+      cat > "${USER_DATA_FILE}" <<'CLOUDINIT'
+#cloud-config
+package_update: true
+package_upgrade: false
+packages:
+  - qemu-guest-agent
+  - nfs-common
+  - cifs-utils
+runcmd:
+  - [ systemctl, enable, --now, qemu-guest-agent.service ]
+CLOUDINIT
+
+      $TENANT_OS server create "${VM_NAME}" \
+        --flavor "${VM_FLAVOR}" \
+        --image "${VM_IMAGE}" \
+        --network "${NETWORK_NAME}" \
+        --security-group "${SG_NAME}" \
+        --key-name "${KEYPAIR_NAME}" \
+        --user-data "${USER_DATA_FILE}" \
+        --wait >/dev/null 2>&1
+      rm -f "${USER_DATA_FILE}"
+      echo "  Created VM ${VM_NAME} (cloud-init will install qemu-guest-agent)"
+    fi
+
+    # ------------------------------------------------------------------
+    # 7) Floating IP
+    # ------------------------------------------------------------------
+    echo ">>> [7/8] Floating IP..."
+    EXISTING_FIP=$($TENANT_OS server show "${VM_NAME}" -f json 2>/dev/null \
+      | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+addrs = d.get("addresses", "")
+if isinstance(addrs, str):
+    # parse "network=ip1, ip2" format
+    for part in addrs.replace(",", " ").split():
+        octets = part.strip().split(".")
+        if len(octets) == 4 and not part.startswith("192.168.50."):
+            print(part.strip())
+            break
+' 2>/dev/null) || true
+
+    if [ -n "$EXISTING_FIP" ]; then
+      echo "  (floating IP already assigned: ${EXISTING_FIP})"
+      FIP_ADDR="${EXISTING_FIP}"
+    else
+      FIP_ADDR=$($TENANT_OS floating ip create "${EXTERNAL_NETWORK}" -f json 2>/dev/null \
+        | python3 -c 'import json,sys; print(json.load(sys.stdin)["floating_ip_address"])' 2>/dev/null) || true
+
+      if [ -z "$FIP_ADDR" ]; then
+        echo "  WARNING: Could not allocate floating IP. VM will not be reachable externally."
+      else
+        $TENANT_OS server add floating ip "${VM_NAME}" "${FIP_ADDR}" 2>/dev/null || true
+        echo "  Assigned floating IP: ${FIP_ADDR}"
+      fi
+    fi
+
+    # ------------------------------------------------------------------
+    # 8) Wait for share, grant access, and mount
+    # ------------------------------------------------------------------
+    echo ">>> [8/8] Share access and mount..."
+
+    # Wait for share to be available
+    echo "  Waiting for share to become available..."
+    ATTEMPTS=0
+    while [ "$ATTEMPTS" -lt 60 ]; do
+      SHARE_STATUS=$($TENANT_OS share show "${SHARE_NAME}" -f json 2>/dev/null \
+        | python3 -c 'import json,sys; print(json.load(sys.stdin).get("status",""))' 2>/dev/null) || true
+      if [ "$SHARE_STATUS" = "available" ]; then
+        break
+      elif [ "$SHARE_STATUS" = "error" ]; then
+        echo "  ERROR: Share is in error state!"
+        break
+      fi
+      ATTEMPTS=$((ATTEMPTS + 1))
+      sleep 10
+    done
+
+    if [ "$SHARE_STATUS" = "available" ]; then
+      echo "  Share is available."
+
+      # Get the VM's fixed IP for access rule
+      VM_FIXED_IP=$($TENANT_OS server show "${VM_NAME}" -f json 2>/dev/null \
+        | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+addrs = d.get("addresses", "")
+if isinstance(addrs, str):
+    for part in addrs.replace(",", " ").split():
+        part = part.strip()
+        if part.startswith("192.168.50."):
+            print(part)
+            break
+elif isinstance(addrs, dict):
+    for net, ips in addrs.items():
+        for ip_info in ips:
+            addr = ip_info if isinstance(ip_info, str) else ip_info.get("addr","")
+            if addr.startswith("192.168.50."):
+                print(addr)
+                break
+' 2>/dev/null) || true
+
+      if [ -n "$VM_FIXED_IP" ]; then
+        # Grant IP-based access to the share
+        echo "  Granting NFS access to ${VM_FIXED_IP}..."
+        $TENANT_OS share access create "${SHARE_NAME}" ip "${VM_FIXED_IP}" 2>/dev/null || true
+
+        # Get the export path
+        EXPORT_PATH=$($TENANT_OS share export location list "${SHARE_NAME}" -f json 2>/dev/null \
+          | python3 -c '
+import json, sys
+locs = json.load(sys.stdin)
+if locs:
+    print(locs[0].get("Path", locs[0].get("path", "")))
+' 2>/dev/null) || true
+
+        echo "  Export path: ${EXPORT_PATH:-pending (share server may still be provisioning)}"
+      else
+        echo "  WARNING: Could not determine VM fixed IP."
+      fi
+    fi
+
+    # Summary for this tenant
+    echo ""
+    echo "  --- Summary for ${tenant} ---"
+    echo "  VM:          ${VM_NAME}"
+    echo "  Floating IP: ${FIP_ADDR:-none}"
+    echo "  Share:       ${SHARE_NAME} (${SHARE_STATUS:-unknown})"
+    echo "  Export:      ${EXPORT_PATH:-pending}"
+    if [ -n "$FIP_ADDR" ] && [ -f "${KEY_DIR}/id_ed25519" ]; then
+      # Determine SSH user based on image
+      SSH_USER="ubuntu"
+      case "${VM_IMAGE,,}" in
+        *cirros*)  SSH_USER="cirros" ;;
+        *centos*)  SSH_USER="centos" ;;
+        *debian*)  SSH_USER="debian" ;;
+        *fedora*)  SSH_USER="fedora" ;;
+        *ubuntu*|*amphora*) SSH_USER="ubuntu" ;;
+      esac
+      echo "  SSH:         ssh -i ${KEY_DIR}/id_ed25519 ${SSH_USER}@${FIP_ADDR}"
+      if [ -n "$EXPORT_PATH" ]; then
+        echo "  Mount:       sudo mkdir -p /mnt/share && sudo mount -t nfs ${EXPORT_PATH} /mnt/share"
+      fi
+    fi
+  done
+
+  # Summary table
+  echo ""
+  echo "============================================================"
+  echo "  OVERALL STATUS"
+  echo "============================================================"
+  printf "  %-15s %-18s %-12s %-10s\n" "TENANT" "FLOATING IP" "SHARE" "VM"
+  printf "  %-15s %-18s %-12s %-10s\n" "------" "-----------" "-----" "--"
+
+  for tenant in $TENANTS; do
+    TENANT_OS="openstack --os-cloud=${tenant}"
+
+    FIP=$($TENANT_OS server show "${tenant}-test-vm" -f json 2>/dev/null \
+      | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+addrs = d.get("addresses", "")
+if isinstance(addrs, str):
+    for part in addrs.replace(",", " ").split():
+        part = part.strip()
+        if not part.startswith("192.168.50.") and "." in part:
+            try:
+                [int(o) for o in part.split(".")]
+                print(part)
+                break
+            except ValueError:
+                pass
+' 2>/dev/null) || true
+
+    SHARE_ST=$($TENANT_OS share show "${tenant}-test-share" -f json 2>/dev/null \
+      | python3 -c 'import json,sys; print(json.load(sys.stdin).get("status","?"))' 2>/dev/null) || true
+
+    VM_ST=$($TENANT_OS server show "${tenant}-test-vm" -f json 2>/dev/null \
+      | python3 -c 'import json,sys; print(json.load(sys.stdin).get("status","?"))' 2>/dev/null) || true
+
+    printf "  %-15s %-18s %-12s %-10s\n" "${tenant}" "${FIP:-none}" "${SHARE_ST:-?}" "${VM_ST:-?}"
+  done
+
+fi
+
+# ==========================================================================
+# DESTROY
+# ==========================================================================
+if [ "$ACTION" = "destroy" ]; then
+
+  echo "============================================================"
+  echo "  DESTROYING TEST SHARES, VMs, AND NETWORKING"
+  echo "============================================================"
+
+  for tenant in $TENANTS; do
+    echo ""
+    echo ">>> ${tenant}: tearing down..."
+
+    TENANT_OS="openstack --os-cloud=${tenant}"
+    VM_NAME="${tenant}-test-vm"
+    SHARE_NAME="${tenant}-test-share"
+    SHARE_NET_NAME="${tenant}-share-network"
+    ROUTER_NAME="${tenant}-router"
+    SG_NAME="${tenant}-test-sg"
+    KEYPAIR_NAME="${tenant}-keypair"
+    SUBNET_NAME="${tenant}-subnet"
+    KEY_DIR="${CUSTOMER_DIR}/${tenant}"
+
+    # Delete VM
+    echo "  Deleting VM..."
+    $TENANT_OS server delete "${VM_NAME}" --wait 2>/dev/null || true
+
+    # Delete floating IPs
+    echo "  Releasing floating IPs..."
+    FIPS=$($TENANT_OS floating ip list -f json 2>/dev/null \
+      | python3 -c 'import json,sys; [print(f["ID"]) for f in json.load(sys.stdin)]' 2>/dev/null) || true
+    for fid in $FIPS; do
+      $TENANT_OS floating ip delete "$fid" 2>/dev/null || true
+    done
+
+    # Revoke share access rules
+    echo "  Revoking share access..."
+    ACCESS_IDS=$($TENANT_OS share access list "${SHARE_NAME}" -f json 2>/dev/null \
+      | python3 -c 'import json,sys; [print(a["id"]) for a in json.load(sys.stdin)]' 2>/dev/null) || true
+    for aid in $ACCESS_IDS; do
+      $TENANT_OS share access delete "${SHARE_NAME}" "$aid" 2>/dev/null || true
+    done
+
+    # Delete shares
+    echo "  Deleting shares..."
+    SHARE_IDS=$($TENANT_OS share list -f json 2>/dev/null \
+      | python3 -c 'import json,sys; [print(s["ID"]) for s in json.load(sys.stdin)]' 2>/dev/null) || true
+    for sid in $SHARE_IDS; do
+      $TENANT_OS share delete "$sid" --force 2>/dev/null || true
+    done
+
+    # Wait for shares to be deleted
+    if [ -n "$SHARE_IDS" ]; then
+      echo "  Waiting for shares to be deleted..."
+      ATTEMPTS=0
+      while [ "$ATTEMPTS" -lt 30 ]; do
+        REMAINING=$($TENANT_OS share list -f json 2>/dev/null \
+          | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))' 2>/dev/null) || true
+        if [ "$REMAINING" = "0" ] || [ -z "$REMAINING" ]; then
+          break
+        fi
+        ATTEMPTS=$((ATTEMPTS + 1))
+        sleep 5
+      done
+    fi
+
+    # Delete share-networks
+    echo "  Deleting share-networks..."
+    SHARE_NET_IDS=$($TENANT_OS share network list -f json 2>/dev/null \
+      | python3 -c 'import json,sys; [print(s["id"]) for s in json.load(sys.stdin)]' 2>/dev/null) || true
+    for snid in $SHARE_NET_IDS; do
+      $TENANT_OS share network delete "$snid" 2>/dev/null || true
+    done
+
+    # Remove router interfaces and delete router
+    echo "  Removing router..."
+    $TENANT_OS router remove subnet "${ROUTER_NAME}" "${SUBNET_NAME}" 2>/dev/null || true
+    $TENANT_OS router unset --external-gateway "${ROUTER_NAME}" 2>/dev/null || true
+    $TENANT_OS router delete "${ROUTER_NAME}" 2>/dev/null || true
+
+    # Delete security group
+    echo "  Deleting security group..."
+    $TENANT_OS security group delete "${SG_NAME}" 2>/dev/null || true
+
+    # Delete keypair and local key files
+    echo "  Deleting keypair..."
+    $TENANT_OS keypair delete "${KEYPAIR_NAME}" 2>/dev/null || true
+    rm -f "${KEY_DIR}/id_ed25519" "${KEY_DIR}/id_ed25519.pub" 2>/dev/null || true
+    rmdir "${KEY_DIR}" 2>/dev/null || true
+
+    echo "  Done: ${tenant}"
+  done
+
+  echo ""
+  echo "============================================================"
+  echo "  TEARDOWN COMPLETE"
+  echo "============================================================"
+fi

--- a/ansible/roles/manila_enablement_techpreview/files/manage-test-tenants.sh
+++ b/ansible/roles/manila_enablement_techpreview/files/manage-test-tenants.sh
@@ -1,0 +1,379 @@
+#!/bin/bash
+# ==========================================================================
+# manage-test-tenants.sh
+#
+# Create, destroy, or reset 2 test tenant accounts with networks, subnets,
+# admin users, and clouds.yaml credentials.
+#
+#   Usage:
+#     manage-test-tenants.sh create   — create tenants (skip if they exist)
+#     manage-test-tenants.sh destroy  — delete all tenant resources, users, and projects
+#     manage-test-tenants.sh reset    — destroy everything and recreate
+#
+# Run as: ubuntu@controller
+# Requires: genestack venv, admin cloud credentials, yq
+# ==========================================================================
+
+ACTION="${1:-}"
+
+if [[ "$ACTION" != "create" && "$ACTION" != "destroy" && "$ACTION" != "reset" ]]; then
+  echo "Usage: $0 {create|destroy|reset}"
+  echo ""
+  echo "  create   — Create test tenants, users, networks, subnets, clouds.yaml"
+  echo "  destroy  — Delete all tenant resources, users, and projects"
+  echo "  reset    — Destroy everything and recreate from scratch"
+  exit 1
+fi
+
+# --------------------------------------------------------------------------
+# Environment setup
+# --------------------------------------------------------------------------
+source /home/ubuntu/.venvs/genestack/bin/activate
+set -a
+source /opt/genestack/scripts/genestack.rc
+set +a
+export HOME=/home/ubuntu
+OS="openstack --os-cloud=default"
+
+TENANTS=("acme-corp" "globex-inc")
+CUSTOMER_DIR=/home/ubuntu/customers
+
+# --------------------------------------------------------------------------
+# Helper: generate random password
+# --------------------------------------------------------------------------
+generate_password() {
+  < /dev/urandom tr -dc 'A-Za-z0-9' | head -c"${1:-24}"
+}
+
+# --------------------------------------------------------------------------
+# Helper: delete all resources in a tenant project, then the user and project
+# --------------------------------------------------------------------------
+destroy_tenant() {
+  local tenant="$1"
+
+  PROJECT_ID=$($OS project show "$tenant" -f json 2>/dev/null \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' 2>/dev/null) || true
+
+  if [ -z "$PROJECT_ID" ]; then
+    echo "  (project ${tenant} not found, skipping)"
+    return
+  fi
+
+  echo "  Cleaning up ${tenant} (${PROJECT_ID})..."
+
+  # Share access rules (must be revoked before shares can be deleted)
+  TENANT_SHARES=$($OS share list --project "$PROJECT_ID" --all-projects -f json 2>/dev/null \
+    | python3 -c 'import json,sys; [print(s["ID"]) for s in json.load(sys.stdin)]' 2>/dev/null) || true
+  for sid in $TENANT_SHARES; do
+    ACCESS_IDS=$($OS share access list "$sid" -f json 2>/dev/null \
+      | python3 -c 'import json,sys; [print(a["id"]) for a in json.load(sys.stdin)]' 2>/dev/null) || true
+    for aid in $ACCESS_IDS; do
+      echo "    Revoking share access $aid on share $sid..."
+      $OS share access delete "$sid" "$aid" 2>/dev/null || true
+    done
+  done
+
+  # Shares
+  for sid in $TENANT_SHARES; do
+    echo "    Deleting share $sid..."
+    $OS share delete "$sid" --force 2>/dev/null || true
+  done
+
+  # Wait for shares to finish deleting before removing share-networks
+  if [ -n "$TENANT_SHARES" ]; then
+    echo "    Waiting for shares to be deleted..."
+    ATTEMPTS=0
+    while [ "$ATTEMPTS" -lt 30 ]; do
+      REMAINING=$($OS share list --project "$PROJECT_ID" --all-projects -f json 2>/dev/null \
+        | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))' 2>/dev/null) || true
+      if [ "$REMAINING" = "0" ] || [ -z "$REMAINING" ]; then
+        break
+      fi
+      ATTEMPTS=$((ATTEMPTS + 1))
+      sleep 5
+    done
+  fi
+
+  # Share networks (must be deleted after shares that reference them)
+  TENANT_SHARE_NETS=$($OS share network list --project "$PROJECT_ID" --all-projects -f json 2>/dev/null \
+    | python3 -c 'import json,sys; [print(s["id"]) for s in json.load(sys.stdin)]' 2>/dev/null) || true
+  for id in $TENANT_SHARE_NETS; do
+    echo "    Deleting share-network $id..."
+    $OS share network delete "$id" 2>/dev/null || true
+  done
+
+  # Servers
+  TENANT_SERVERS=$($OS server list --project "$PROJECT_ID" --all-projects -f json 2>/dev/null \
+    | python3 -c 'import json,sys; [print(s["ID"]) for s in json.load(sys.stdin)]' 2>/dev/null) || true
+  for id in $TENANT_SERVERS; do
+    echo "    Deleting server $id..."
+    $OS server delete "$id" --wait 2>/dev/null || true
+  done
+
+  # Floating IPs
+  TENANT_FIPS=$($OS floating ip list --project "$PROJECT_ID" -f json 2>/dev/null \
+    | python3 -c 'import json,sys; [print(f["ID"]) for f in json.load(sys.stdin)]' 2>/dev/null) || true
+  for id in $TENANT_FIPS; do
+    echo "    Deleting floating IP $id..."
+    $OS floating ip delete "$id" 2>/dev/null || true
+  done
+
+  # Routers (remove interfaces and gateway first)
+  TENANT_ROUTERS=$($OS router list --project "$PROJECT_ID" -f json 2>/dev/null \
+    | python3 -c 'import json,sys; [print(r["ID"]) for r in json.load(sys.stdin)]' 2>/dev/null) || true
+  for rid in $TENANT_ROUTERS; do
+    echo "    Cleaning up router $rid..."
+    ROUTER_SUBNETS=$($OS router show "$rid" -f json 2>/dev/null \
+      | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+for iface in d.get("interfaces_info", []):
+    print(iface["subnet_id"])
+' 2>/dev/null) || true
+    for rsub in $ROUTER_SUBNETS; do
+      $OS router remove subnet "$rid" "$rsub" 2>/dev/null || true
+    done
+    $OS router unset --external-gateway "$rid" 2>/dev/null || true
+    $OS router delete "$rid" 2>/dev/null || true
+  done
+
+  # Ports
+  TENANT_PORTS=$($OS port list --project "$PROJECT_ID" -f json 2>/dev/null \
+    | python3 -c 'import json,sys; [print(p["ID"]) for p in json.load(sys.stdin)]' 2>/dev/null) || true
+  for id in $TENANT_PORTS; do
+    $OS port delete "$id" 2>/dev/null || true
+  done
+
+  # Subnets
+  TENANT_SUBNETS=$($OS subnet list --project "$PROJECT_ID" -f json 2>/dev/null \
+    | python3 -c 'import json,sys; [print(s["ID"]) for s in json.load(sys.stdin)]' 2>/dev/null) || true
+  for id in $TENANT_SUBNETS; do
+    echo "    Deleting subnet $id..."
+    $OS subnet delete "$id" 2>/dev/null || true
+  done
+
+  # Networks
+  TENANT_NETS=$($OS network list --project "$PROJECT_ID" -f json 2>/dev/null \
+    | python3 -c 'import json,sys; [print(n["ID"]) for n in json.load(sys.stdin)]' 2>/dev/null) || true
+  for id in $TENANT_NETS; do
+    echo "    Deleting network $id..."
+    $OS network delete "$id" 2>/dev/null || true
+  done
+
+  # Security groups (skip 'default')
+  TENANT_SGS=$($OS security group list --project "$PROJECT_ID" -f json 2>/dev/null \
+    | python3 -c '
+import json, sys
+for sg in json.load(sys.stdin):
+    if sg.get("Name", "") != "default":
+        print(sg["ID"])
+' 2>/dev/null) || true
+  for id in $TENANT_SGS; do
+    echo "    Deleting security group $id..."
+    $OS security group delete "$id" 2>/dev/null || true
+  done
+
+  # Volumes
+  TENANT_VOLS=$($OS volume list --project "$PROJECT_ID" --all-projects -f json 2>/dev/null \
+    | python3 -c 'import json,sys; [print(v["ID"]) for v in json.load(sys.stdin)]' 2>/dev/null) || true
+  for id in $TENANT_VOLS; do
+    echo "    Deleting volume $id..."
+    $OS volume delete "$id" --force 2>/dev/null || true
+  done
+
+  # Keypairs (delete via tenant cloud if possible, otherwise skip)
+  TENANT_KEYPAIRS=$($OS keypair list --project "$PROJECT_ID" -f json 2>/dev/null \
+    | python3 -c 'import json,sys; [print(k["Name"]) for k in json.load(sys.stdin)]' 2>/dev/null) || true
+  for kp in $TENANT_KEYPAIRS; do
+    echo "    Deleting keypair $kp..."
+    $OS keypair delete "$kp" --user "${tenant}-admin" 2>/dev/null || true
+  done
+
+  # User
+  echo "    Deleting user ${tenant}-admin..."
+  $OS user delete "${tenant}-admin" 2>/dev/null || true
+
+  # Project
+  echo "    Deleting project ${tenant}..."
+  $OS project delete "$tenant" 2>/dev/null || true
+
+  # Local credential files
+  if [ -d "${CUSTOMER_DIR}/${tenant}" ]; then
+    echo "    Removing local keys in ${CUSTOMER_DIR}/${tenant}..."
+    rm -rf "${CUSTOMER_DIR}/${tenant}" 2>/dev/null || true
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Helper: create tenants, users, networks, subnets, clouds.yaml
+# --------------------------------------------------------------------------
+create_tenants() {
+  AUTH_URL=$($OS endpoint list -f json \
+    | python3 -c '
+import json, sys
+for ep in json.load(sys.stdin):
+    if ep["Service Name"] == "keystone" and ep["Interface"] == "internal":
+        print(ep["URL"])
+        break
+')
+
+  if [ -z "$AUTH_URL" ]; then
+    echo "ERROR: Could not determine AUTH_URL from keystone endpoints"
+    exit 1
+  fi
+
+  mkdir -p "$CUSTOMER_DIR"
+
+  cat > "${CUSTOMER_DIR}/clouds.yaml" << 'HEADER'
+clouds:
+HEADER
+
+  for tenant in "${TENANTS[@]}"; do
+    USERNAME="${tenant}-admin"
+    PASSWORD=$(generate_password 32)
+
+    echo ""
+    echo ">>> Creating project: ${tenant}"
+
+    $OS project create "$tenant" \
+      --domain default \
+      --description "Test tenant: ${tenant}" \
+      2>/dev/null || echo "  (project already exists)"
+
+    $OS user create "$USERNAME" \
+      --domain default \
+      --project "$tenant" \
+      --password "$PASSWORD" \
+      --description "Admin user for ${tenant}" \
+      2>/dev/null || echo "  (user already exists, resetting password)"
+
+    $OS user set "$USERNAME" --password "$PASSWORD" 2>/dev/null || true
+
+    $OS role add --project "$tenant" --user "$USERNAME" member 2>/dev/null || true
+    $OS role add --project "$tenant" --user "$USERNAME" admin 2>/dev/null || true
+
+    echo "  Project: ${tenant}  User: ${USERNAME}  Roles: member, admin"
+
+    cat >> "${CUSTOMER_DIR}/clouds.yaml" << EOF
+  ${tenant}:
+    auth:
+      auth_url: ${AUTH_URL}
+      project_name: ${tenant}
+      project_domain_name: Default
+      username: ${USERNAME}
+      user_domain_name: Default
+      password: ${PASSWORD}
+    region_name: RegionOne
+    interface: internal
+    identity_api_version: 3
+EOF
+  done
+
+  chmod 0640 "${CUSTOMER_DIR}/clouds.yaml"
+
+  # Create tenant networks and subnets
+  # Point the OpenStack client at the tenant clouds.yaml
+  export OS_CLIENT_CONFIG_FILE="${CUSTOMER_DIR}/clouds.yaml"
+
+  echo ""
+  echo "============================================================"
+  echo "  CREATING TENANT NETWORKS AND SUBNETS"
+  echo "============================================================"
+
+  for tenant in $(yq '.clouds | keys | .[]' "${CUSTOMER_DIR}/clouds.yaml"); do
+    echo ""
+    echo ">>> Creating network and subnet for: ${tenant}"
+
+    openstack --os-cloud="${tenant}" network create \
+      --project="${tenant}" \
+      --provider-network-type=geneve \
+      --internal \
+      --enable-port-security \
+      --enable \
+      "${tenant}-network" 2>/dev/null || echo "  (network already exists)"
+
+    openstack --os-cloud="${tenant}" subnet create \
+      --project="${tenant}" \
+      --dhcp \
+      --network="${tenant}-network" \
+      --subnet-range=192.168.50.0/24 \
+      --gateway=192.168.50.1 \
+      "${tenant}-subnet" 2>/dev/null || echo "  (subnet already exists)"
+
+    echo "  Created: ${tenant}-network / ${tenant}-subnet (192.168.50.0/24)"
+  done
+
+  # Restore default clouds.yaml search path for admin commands
+  unset OS_CLIENT_CONFIG_FILE
+}
+
+# ==========================================================================
+# Main
+# ==========================================================================
+
+# --------------------------------------------------------------------------
+# Action: destroy
+# --------------------------------------------------------------------------
+if [ "$ACTION" = "destroy" ]; then
+  echo "============================================================"
+  echo "  DESTROYING ALL TEST TENANTS"
+  echo "============================================================"
+  echo ""
+  echo ">>> Destroying tenant resources, users, and projects..."
+
+  for tenant in "${TENANTS[@]}"; do
+    destroy_tenant "$tenant"
+  done
+
+  rm -f "${CUSTOMER_DIR}/clouds.yaml" 2>/dev/null || true
+
+  echo ""
+  echo "============================================================"
+  echo "  DESTROY COMPLETE"
+  echo "============================================================"
+  echo ""
+  echo "All test tenant projects, users, and resources have been removed."
+  exit 0
+fi
+
+# --------------------------------------------------------------------------
+# Action: reset (destroy + create)
+# --------------------------------------------------------------------------
+if [ "$ACTION" = "reset" ]; then
+  echo "============================================================"
+  echo "  RESETTING TEST TENANTS"
+  echo "============================================================"
+  echo ""
+  echo ">>> Destroying existing tenant resources and projects..."
+
+  for tenant in "${TENANTS[@]}"; do
+    destroy_tenant "$tenant"
+  done
+
+  rm -f "${CUSTOMER_DIR}/clouds.yaml" 2>/dev/null || true
+
+  echo ""
+  echo ">>> All test tenants removed. Recreating..."
+fi
+
+# --------------------------------------------------------------------------
+# Action: create (also reached by reset after destroy)
+# --------------------------------------------------------------------------
+if [ "$ACTION" = "create" ]; then
+  echo "============================================================"
+  echo "  CREATING TEST TENANTS"
+  echo "============================================================"
+fi
+
+create_tenants
+
+echo ""
+echo "============================================================"
+echo "  DONE"
+echo "============================================================"
+echo ""
+echo "Tenant credentials written to: ${CUSTOMER_DIR}/clouds.yaml"
+echo ""
+echo "Test with:"
+echo "  openstack --os-cloud=acme-corp token issue"
+echo "  openstack --os-cloud=acme-corp network list"

--- a/ansible/roles/manila_enablement_techpreview/files/manila-full-teardown-and-test-tenants.sh
+++ b/ansible/roles/manila_enablement_techpreview/files/manila-full-teardown-and-test-tenants.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# ==========================================================================
+# manila-full-teardown.sh
+#
+# Tears down ALL Manila resources: Helm release, K8s objects, share server
+# VMs, service network/subnet, router, security groups, keypair, and image.
+#
+# Run as: ubuntu@controller
+# Requires: genestack venv, admin cloud credentials
+# ==========================================================================
+
+# --------------------------------------------------------------------------
+# Environment setup
+# --------------------------------------------------------------------------
+source /home/ubuntu/.venvs/genestack/bin/activate
+set -a
+source /opt/genestack/scripts/genestack.rc
+set +a
+export HOME=/home/ubuntu
+OS="openstack --os-cloud=default"
+
+echo "============================================================"
+echo "  MANILA FULL TEARDOWN"
+echo "============================================================"
+
+# --------------------------------------------------------------------------
+# 1) Uninstall Manila Helm release and delete ALL k8s resources
+# --------------------------------------------------------------------------
+echo ""
+echo ">>> [1/7] Removing Manila Helm release..."
+helm -n openstack uninstall manila --wait 2>/dev/null || echo "  (no helm release found)"
+
+echo ">>> [1/7] Deleting Manila K8s jobs..."
+kubectl -n openstack delete job \
+  manila-db-sync \
+  manila-ks-endpoints \
+  manila-ks-service \
+  manila-ks-user \
+  --ignore-not-found=true 2>/dev/null || true
+
+echo ">>> [1/7] Deleting Manila K8s secrets..."
+for secret in \
+  manila-admin \
+  manila-db-admin \
+  manila-db-password \
+  manila-db-user \
+  manila-etc \
+  manila-keystone-admin \
+  manila-keystone-user \
+  manila-rabbitmq-admin \
+  manila-rabbitmq-password \
+  manila-rabbitmq-user \
+  manila-service-keypair \
+  manila-user-credentials; do
+  kubectl -n openstack delete secret "$secret" --ignore-not-found=true 2>/dev/null || true
+done
+
+echo ">>> [1/7] Deleting Manila Helm release secrets..."
+kubectl -n openstack delete secret -l name=manila,owner=helm --ignore-not-found=true 2>/dev/null || true
+
+echo ">>> [1/7] Deleting Manila configmaps..."
+kubectl -n openstack delete cm manila-bin --ignore-not-found=true 2>/dev/null || true
+
+# --------------------------------------------------------------------------
+# 2) Delete Manila share servers (VMs) if any exist
+# --------------------------------------------------------------------------
+echo ""
+echo ">>> [2/7] Deleting Manila share server VMs..."
+MANILA_SERVERS=$($OS server list --all-projects -f json 2>/dev/null \
+  | python3 -c '
+import json, sys
+servers = json.load(sys.stdin)
+for s in servers:
+    name = s.get("Name", "").lower()
+    if "manila" in name or "share" in name:
+        print(s["ID"])
+' 2>/dev/null) || true
+
+if [ -n "$MANILA_SERVERS" ]; then
+  for sid in $MANILA_SERVERS; do
+    echo "  Deleting server $sid..."
+    $OS server delete "$sid" --wait 2>/dev/null || true
+  done
+else
+  echo "  (no Manila VMs found)"
+fi
+
+# --------------------------------------------------------------------------
+# 3) Delete ports on manila-service-network
+# --------------------------------------------------------------------------
+echo ""
+echo ">>> [3/7] Deleting ports on manila-service-network..."
+MANILA_PORTS=$($OS port list --network manila-service-network -f json 2>/dev/null \
+  | python3 -c 'import json,sys; [print(p["ID"]) for p in json.load(sys.stdin)]' 2>/dev/null) || true
+
+if [ -n "$MANILA_PORTS" ]; then
+  for pid in $MANILA_PORTS; do
+    echo "  Deleting port $pid..."
+    $OS router remove port manila-share-router "$pid" 2>/dev/null || true
+    $OS port delete "$pid" 2>/dev/null || true
+  done
+else
+  echo "  (no ports found)"
+fi
+
+# --------------------------------------------------------------------------
+# 4) Delete manila-service-subnet and manila-service-network
+# --------------------------------------------------------------------------
+echo ""
+echo ">>> [4/7] Deleting manila-service-network and subnet..."
+
+SUBNET_ID=$($OS subnet show manila-service-subnet -f json 2>/dev/null \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' 2>/dev/null) || true
+
+if [ -n "$SUBNET_ID" ]; then
+  ROUTER_IDS=$($OS router list -f json 2>/dev/null \
+    | python3 -c 'import json,sys; [print(r["ID"]) for r in json.load(sys.stdin)]' 2>/dev/null) || true
+  for rid in $ROUTER_IDS; do
+    $OS router remove subnet "$rid" "$SUBNET_ID" 2>/dev/null || true
+  done
+  $OS subnet delete manila-service-subnet 2>/dev/null || echo "  (subnet already gone)"
+else
+  echo "  (subnet not found)"
+fi
+
+$OS network delete manila-service-network 2>/dev/null || echo "  (network already gone)"
+
+# --------------------------------------------------------------------------
+# 5) Delete Manila router
+# --------------------------------------------------------------------------
+echo ""
+echo ">>> [5/7] Deleting Manila router(s)..."
+
+ROUTER_INFO=$($OS router show manila-share-router -f json 2>/dev/null) || true
+if [ -n "$ROUTER_INFO" ]; then
+  IFACE_SUBNETS=$(echo "$ROUTER_INFO" \
+    | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+for iface in d.get("interfaces_info", []):
+    print(iface["subnet_id"])
+' 2>/dev/null) || true
+
+  for sub in $IFACE_SUBNETS; do
+    echo "  Removing subnet $sub from manila-share-router..."
+    $OS router remove subnet manila-share-router "$sub" 2>/dev/null || true
+  done
+
+  $OS router unset --external-gateway manila-share-router 2>/dev/null || true
+
+  echo "  Deleting manila-share-router..."
+  $OS router delete manila-share-router 2>/dev/null || true
+else
+  echo "  (no manila-share-router found)"
+fi
+
+# --------------------------------------------------------------------------
+# 6) Delete Manila security groups
+# --------------------------------------------------------------------------
+echo ""
+echo ">>> [6/7] Deleting Manila security groups..."
+MANILA_SGS=$($OS security group list --project admin -f json 2>/dev/null \
+  | python3 -c '
+import json, sys
+for sg in json.load(sys.stdin):
+    if "manila" in sg.get("Name", "").lower():
+        print(sg["ID"])
+' 2>/dev/null) || true
+
+if [ -n "$MANILA_SGS" ]; then
+  for sgid in $MANILA_SGS; do
+    echo "  Deleting security group $sgid..."
+    $OS security group delete "$sgid" 2>/dev/null || true
+  done
+else
+  echo "  (no Manila security groups found)"
+fi
+
+# --------------------------------------------------------------------------
+# 7) Delete Manila OpenStack keypair, Glance image, and quota marker
+# --------------------------------------------------------------------------
+echo ""
+echo ">>> [7/7] Deleting Manila keypair, image, and quota marker..."
+$OS keypair delete manila-service-keypair 2>/dev/null || echo "  (keypair already gone)"
+$OS image delete manila-service-image 2>/dev/null || echo "  (image already gone)"
+rm -f /etc/genestack/.manila_quotas_applied && echo "  Removed quota marker" || true
+
+echo ""
+echo "============================================================"
+echo "  MANILA TEARDOWN COMPLETE"
+echo "============================================================"
+echo ""
+echo "Next step: run the manila_enablement_techpreview ansible role to re-deploy"

--- a/ansible/roles/manila_enablement_techpreview/files/merge_endpoints.py
+++ b/ansible/roles/manila_enablement_techpreview/files/merge_endpoints.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Deep-merge a Manila endpoints fragment into global_overrides/endpoints.yaml.
+
+Preserves the _region YAML anchor line that safe_load would otherwise drop.
+
+Usage:
+    python3 merge_endpoints.py ENDPOINTS_FILE FRAGMENT_FILE
+"""
+import copy
+import os
+import sys
+import yaml
+
+
+def deep_merge(base, overlay):
+    """Recursively merge overlay into base. Overlay values win."""
+    result = copy.deepcopy(base)
+    for key, value in overlay.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = copy.deepcopy(value)
+    return result
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} ENDPOINTS_FILE FRAGMENT_FILE", file=sys.stderr)
+        sys.exit(1)
+
+    endpoints_file = sys.argv[1]
+    fragment_file = sys.argv[2]
+    anchor_line = ""
+
+    if os.path.exists(endpoints_file):
+        with open(endpoints_file, "r") as fh:
+            content = fh.read()
+            base = yaml.safe_load(content) or {}
+            for line in content.splitlines():
+                if line.strip().startswith("_region:"):
+                    anchor_line = line
+                    break
+    else:
+        base = {}
+
+    with open(fragment_file, "r") as fh:
+        fragment = yaml.safe_load(fh) or {}
+
+    merged = deep_merge(base, fragment)
+
+    with open(endpoints_file, "w") as fh:
+        if anchor_line:
+            fh.write(anchor_line + "\n\n")
+        # Remove _region from the dict so it is not dumped twice
+        merged.pop("_region", None)
+        yaml.dump(merged, fh, default_flow_style=False, sort_keys=False, width=200)
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible/roles/manila_enablement_techpreview/files/merge_manila_secret.py
+++ b/ansible/roles/manila_enablement_techpreview/files/merge_manila_secret.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Merge the Manila service instance password into global_overrides/secrets.yaml.
+
+Reads the password from the _MANILA_SVC_PW environment variable and writes it
+into conf.manila.generic.service_instance_password, preserving any other keys
+already present in the file.
+
+Usage:
+    _MANILA_SVC_PW=<password> python3 merge_manila_secret.py SECRETS_FILE
+"""
+import os
+import sys
+import yaml
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} SECRETS_FILE", file=sys.stderr)
+        sys.exit(1)
+
+    secrets_file = sys.argv[1]
+    password = os.environ.get("_MANILA_SVC_PW", "")
+    if not password:
+        print("Error: _MANILA_SVC_PW environment variable is not set", file=sys.stderr)
+        sys.exit(1)
+
+    if os.path.exists(secrets_file):
+        with open(secrets_file, "r") as fh:
+            data = yaml.safe_load(fh) or {}
+    else:
+        data = {}
+
+    data.setdefault("conf", {}).setdefault("manila", {}).setdefault("generic", {})
+    data["conf"]["manila"]["generic"]["service_instance_password"] = password
+
+    with open(secrets_file, "w") as fh:
+        yaml.dump(data, fh, default_flow_style=False, sort_keys=False)
+    os.chmod(secrets_file, 0o640)
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible/roles/manila_enablement_techpreview/handlers/main.yml
+++ b/ansible/roles/manila_enablement_techpreview/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for manila_enablement_techpreview

--- a/ansible/roles/manila_enablement_techpreview/meta/main.yml
+++ b/ansible/roles/manila_enablement_techpreview/meta/main.yml
@@ -1,0 +1,16 @@
+galaxy_info:
+  author: Dan With
+  description: End-to-end enablement of OpenStack Manila (tech preview)
+  company: Rackspace Technology
+  license: Apache-2.0
+  min_ansible_version: 2.15.8
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/ansible/roles/manila_enablement_techpreview/tasks/main.yml
+++ b/ansible/roles/manila_enablement_techpreview/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+# tasks file for manila_enablement_techpreview
+#
+# Tag strategy:
+#   --tags secrets       → K8s secrets only (keypair, passwords, RabbitMQ/MariaDB sync)
+#   --tags image_build   → service image build/upload (requires secrets to exist)
+#   --tags pre_deploy    → gateway, kustomize, endpoints, helm config (requires image in Glance)
+#   --tags post_deploy   → share type creation (requires Manila API running)
+#   (no tags)            → runs everything in order
+
+- name: Import tasks to create Manila K8s secrets
+  import_tasks: manila_k8s_secrets.yml
+  tags:
+    - secrets
+
+- name: Import tasks to build and upload Manila service image
+  import_tasks: manila_service_image_builder.yml
+  become: true
+  become_user: ubuntu
+  tags:
+    - image_build
+
+- name: Import tasks to create gateway listener, route, kustomize overlay, and endpoints
+  import_tasks: manila_gateway_and_kustomize.yml
+  tags:
+    - pre_deploy
+
+- name: Import tasks to configure Manila Helm values
+  import_tasks: manila_helm_config.yml
+  tags:
+    - pre_deploy
+
+- name: Import tasks to create Manila share type
+  import_tasks: manila_share_type_setup.yml
+  tags:
+    - post_deploy

--- a/ansible/roles/manila_enablement_techpreview/tasks/manila_gateway_and_kustomize.yml
+++ b/ansible/roles/manila_enablement_techpreview/tasks/manila_gateway_and_kustomize.yml
@@ -1,0 +1,260 @@
+---
+# Generate gateway listener, route, kustomize overlay, and endpoint overrides
+# for Manila in /etc/genestack, then patch the envoy gateway and apply the route.
+#
+# These files land inside the /etc/genestack git tree, so the role finishes
+# with a summary telling the operator what changed and that a commit is needed.
+
+# -------------------------------------------------------------------------
+# Discover the region from the existing endpoints.yaml anchor (_region)
+# or fall back to manila_region_name from defaults.
+# -------------------------------------------------------------------------
+- name: Detect region from existing endpoints.yaml
+  ansible.builtin.shell: |
+    if [ -f /etc/genestack/helm-configs/global_overrides/endpoints.yaml ]; then
+      # Grab the YAML anchor value  _region: &region <VALUE>
+      grep -oP '^\s*_region:\s*&\w+\s+\K\S+' \
+        /etc/genestack/helm-configs/global_overrides/endpoints.yaml 2>/dev/null || true
+    fi
+  args:
+    executable: /bin/bash
+  register: _detected_region
+  changed_when: false
+
+- name: Set manila_gateway_region_lower fact
+  ansible.builtin.set_fact:
+    manila_gateway_region_lower: >-
+      {{ (_detected_region.stdout | trim | lower)
+         if (_detected_region.stdout | trim | length > 0)
+         else (manila_region_name | lower) }}
+
+- name: Display resolved gateway region
+  ansible.builtin.debug:
+    msg: "Gateway hostname region component: {{ manila_gateway_region_lower }}"
+
+# -------------------------------------------------------------------------
+# Track files changed for the summary message
+# -------------------------------------------------------------------------
+- name: Initialise list of changed files
+  ansible.builtin.set_fact:
+    _manila_preconf_changed_files: []
+
+# -------------------------------------------------------------------------
+# 1) Envoy gateway listener — /etc/genestack/gateway-api/listeners/
+# -------------------------------------------------------------------------
+- name: Ensure gateway-api listeners directory exists
+  ansible.builtin.file:
+    path: /etc/genestack/gateway-api/listeners
+    state: directory
+    mode: "0755"
+
+- name: Template Manila HTTPS listener JSON
+  ansible.builtin.template:
+    src: manila-https-listener.json.j2
+    dest: /etc/genestack/gateway-api/listeners/manila-https.json
+    mode: "0644"
+  register: _listener_result
+
+- name: Record listener change  # noqa: no-handler
+  ansible.builtin.set_fact:
+    _manila_preconf_changed_files: "{{ _manila_preconf_changed_files + ['/etc/genestack/gateway-api/listeners/manila-https.json'] }}"
+  when: _listener_result.changed
+
+# -------------------------------------------------------------------------
+# 2) Gateway route — /etc/genestack/gateway-api/routes/
+# -------------------------------------------------------------------------
+- name: Ensure gateway-api routes directory exists
+  ansible.builtin.file:
+    path: /etc/genestack/gateway-api/routes
+    state: directory
+    mode: "0755"
+
+- name: Template Manila gateway route
+  ansible.builtin.template:
+    src: custom-manila-gateway-route.yaml.j2
+    dest: /etc/genestack/gateway-api/routes/custom-manila-gateway-route.yaml
+    mode: "0644"
+  register: _route_result
+
+- name: Record route change  # noqa: no-handler
+  ansible.builtin.set_fact:
+    _manila_preconf_changed_files: "{{ _manila_preconf_changed_files + ['/etc/genestack/gateway-api/routes/custom-manila-gateway-route.yaml'] }}"
+  when: _route_result.changed
+
+# -------------------------------------------------------------------------
+# 3) Kustomize overlay — /etc/genestack/kustomize/manila/
+# -------------------------------------------------------------------------
+- name: Ensure kustomize manila overlay directory exists
+  ansible.builtin.file:
+    path: /etc/genestack/kustomize/manila/overlay
+    state: directory
+    mode: "0755"
+
+- name: Create symlink to base-kustomize/manila/aio
+  ansible.builtin.file:
+    src: /opt/genestack/base-kustomize/manila/aio
+    dest: /etc/genestack/kustomize/manila/aio
+    state: link
+    force: true
+  register: _aio_link_result
+
+- name: Record aio symlink change  # noqa: no-handler
+  ansible.builtin.set_fact:
+    _manila_preconf_changed_files: "{{ _manila_preconf_changed_files + ['/etc/genestack/kustomize/manila/aio'] }}"
+  when: _aio_link_result.changed
+
+- name: Create symlink to base-kustomize/manila/base
+  ansible.builtin.file:
+    src: /opt/genestack/base-kustomize/manila/base
+    dest: /etc/genestack/kustomize/manila/base
+    state: link
+    force: true
+  register: _base_link_result
+
+- name: Record base symlink change  # noqa: no-handler
+  ansible.builtin.set_fact:
+    _manila_preconf_changed_files: "{{ _manila_preconf_changed_files + ['/etc/genestack/kustomize/manila/base'] }}"
+  when: _base_link_result.changed
+
+- name: Template kustomization.yaml for Manila overlay
+  ansible.builtin.template:
+    src: manila-kustomization.yaml.j2
+    dest: /etc/genestack/kustomize/manila/overlay/kustomization.yaml
+    mode: "0644"
+  register: _kustomization_result
+
+- name: Record kustomization change  # noqa: no-handler
+  ansible.builtin.set_fact:
+    _manila_preconf_changed_files: "{{ _manila_preconf_changed_files + ['/etc/genestack/kustomize/manila/overlay/kustomization.yaml'] }}"
+  when: _kustomization_result.changed
+
+# -------------------------------------------------------------------------
+# 4) Endpoints — deep-merge Manila stanzas into global_overrides/endpoints.yaml
+# -------------------------------------------------------------------------
+- name: Ensure global_overrides directory exists
+  ansible.builtin.file:
+    path: /etc/genestack/helm-configs/global_overrides
+    state: directory
+    mode: "0755"
+
+- name: Template Manila endpoints fragment
+  ansible.builtin.template:
+    src: manila-endpoints-fragment.yaml.j2
+    dest: /tmp/manila_endpoints_fragment.yaml
+    mode: "0644"
+
+- name: Deep-merge Manila endpoints into global_overrides/endpoints.yaml
+  ansible.builtin.script:
+    cmd: >-
+      merge_endpoints.py
+      /etc/genestack/helm-configs/global_overrides/endpoints.yaml
+      /tmp/manila_endpoints_fragment.yaml
+    executable: python3
+  register: _endpoints_result
+  changed_when: true
+
+- name: Record endpoints change
+  ansible.builtin.set_fact:
+    _manila_preconf_changed_files: "{{ _manila_preconf_changed_files + ['/etc/genestack/helm-configs/global_overrides/endpoints.yaml'] }}"
+
+- name: Remove temporary endpoints fragment
+  ansible.builtin.file:
+    path: /tmp/manila_endpoints_fragment.yaml
+    state: absent
+
+# -------------------------------------------------------------------------
+# 5) Patch the envoy gateway with the Manila listener
+# -------------------------------------------------------------------------
+- name: Patch envoy gateway with Manila HTTPS listener
+  ansible.builtin.shell: |
+    set -o pipefail
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+
+    # Only patch if the listener is not already present
+    EXISTING=$(kubectl -n envoy-gateway get gateway flex-gateway -o json 2>/dev/null \
+      | jq -r '.spec.listeners[]? | select(.name == "manila-https") | .name' 2>/dev/null)
+
+    if [ "$EXISTING" = "manila-https" ]; then
+      echo "Manila HTTPS listener already present on flex-gateway — skipping patch"
+    else
+      kubectl patch -n envoy-gateway gateway flex-gateway \
+        --type='json' \
+        --patch-file /etc/genestack/gateway-api/listeners/manila-https.json
+      echo "Patched flex-gateway with Manila HTTPS listener"
+    fi
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _gw_patch_result
+  changed_when: "'Patched' in _gw_patch_result.stdout"
+
+- name: Show gateway patch result
+  ansible.builtin.debug:
+    msg: "{{ _gw_patch_result.stdout }}"
+
+# -------------------------------------------------------------------------
+# 6) Apply the Manila gateway route
+# -------------------------------------------------------------------------
+- name: Apply Manila gateway route
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    kubectl apply -f /etc/genestack/gateway-api/routes/custom-manila-gateway-route.yaml
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _route_apply_result
+  changed_when: "'created' in _route_apply_result.stdout or 'configured' in _route_apply_result.stdout"
+
+- name: Show route apply result
+  ansible.builtin.debug:
+    msg: "{{ _route_apply_result.stdout }}"
+
+# -------------------------------------------------------------------------
+# 7) Summary — tell the operator what changed and that /etc/genestack is dirty
+# -------------------------------------------------------------------------
+- name: Build preconf summary
+  ansible.builtin.set_fact:
+    _manila_preconf_summary: |
+      ================================================================
+        MANILA PRECONF — FILE CHANGE SUMMARY
+      ================================================================
+
+      The following files/directories were created or modified under
+      /etc/genestack:
+
+      {% for f in _manila_preconf_changed_files %}
+        - {{ f }}
+      {% endfor %}
+      {% if _manila_preconf_changed_files | length == 0 %}
+        (no file changes — all files already existed with correct content)
+      {% endif %}
+
+      Additional runtime actions taken:
+        - Envoy gateway listener: {{ _gw_patch_result.stdout | trim }}
+        - Gateway route: {{ _route_apply_result.stdout | trim }}
+
+      ================================================================
+        ACTION REQUIRED
+      ================================================================
+      The /etc/genestack git tree is likely dirty with uncommitted
+      changes. Before proceeding with install-manila.sh, please:
+
+        cd /etc/genestack
+        git status
+        git add -A
+        git commit -m "Add Manila gateway, kustomize, and endpoint configuration"
+        git push
+
+      ================================================================
+
+- name: Display preconf summary
+  ansible.builtin.debug:
+    msg: "{{ _manila_preconf_summary }}"

--- a/ansible/roles/manila_enablement_techpreview/tasks/manila_helm_config.yml
+++ b/ansible/roles/manila_enablement_techpreview/tasks/manila_helm_config.yml
@@ -1,0 +1,114 @@
+---
+# Configure Manila Helm values after image creation and network setup.
+# - Resolves image ID from OpenStack if not already set as a fact
+# - Retrieves the service instance password from the manila-admin k8s secret
+# - Creates /etc/genestack/helm-configs/global_overrides/secrets.yaml
+#   with the password (kept out of the main helm config template)
+# - Templates the main Manila helm override config with resolved IDs
+
+- name: Retrieve Manila service image ID from OpenStack
+  ansible.builtin.shell: |
+    set -o pipefail
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} image show {{ manila_service_image_name }} \
+      -f json | jq -r .id
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _helm_image_id_result
+  changed_when: false
+  when: manila_service_image_id | length == 0
+
+- name: Set manila_service_image_id fact from OpenStack
+  ansible.builtin.set_fact:
+    manila_service_image_id: "{{ _helm_image_id_result.stdout | trim }}"
+  when: manila_service_image_id | length == 0
+
+- name: Retrieve Manila service flavor ID from OpenStack
+  ansible.builtin.shell: |
+    set -o pipefail
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} flavor show {{ manila_service_instance_flavor_name }} \
+      -f json | jq -r .id
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _helm_flavor_id_result
+  changed_when: false
+  when: manila_service_instance_flavor_id | length == 0
+
+- name: Set manila_service_instance_flavor_id fact from OpenStack
+  ansible.builtin.set_fact:
+    manila_service_instance_flavor_id: "{{ _helm_flavor_id_result.stdout | trim }}"
+  when: manila_service_instance_flavor_id | length == 0
+
+- name: Retrieve Manila service instance password from K8s secret
+  ansible.builtin.shell: |
+    set -o pipefail
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    kubectl -n openstack get secrets/manila-admin \
+      --template={{ '{{' }}.data.password{{ '}}' }} | base64 -d
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _manila_password_result
+  changed_when: false
+  no_log: true
+
+- name: Set manila_service_instance_password fact
+  ansible.builtin.set_fact:
+    manila_service_instance_password: "{{ _manila_password_result.stdout }}"
+  no_log: true
+
+- name: Ensure global_overrides directory exists
+  ansible.builtin.file:
+    path: /etc/genestack/helm-configs/global_overrides
+    state: directory
+    mode: "0755"
+
+- name: Merge Manila service instance password into global_overrides secrets.yaml
+  ansible.builtin.script:
+    cmd: >-
+      merge_manila_secret.py
+      /etc/genestack/helm-configs/global_overrides/secrets.yaml
+    executable: python3
+  environment:
+    _MANILA_SVC_PW: "{{ manila_service_instance_password }}"
+  no_log: true
+
+- name: Ensure Manila helm-configs directory exists
+  ansible.builtin.file:
+    path: /etc/genestack/helm-configs/manila
+    state: directory
+    mode: "0755"
+
+- name: Template selected driver config to temporary file
+  ansible.builtin.template:
+    src: "{{ manila_driver_config_template }}"
+    dest: /tmp/manila_driver_config_fragment.yaml
+    mode: "0644"
+
+- name: Deep-merge driver config into existing manila-helm-overrides.yaml
+  ansible.builtin.script:
+    cmd: >-
+      deep_merge_yaml.py
+      /etc/genestack/helm-configs/manila/manila-helm-overrides.yaml
+      /tmp/manila_driver_config_fragment.yaml
+    executable: python3
+
+- name: Remove temporary driver config fragment
+  ansible.builtin.file:
+    path: /tmp/manila_driver_config_fragment.yaml
+    state: absent

--- a/ansible/roles/manila_enablement_techpreview/tasks/manila_k8s_secrets.yml
+++ b/ansible/roles/manila_enablement_techpreview/tasks/manila_k8s_secrets.yml
@@ -1,0 +1,178 @@
+---
+# Create Manila K8s secrets (rabbitmq, db, admin, service keypair).
+# If manila_force_recreate_secrets or force_full_recreation is true,
+# existing secrets are deleted first and regenerated, and the new
+# passwords are synced to RabbitMQ and MariaDB.
+
+# Compute a single "do we need to recreate all secrets?" flag that
+# accounts for both force flags.
+- name: Derive effective secrets recreation flag
+  ansible.builtin.set_fact:
+    _recreate_all_secrets: "{{ (manila_force_recreate_secrets | bool) or (force_full_recreation | bool) }}"
+
+- name: Remove stale secrets temp files from previous runs
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /tmp/manila_secrets.yml
+    - /tmp/manila_ssh_key
+    - /tmp/manila_ssh_key.pub
+
+- name: Delete existing Manila K8s secrets
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    for secret in manila-rabbitmq-password manila-db-password manila-admin manila-service-keypair; do
+      kubectl -n openstack delete secret "$secret" --ignore-not-found=true
+    done
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: _recreate_all_secrets | bool
+
+- name: Check if Manila K8s secrets already exist
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    kubectl -n openstack get secret manila-rabbitmq-password -o name 2>/dev/null
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _manila_secrets_check
+  changed_when: false
+  failed_when: false
+
+- name: Determine if secrets need to be generated
+  ansible.builtin.set_fact:
+    _do_generate_secrets: "{{ (_manila_secrets_check.rc != 0) or (_recreate_all_secrets | bool) }}"
+
+- name: Generate Manila secrets
+  ansible.builtin.script:
+    cmd: create_manila_k8s_secrets.sh {{ manila_os_region_name }}
+  when: _do_generate_secrets | bool
+
+- name: Apply Manila secrets to Kubernetes
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    kubectl apply -f /tmp/manila_secrets.yml
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: _do_generate_secrets | bool
+
+- name: Clean up temporary secrets file
+  ansible.builtin.file:
+    path: /tmp/manila_secrets.yml
+    state: absent
+
+# --------------------------------------------------------------------------
+# When secrets are created or recreated the new RabbitMQ and DB passwords
+# must be synced to the backing services, otherwise Manila pods crash with
+# ACCESS_REFUSED (RabbitMQ) or access-denied (MariaDB).
+# --------------------------------------------------------------------------
+
+- name: Sync new RabbitMQ password into the RabbitMQ cluster
+  ansible.builtin.shell: |
+    set -o pipefail
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+
+    NEW_PASS=$(kubectl -n openstack get secret manila-rabbitmq-password \
+      -o jsonpath='{.data.password}' | base64 -d)
+
+    # Check if the manila user exists in RabbitMQ
+    if kubectl -n openstack exec rabbitmq-server-0 -- \
+        rabbitmqctl list_users 2>/dev/null | grep -q '^manila'; then
+      echo "Updating existing manila user password in RabbitMQ..."
+      kubectl -n openstack exec rabbitmq-server-0 -- \
+        rabbitmqctl change_password manila "$NEW_PASS"
+    else
+      echo "Creating manila user in RabbitMQ..."
+      kubectl -n openstack exec rabbitmq-server-0 -- \
+        rabbitmqctl add_user manila "$NEW_PASS"
+      kubectl -n openstack exec rabbitmq-server-0 -- \
+        rabbitmqctl set_permissions manila ".*" ".*" ".*"
+      kubectl -n openstack exec rabbitmq-server-0 -- \
+        rabbitmqctl set_user_tags manila management policymaker
+    fi
+
+    echo "Verifying RabbitMQ authentication..."
+    kubectl -n openstack exec rabbitmq-server-0 -- \
+      rabbitmqctl authenticate_user manila "$NEW_PASS"
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _rabbitmq_sync
+  when: _do_generate_secrets | bool
+
+- name: Show RabbitMQ sync result
+  ansible.builtin.debug:
+    msg: "{{ _rabbitmq_sync.stdout_lines }}"
+  when: _rabbitmq_sync is not skipped
+
+- name: Sync new DB password into MariaDB
+  ansible.builtin.shell: |
+    set -o pipefail
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+
+    NEW_DB_PASS=$(kubectl -n openstack get secret manila-db-password \
+      -o jsonpath='{.data.password}' | base64 -d)
+
+    # Find a running MariaDB pod
+    MARIADB_POD=$(kubectl -n openstack get pods -l application=mariadb \
+      --field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+
+    if [ -z "$MARIADB_POD" ]; then
+      echo "WARNING: No running MariaDB pod found — skipping DB password sync."
+      echo "         The DB password will be applied during Helm install."
+      exit 0
+    fi
+
+    # Get the MariaDB root password
+    ROOT_PASS=$(kubectl -n openstack get secret mariadb \
+      -o jsonpath='{.data.root-password}' 2>/dev/null | base64 -d) || true
+
+    if [ -z "$ROOT_PASS" ]; then
+      echo "WARNING: Could not retrieve MariaDB root password — skipping DB password sync."
+      exit 0
+    fi
+
+    echo "Updating manila DB user password in MariaDB..."
+    kubectl -n openstack exec "$MARIADB_POD" -- \
+      mariadb -u root -p"$ROOT_PASS" -e \
+        "ALTER USER IF EXISTS 'manila'@'%' IDENTIFIED BY '$NEW_DB_PASS'; FLUSH PRIVILEGES;" 2>/dev/null
+
+    echo "DB password synced for user 'manila'."
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _db_sync
+  failed_when: false
+  when: _do_generate_secrets | bool
+
+- name: Show DB sync result
+  ansible.builtin.debug:
+    msg: "{{ _db_sync.stdout_lines }}"
+  when: _db_sync is not skipped
+
+- name: Set flag indicating secrets were recreated
+  ansible.builtin.set_fact:
+    manila_secrets_recreated: "{{ _do_generate_secrets | bool }}"

--- a/ansible/roles/manila_enablement_techpreview/tasks/manila_service_image_builder.yml
+++ b/ansible/roles/manila_enablement_techpreview/tasks/manila_service_image_builder.yml
@@ -1,0 +1,565 @@
+---
+# Build and upload the Manila service image to Glance.
+# Imported from main.yml with become: true / become_user: ubuntu.
+# Tasks that require root override with become_user: root.
+
+# =========================================================================
+# PART 1: BOOTSTRAP
+# Always runs. Installs tooling, prepares the build tree, patches scripts.
+# =========================================================================
+
+- name: Install python-manilaclient into genestack virtualenv
+  ansible.builtin.pip:
+    virtualenv: "{{ genestack_venv }}"
+    name: python-manilaclient
+    state: present
+
+- name: Create build directory
+  ansible.builtin.file:
+    path: "{{ manila_build_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Delete old manila-image-elements directory if it exists
+  ansible.builtin.file:
+    path: "{{ manila_build_dir }}/manila-image-elements"
+    state: absent
+  become: true
+  become_user: root
+
+- name: Clone manila-image-elements repository  # noqa: latest[git]
+  ansible.builtin.git:
+    repo: https://opendev.org/openstack/manila-image-elements
+    dest: "{{ manila_build_dir }}/manila-image-elements"
+    update: true
+    force: false
+
+# qemu-utils provides qemu-img, required by diskimage-builder at runtime.
+- name: Install QEMU and image-build system dependencies
+  ansible.builtin.apt:
+    name:
+      - qemu-system
+      - qemu-system-arm
+      - qemu-system-mips
+      - qemu-system-ppc
+      - qemu-system-sparc
+      - qemu-system-x86
+      - qemu-system-s390x
+      - qemu-system-misc
+      - qemu-utils
+      - debootstrap
+      - tox
+    state: present
+    update_cache: true
+  become: true
+  become_user: root
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+
+- name: Create Manila build virtualenv
+  ansible.builtin.pip:
+    virtualenv: "{{ manila_venv_dir }}"
+    virtualenv_command: python3 -m venv
+    name: pip
+    state: present
+
+- name: Install manila-image-elements Python requirements
+  ansible.builtin.pip:
+    virtualenv: "{{ manila_venv_dir }}"
+    requirements: "{{ manila_build_dir }}/manila-image-elements/requirements.txt"
+
+- name: Install manila-image-elements test requirements
+  ansible.builtin.pip:
+    virtualenv: "{{ manila_venv_dir }}"
+    requirements: "{{ manila_build_dir }}/manila-image-elements/test-requirements.txt"
+
+- name: Set MANILA_IMG_OS_VER to "{{ manila_service_image_version }}" in manila-image-create
+  ansible.builtin.replace:
+    path: "{{ manila_build_dir }}/manila-image-elements/bin/manila-image-create"
+    regexp: 'MANILA_IMG_OS_VER=\$\{MANILA_IMG_OS_VER:-".*"\}'
+    replace: 'MANILA_IMG_OS_VER=${MANILA_IMG_OS_VER:-"{{ manila_service_image_version }}"}'
+
+- name: Set MANILA_IMG_NAME to "{{ manila_service_image_name }}" in manila-image-create
+  ansible.builtin.replace:
+    path: "{{ manila_build_dir }}/manila-image-elements/bin/manila-image-create"
+    regexp: 'MANILA_IMG_NAME=\$\{MANILA_IMG_NAME:-".*"\}'
+    replace: 'MANILA_IMG_NAME=${MANILA_IMG_NAME:-"{{ manila_service_image_name }}"}'
+
+# Uses Python str.replace() — the multi-step sed approach in the original
+# script cascades incorrectly; the replace module can't handle replacements
+# ending in '\' (Python re.sub raises "bad escape").
+- name: Patch samba packages in Dockerfile
+  ansible.builtin.shell: |
+    python3 << 'EOF'
+    with open('Dockerfile', 'r') as f:
+        content = f.read()
+    content = content.replace(
+        '      samba \\\n',
+        '      samba-common \\\n      samba-common-bin \\\n'
+    )
+    with open('Dockerfile', 'w') as f:
+        f.write(content)
+    EOF
+  args:
+    executable: /bin/bash
+    chdir: "{{ manila_build_dir }}/manila-image-elements/data/docker"
+
+- name: Add curl to package-installs.yaml if not already present
+  ansible.builtin.lineinfile:
+    path: "{{ manila_build_dir }}/manila-image-elements/elements/manila-ssh/package-installs.yaml"
+    line: "curl:"
+    regexp: "curl"
+    state: present
+
+# =========================================================================
+# PART 2: STATE DETECTION
+# Probe OpenStack to learn what already exists, then derive the set of
+# actions that need to run based on current state + force flags.
+# =========================================================================
+
+- name: Check if {{ manila_keypair_name }} exists in OpenStack
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} keypair show {{ manila_keypair_name }} \
+      -f json 2>/dev/null
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: keypair_check
+  changed_when: false
+  failed_when: false
+
+- name: Check if {{ manila_service_image_name }} exists in OpenStack
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} image show {{ manila_service_image_name }} \
+      -f json 2>/dev/null
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: image_check
+  changed_when: false
+  failed_when: false
+
+- name: Derive action flags from current state and force options
+  ansible.builtin.set_fact:
+    keypair_exists: "{{ keypair_check.rc == 0 }}"
+    image_exists: "{{ image_check.rc == 0 }}"
+    # secrets_changed is true when manila_k8s_secrets.yml created or recreated secrets
+    secrets_changed: "{{ manila_secrets_recreated | default(false) | bool }}"
+    do_regenerate_k8s: "{{ force_full_recreation | bool }}"
+    do_delete_keypair: >-
+      {{ (force_recreate_keypair | bool)
+         or (force_full_recreation | bool)
+         or (manila_secrets_recreated | default(false) | bool) }}
+    do_create_keypair: >-
+      {{ (keypair_check.rc != 0)
+         or (force_recreate_keypair | bool)
+         or (force_full_recreation | bool)
+         or (manila_secrets_recreated | default(false) | bool) }}
+    do_rebuild_image: >-
+      {{ (image_check.rc != 0)
+         or (force_rebuild_image | bool)
+         or (force_recreate_keypair | bool)
+         or (force_full_recreation | bool)
+         or (manila_secrets_recreated | default(false) | bool) }}
+
+- name: Display planned actions
+  ansible.builtin.debug:
+    msg:
+      - "State ──────────────────────────────────────────"
+      - "  keypair exists in OpenStack : {{ keypair_exists }}"
+      - "  image exists in OpenStack   : {{ image_exists }}"
+      - "  secrets were (re)created    : {{ secrets_changed }}"
+      - "Actions ────────────────────────────────────────"
+      - "  regenerate k8s secret       : {{ do_regenerate_k8s }}"
+      - "  delete/recreate keypair     : {{ do_delete_keypair }} / {{ do_create_keypair }}"
+      - "  rebuild + upload image      : {{ do_rebuild_image }}"
+
+# =========================================================================
+# PART 3: K8S SECRET REGENERATION  (option 3 only)
+# When force_full_recreation=true, ALL K8s secrets (including the keypair)
+# are already regenerated upstream in manila_k8s_secrets.yml.  This part
+# is now a no-op for that path.  It is kept as a safety net in case
+# someone later adds a keypair-only regeneration path that doesn't go
+# through the full secrets flow.
+# =========================================================================
+
+- name: "Part 3 — skipped (keypair already regenerated by manila_k8s_secrets)"
+  ansible.builtin.debug:
+    msg: "Keypair K8s secret was already regenerated in the secrets task. Skipping Part 3."
+  when: do_regenerate_k8s | bool
+
+# =========================================================================
+# PART 4: RETRIEVE K8S PUBLIC KEY
+# Always runs — the public key is needed both for the build and for
+# fingerprint verification in option 1.
+# =========================================================================
+
+- name: Retrieve Manila service public key from Kubernetes secret
+  ansible.builtin.shell: |
+    set -o pipefail
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    kubectl -n openstack get secrets/{{ manila_keypair_name }} \
+      --template={{ '{{' }}.data.public_key{{ '}}' }} | base64 -d
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: manila_public_key
+  changed_when: false
+
+- name: Write Manila service public key to file
+  ansible.builtin.copy:
+    content: "{{ manila_public_key.stdout }}"
+    dest: "{{ manila_build_dir }}/manila-image-elements/manila-service-keypair.pub"
+    owner: ubuntu
+    group: ubuntu
+    mode: "0644"
+
+- name: Strip inherited ACLs from Manila service public key file
+  ansible.builtin.shell: >
+    setfacl -b {{ manila_build_dir }}/manila-image-elements/manila-service-keypair.pub
+  args:
+    executable: /bin/bash
+  changed_when: false
+
+# =========================================================================
+# PART 5: KEYPAIR SAFETY CHECK  (option 1 only)
+# When only a rebuild is requested (not a keypair replacement), verify that
+# the public key in the k8s secret matches the fingerprint of the keypair
+# already registered in OpenStack.
+# =========================================================================
+
+- name: Verify k8s public key fingerprint matches existing OpenStack keypair
+  ansible.builtin.shell: |
+    set -o pipefail
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+
+    OS_FP=$(openstack --os-cloud={{ os_cloud }} keypair show {{ manila_keypair_name }} \
+      -f json | jq -r .fingerprint)
+    K8S_FP=$(ssh-keygen -l -E md5 \
+      -f {{ manila_build_dir }}/manila-image-elements/manila-service-keypair.pub \
+      | awk '{print $2}' | sed 's/MD5://')
+
+    if [ "$OS_FP" != "$K8S_FP" ]; then
+      echo "ERROR: Fingerprint mismatch — cannot safely rebuild image."
+      echo "  OpenStack keypair fingerprint : $OS_FP"
+      echo "  k8s secret fingerprint        : $K8S_FP"
+      echo "  To resolve, use -e force_recreate_keypair=true (option 2)"
+      echo "  or -e force_full_recreation=true (option 3)."
+      exit 1
+    fi
+    echo "OK: Fingerprint match confirmed ($OS_FP)"
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  changed_when: false
+  when:
+    - force_rebuild_image | bool
+    - not (force_recreate_keypair | bool)
+    - not (force_full_recreation | bool)
+    - keypair_exists | bool
+
+# =========================================================================
+# PART 6: KEYPAIR MANAGEMENT
+# =========================================================================
+
+- name: Delete existing OpenStack keypair (options 2 and 3)
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} keypair delete {{ manila_keypair_name }}
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when:
+    - do_delete_keypair | bool
+    - keypair_exists | bool
+
+- name: Create Manila service keypair in OpenStack
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} keypair create --public-key \
+      {{ manila_build_dir }}/manila-image-elements/manila-service-keypair.pub \
+      {{ manila_keypair_name }}
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: do_create_keypair | bool
+
+# =========================================================================
+# PART 7: IMAGE BUILD AND UPLOAD
+# Gated by do_rebuild_image. Deletes any existing Glance image and local
+# qcow2 before building to ensure a clean slate.
+# =========================================================================
+
+- name: Retrieve Manila admin password from Kubernetes secret
+  ansible.builtin.shell: |
+    set -o pipefail
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    kubectl -n openstack get secrets/manila-admin \
+      --template={{ '{{' }}.data.password{{ '}}' }} | base64 -d
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: manila_admin_password_result
+  changed_when: false
+  no_log: true
+  when: do_rebuild_image | bool
+
+- name: Delete existing Manila service image from OpenStack
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} image delete {{ manila_service_image_name }}
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when:
+    - do_rebuild_image | bool
+    - image_exists | bool
+
+- name: Delete local qcow2 to ensure a clean rebuild
+  ansible.builtin.file:
+    path: "{{ manila_build_dir }}/manila-image-elements/{{ manila_service_image_name }}.qcow2"
+    state: absent
+  become: true
+  become_user: root
+  when: do_rebuild_image | bool
+
+# diskimage-builder requires root for debootstrap/mount/losetup/mknod.
+# Retries handle transient Ubuntu mirror 404 race conditions.
+- name: Clean up any stale diskimage-builder build directories
+  ansible.builtin.shell: |
+    for d in /tmp/dib_build.* /tmp/dib_image.*; do
+      [ -d "$d" ] || continue
+      umount -lR "$d" 2>/dev/null || true
+      rm -rf "$d"
+    done
+  args:
+    executable: /bin/bash
+  become: true
+  become_user: root
+  changed_when: false
+  when: do_rebuild_image | bool
+
+- name: Build Manila service image with tox
+  ansible.builtin.shell: |
+    for d in /tmp/dib_build.*; do [ -d "$d" ] && umount -lR "$d" 2>/dev/null; done; rm -rf /tmp/dib_build.*
+    source {{ manila_venv_dir }}/bin/activate
+    cd {{ manila_build_dir }}/manila-image-elements
+    tox -e buildimage
+  args:
+    executable: /bin/bash
+  become: true
+  become_user: root
+  register: tox_build_result
+  retries: 3
+  delay: 30
+  until: tox_build_result.rc == 0
+  environment:
+    HOME: "{{ ubuntu_home }}"
+    MANILA_PASSWORD: "{{ manila_admin_password_result.stdout }}"
+    MANILA_USER_AUTHORIZED_KEYS: "{{ manila_build_dir }}/manila-image-elements/manila-service-keypair.pub"
+    MANILA_IMG_NAME: "{{ manila_service_image_name }}"
+    DHCP_TIMEOUT: "900"
+  when: do_rebuild_image | bool
+
+- name: Upload Manila service image to OpenStack Glance
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} image create \
+      --disk-format qcow2 \
+      --container-format bare \
+      --private \
+      --file {{ manila_build_dir }}/manila-image-elements/{{ manila_service_image_name }}.qcow2 \
+      --progress {{ manila_service_image_name }}
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: do_rebuild_image | bool
+
+# =========================================================================
+# PART 8: IMAGE SHARING
+# Runs only when a new image was built and uploaded.
+# =========================================================================
+
+- name: Get admin project ID
+  ansible.builtin.shell: |
+    set -o pipefail
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} project show admin -f json | jq -r .id
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: admin_project_id_result
+  changed_when: false
+  when: do_rebuild_image | bool
+
+- name: Get service project ID
+  ansible.builtin.shell: |
+    set -o pipefail
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} project show service -f json | jq -r .id
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: service_project_id_result
+  changed_when: false
+  when: do_rebuild_image | bool
+
+- name: Get newly uploaded Manila service image ID
+  ansible.builtin.shell: |
+    set -o pipefail
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} image show {{ manila_service_image_name }} \
+      -f json | jq -r .id
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: manila_image_id_result
+  changed_when: false
+  when: do_rebuild_image | bool
+
+- name: Set project/image ID facts
+  ansible.builtin.set_fact:
+    admin_project_id: "{{ admin_project_id_result.stdout | trim }}"
+    service_project_id: "{{ service_project_id_result.stdout | trim }}"
+    manila_service_image_id: "{{ manila_image_id_result.stdout | trim }}"
+  when: do_rebuild_image | bool
+
+- name: Share image with admin project
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} image set \
+      --project {{ admin_project_id }} --shared {{ manila_service_image_id }}
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: do_rebuild_image | bool
+
+- name: Add image to service project membership
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} image add project \
+      {{ manila_service_image_id }} {{ service_project_id }}
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: do_rebuild_image | bool
+
+- name: Accept image membership for service project
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} image set \
+      --project {{ service_project_id }} --accept {{ manila_service_image_id }}
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: do_rebuild_image | bool
+
+- name: Add image to admin project membership
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} image add project \
+      {{ manila_service_image_id }} {{ admin_project_id }}
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: do_rebuild_image | bool
+
+- name: Accept image membership for admin project
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} image set \
+      --project {{ admin_project_id }} --accept {{ manila_service_image_id }}
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: do_rebuild_image | bool
+
+- name: List image members
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} image member list {{ manila_service_image_id }}
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: image_member_list
+  changed_when: false
+  when: do_rebuild_image | bool
+
+- name: Display image member list
+  ansible.builtin.debug:
+    msg: "{{ image_member_list.stdout_lines }}"
+  when: do_rebuild_image | bool

--- a/ansible/roles/manila_enablement_techpreview/tasks/manila_share_type_setup.yml
+++ b/ansible/roles/manila_enablement_techpreview/tasks/manila_share_type_setup.yml
@@ -1,0 +1,102 @@
+---
+# Create the default Manila share type after Manila has been deployed.
+# This task requires the Manila API to be running (post Helm install).
+# Idempotent — skips creation if the share type already exists.
+# Gracefully skips ALL tasks if the Manila API is not reachable.
+
+- name: Check if Manila API is reachable
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} share type list -f json 2>/dev/null
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _manila_api_check
+  changed_when: false
+  failed_when: false
+
+- name: Skip share type setup if Manila API is not available
+  ansible.builtin.debug:
+    msg: "Manila API is not reachable — skipping share type setup. Run with --tags post_deploy after Manila is deployed."
+  when: _manila_api_check.rc != 0
+
+- name: Check if generic share type already exists
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} share type show generic -f json 2>/dev/null
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _share_type_check
+  changed_when: false
+  failed_when: false
+  when: _manila_api_check.rc == 0
+
+- name: Create generic share type
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} share type create generic true \
+      --description "Generic Manila share type" \
+      --public true \
+      --snapshot-support true \
+      --create-share-from-snapshot-support true \
+      --revert-to-snapshot-support false \
+      --extra-specs \
+        share_backend_name=generic
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when:
+    - _manila_api_check.rc == 0
+    - _share_type_check.rc != 0
+
+- name: Set generic share type as default
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} share type set generic --default
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when:
+    - _manila_api_check.rc == 0
+    - _share_type_check.rc != 0
+  # --default may not be available on all versions; fall back gracefully
+  failed_when: false
+
+- name: Display generic share type
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    openstack --os-cloud={{ os_cloud }} share type show generic -f json
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _share_type_info
+  changed_when: false
+  when: _manila_api_check.rc == 0
+
+- name: Show share type details
+  ansible.builtin.debug:
+    msg: "{{ _share_type_info.stdout | from_json }}"
+  when:
+    - _manila_api_check.rc == 0
+    - _share_type_info.stdout | default('') | length > 0

--- a/ansible/roles/manila_enablement_techpreview/templates/custom-manila-gateway-route.yaml.j2
+++ b/ansible/roles/manila_enablement_techpreview/templates/custom-manila-gateway-route.yaml.j2
@@ -1,0 +1,21 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: custom-manila-gateway-route
+  namespace: openstack
+  labels:
+    application: gateway-api
+    service: HTTPRoute
+    route: manila
+spec:
+  parentRefs:
+    - name: flex-gateway
+      sectionName: manila-https
+      namespace: envoy-gateway
+  hostnames:
+    - "manila.api.{{ manila_gateway_region_lower }}.rackspacecloud.com"
+  rules:
+    - backendRefs:
+        - name: manila-api
+          port: 8786

--- a/ansible/roles/manila_enablement_techpreview/templates/manila-endpoints-fragment.yaml.j2
+++ b/ansible/roles/manila_enablement_techpreview/templates/manila-endpoints-fragment.yaml.j2
@@ -1,0 +1,25 @@
+endpoints:
+  identity:
+    auth:
+      manila:
+        region_name: {{ manila_region_name }}
+  share:
+    host_fqdn_override:
+      public:
+        tls: {}
+        host: manila.api.{{ manila_gateway_region_lower }}.rackspacecloud.com
+    port:
+      api:
+        public: 443
+    scheme:
+      public: https
+  sharev2:
+    host_fqdn_override:
+      public:
+        tls: {}
+        host: manila.api.{{ manila_gateway_region_lower }}.rackspacecloud.com
+    port:
+      api:
+        public: 443
+    scheme:
+      public: https

--- a/ansible/roles/manila_enablement_techpreview/templates/manila-https-listener.json.j2
+++ b/ansible/roles/manila_enablement_techpreview/templates/manila-https-listener.json.j2
@@ -1,0 +1,27 @@
+[
+    {
+        "op": "add",
+        "path": "/spec/listeners/-",
+        "value": {
+            "name": "manila-https",
+            "port": 443,
+            "protocol": "HTTPS",
+            "hostname": "manila.api.{{ manila_gateway_region_lower }}.rackspacecloud.com",
+            "allowedRoutes": {
+                "namespaces": {
+                    "from": "All"
+                }
+            },
+            "tls": {
+                "certificateRefs": [
+                    {
+                        "group": "",
+                        "kind": "Secret",
+                        "name": "manila-gw-tls-secret"
+                    }
+                ],
+                "mode": "Terminate"
+            }
+        }
+    }
+]

--- a/ansible/roles/manila_enablement_techpreview/templates/manila-kustomization.yaml.j2
+++ b/ansible/roles/manila_enablement_techpreview/templates/manila-kustomization.yaml.j2
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base

--- a/ansible/roles/manila_enablement_techpreview/templates/manila_default_helm_config.yaml
+++ b/ansible/roles/manila_enablement_techpreview/templates/manila_default_helm_config.yaml
@@ -1,0 +1,190 @@
+---
+images:
+  tags:
+    db_init: "ghcr.io/rackerlabs/genestack-images/heat:2025.1-latest"
+    db_sync: "ghcr.io/rackerlabs/genestack-images/heat:2025.1-latest"
+    db_drop: "ghcr.io/rackerlabs/genestack-images/heat:2025.1-latest"
+    dep_check: "ghcr.io/rackerlabs/genestack-images/kubernetes-entrypoint:latest"
+    image_repo_sync: "docker.io/docker:17.07.0"
+    ks_endpoints: "ghcr.io/rackerlabs/genestack-images/heat:2025.1-latest"
+    ks_service: "ghcr.io/rackerlabs/genestack-images/heat:2025.1-latest"
+    ks_user: "ghcr.io/rackerlabs/genestack-images/heat:2025.1-latest"
+    manila: "ghcr.io/rackerlabs/genestack-images/manila:2025.1-latest"
+    manila_api: "ghcr.io/rackerlabs/genestack-images/manila:2025.1-latest"
+    manila_data: "ghcr.io/rackerlabs/genestack-images/manila:2025.1-latest"
+    manila_db_sync: "ghcr.io/rackerlabs/genestack-images/manila:2025.1-latest"
+    manila_scheduler: "ghcr.io/rackerlabs/genestack-images/manila:2025.1-latest"
+    manila_share: "ghcr.io/rackerlabs/genestack-images/manila:2025.1-latest"
+    manila_processor: "ghcr.io/rackerlabs/genestack-images/manila:2025.1-latest"
+    manila_storage_init: "ghcr.io/rackerlabs/genestack-images/manila:2025.1-latest"
+    rabbit_init: "docker.io/rabbitmq:3.13-management"
+  pull_policy: "Always"
+
+# NOTE: (brew) requests cpu/mem values based on a three node
+# hyperconverged lab (/scripts/hyperconverged-lab.sh).
+# limit values based on defaults from the openstack-helm charts unless defined
+pod:
+  replicas:
+    api: 2
+    data: 2
+    scheduler: 2
+    share: 3
+  lifecycle:
+    upgrades:
+      deployments:
+        rolling_update:
+          max_unavailable: 20%
+
+  resources:
+    enabled: true
+    api:
+      requests:
+        memory: "256Mi"
+        cpu: "500m"
+      limits:
+        memory: "2048Mi"
+        cpu: "2000m"
+    data:
+      requests:
+        memory: "256Mi"
+        cpu: "500m"
+      limits:
+        memory: "2048Mi"
+        cpu: "2000m"
+    scheduler:
+      requests:
+        memory: "256Mi"
+        cpu: "500m"
+      limits:
+        memory: "1024Mi"
+        cpu: "2000m"
+    share:
+      requests:
+        memory: "256Mi"
+        cpu: "100m"
+      limits:
+        memory: "2048Mi"
+        cpu: "2000m"
+
+bootstrap:
+  enabled: false
+
+dependencies:
+  static:
+    api:
+      jobs:
+        - manila-db-sync
+        - manila-ks-user
+        - manila-ks-endpoints
+    data:
+      jobs:
+        - manila-db-sync
+        - manila-ks-user
+        - manila-ks-endpoints
+    share:
+      jobs:
+        - manila-db-sync
+        - manila-ks-user
+        - manila-ks-endpoints
+    scheduler:
+      jobs:
+        - manila-db-sync
+        - manila-ks-user
+        - manila-ks-endpoints
+    manager:
+      jobs:
+        - manila-db-sync
+        - manila-ks-user
+        - manila-ks-endpoints
+    db_sync:
+      jobs: []
+
+conf:
+  manila:
+    DEFAULT:
+      default_share_type: generic
+      default_share_group_type: generic
+      enabled_share_backends: generic
+      storage_availability_zone: az1
+      backend_availability_zone: az1
+      share_name_template: "share-%s"
+      rootwrap_config: /etc/manila/rootwrap.conf
+      api_paste_config: /etc/manila/api-paste.ini
+      scheduler_default_share_group_filters: AvailabilityZoneFilter,DriverFilter
+      capacity_weight_multiplier: 1.0
+      enable_new_services: true
+      debug: true
+    generic:
+      share_backend_name: GENERIC
+      share_driver: manila.share.drivers.generic.GenericShareDriver
+      driver_handles_share_servers: true
+      connect_share_server_to_tenant_network: true
+      service_network_name: manila-service-network
+      manila_service_keypair_name: manila-service-keypair
+      path_to_private_key: /var/lib/openstack/.ssh/manila-service-keypair.pem
+      path_to_public_key: /var/lib/openstack/.ssh/manila-service-keypair.pub
+      network_config_group: generic_network
+      volume_api_class: manila.volume.cinder.API
+      max_time_to_create_volume: 180
+      max_time_to_extend_volume: 180
+      max_time_to_attach: 120
+      volume_name_template: "manila-share-%s"
+      volume_snapshot_name_template: "manila-snapshot-%s"
+      share_volume_fstype: ext4
+      service_image_id: {{manila_service_image_id}}
+      service_image_name: manila-service-image
+      service_instance_user: manila
+      service_instance_flavor_id: {{manila_service_instance_flavor_id}}
+      service_instance_name_template: "%s"
+      service_instance_security_group: manila-service-sg
+      backend_availability_zone: az1
+      storage_availability_zone: az1
+      lvm_share_volume_group: cinder-volumes-1
+      cinder_volume_type: Standard
+    generic_network:
+      interface_driver: manila.network.linux.interface.NoopInterfaceDriver
+    cinder:
+      cross_az_attach: true
+    barbican:
+      barbican_endpoint_type: internal
+    key_manager:
+      backend: barbican
+    database:
+      max_retries: -1
+    oslo_policy:
+      policy_file: /etc/manila/policy.yaml
+    oslo_concurrency:
+      lock_path: /var/lib/manila/tmp
+    oslo_messaging_notifications:
+      driver: noop
+    oslo_middleware:
+      enable_proxy_headers_parsing: true
+    oslo_messaging_rabbit:
+      rabbit_ha_queues: true
+  manila_api_uwsgi:
+    uwsgi:
+      add-header: "Connection: close"
+      buffer-size: 65535
+      die-on-term: true
+      enable-threads: true
+      exit-on-reload: false
+      hook-master-start: unix_signal:15 gracefully_kill_them_all
+      lazy-apps: true
+      log-x-forwarded-for: true
+      master: true
+      procname-prefix-spaced: "manila-api:"
+      route-user-agent: '^kube-probe.* donotlog:'
+      thunder-lock: true
+      worker-reload-mercy: 80
+      wsgi-file: /var/lib/openstack/bin/manila-wsgi
+      processes: 1
+  logging:
+    logger_root:
+      level: DEBUG
+      handlers: stdout
+    logger_manila:
+      level: DEBUG
+      handlers: stdout
+
+manifests:
+  deployment_share: true

--- a/ansible/roles/manila_enablement_techpreview/templates/manila_generic_driver_helm_config.yaml
+++ b/ansible/roles/manila_enablement_techpreview/templates/manila_generic_driver_helm_config.yaml
@@ -1,0 +1,45 @@
+---
+conf:
+  manila:
+    DEFAULT:
+      default_share_type: generic
+      default_share_group_type: generic
+      enabled_share_backends: generic
+      storage_availability_zone: az1
+      backend_availability_zone: az1
+      share_name_template: "share-%s"
+      rootwrap_config: /etc/manila/rootwrap.conf
+      api_paste_config: /etc/manila/api-paste.ini
+      scheduler_default_share_group_filters: AvailabilityZoneFilter,DriverFilter
+      capacity_weight_multiplier: 1.0
+      enable_new_services: true
+      debug: true
+    generic:
+      share_backend_name: GENERIC
+      share_driver: manila.share.drivers.generic.GenericShareDriver
+      driver_handles_share_servers: true
+      connect_share_server_to_tenant_network: true
+      service_network_name: manila-service-network
+      manila_service_keypair_name: manila-service-keypair
+      path_to_private_key: /var/lib/openstack/.ssh/manila-service-keypair.pem
+      path_to_public_key: /var/lib/openstack/.ssh/manila-service-keypair.pub
+      network_config_group: generic_network
+      volume_api_class: manila.volume.cinder.API
+      max_time_to_create_volume: 180
+      max_time_to_extend_volume: 180
+      max_time_to_attach: 120
+      volume_name_template: "manila-share-%s"
+      volume_snapshot_name_template: "manila-snapshot-%s"
+      share_volume_fstype: ext4
+      service_image_id: {{manila_service_image_id}}
+      service_image_name: manila-service-image
+      service_instance_user: manila
+      service_instance_flavor_id: {{manila_service_instance_flavor_id}}
+      service_instance_name_template: "%s"
+      service_instance_security_group: manila-service-sg
+      backend_availability_zone: az1
+      storage_availability_zone: az1
+      lvm_share_volume_group: cinder-volumes-1
+      cinder_volume_type: Standard
+    generic_network:
+      interface_driver: manila.network.linux.interface.NoopInterfaceDriver

--- a/ansible/roles/manila_enablement_techpreview/vars/main.yml
+++ b/ansible/roles/manila_enablement_techpreview/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for manila_enablement_techpreview


### PR DESCRIPTION
feat: add manila_enablement_techpreview ansible role

Adds a pre/post-configuration Ansible role and playbook for deploying
Manila (Shared File Systems) on Genestack. The role handles everything
that must happen before and after `helm install` so that Manila is
fully operational with the generic NFS driver.

## What the role does

The `manila_enablement_techpreview` role performs five phases, controlled
by Ansible tags:

| Tag | Phase | Description |
|-----|-------|-------------|
| `secrets` | K8s Secrets | Creates `manila-rabbitmq-password`, `manila-db-password`, `manila-admin`, and `manila-service-keypair` secrets; syncs credentials to RabbitMQ and MariaDB |
| `image_build` | Service Image | Builds an Ubuntu Noble disk image with DIB, uploads to Glance as `manila-service-image`, registers the `manila-service-keypair` in Nova |
| `pre_deploy` | Gateway & Kustomize | Generates the Envoy gateway HTTPS listener/route, kustomize overlay, and merges Manila endpoints into the global overrides |
| `pre_deploy` | Helm Config | Resolves the image/flavor IDs, injects the service password into `secrets.yaml`, and deep-merges driver-specific Helm values into `manila-helm-overrides.yaml` |
| `post_deploy` | Share Types | Creates the `generic` share type with `share_backend_name=generic` and sets it as the default |

Running the playbook without tags executes all phases in order.

## Deployment workflow

### 1. Run the preconf playbook (secrets + image + gateway + helm config)

```bash
cd /opt/genestack
ansible-playbook -i /etc/genestack/inventory/inventory.yaml ansible/playbooks/manila-enablement-techpreview.yaml
```

This runs the `secrets`, `image_build`, and `pre_deploy` phases. When
complete it prints a summary of files written under `/etc/genestack/`.
Commit those changes to the `/etc/genestack` git tree before proceeding.

### 2. Install Manila via Helm

```bash
/opt/genestack/bin/install-manila.sh
```

The install script reads overrides from:
- `/opt/genestack/base-helm-configs/manila/` (base)
- `/etc/genestack/helm-configs/global_overrides/` (endpoints, secrets)
- `/etc/genestack/helm-configs/manila/` (driver config from the role)

It injects live K8s secret values via `--set` flags and applies the
kustomize post-renderer.

### 3. Run the post_deploy phase (share types)

```bash
ansible-playbook -i /etc/genestack/inventory/inventory.yaml ansible/playbooks/manila-enablement-techpreview.yaml \
  --tags post_deploy
```

This creates the `generic` share type and sets it as the default.
The task is idempotent and skips gracefully if the Manila API is not
yet reachable.

### 4. Upgrade Skyline to include Manila share UI

```bash
/opt/genestack/bin/install-skyline.sh
```

This re-applies the Skyline kustomize overlay, which picks up the
Manila share management UI elements.

## Test tenant scripts

Two helper scripts are provided for lab validation. They live in the
role's `files/` directory and are also deployed to the controller.

### manage-test-tenants.sh

Creates two test tenant projects (`acme-corp`, `globex-inc`) with admin
users, Geneve networks, subnets, and a combined `clouds.yaml`.

> [!NOTE]
> Credentials are written to `/home/ubuntu/customers/clouds.yaml`.

```bash
# Create test tenants
cd /opt/genestack/ansible/roles/manila_enablement_techpreview/files
./manage-test-tenants.sh create

# Verify
cd /home/ubuntu/customers/
openstack --os-cloud=acme-corp token issue
openstack --os-cloud=acme-corp network list
cd /opt/genestack/ansible/roles/manila_enablement_techpreview/files

# Tear down
./manage-test-tenants.sh destroy

# Full reset (destroy + create)
./manage-test-tenants.sh reset
```

Credentials are written to `/home/ubuntu/customers/clouds.yaml`.

### manage-test-tenant-shares.sh

End-to-end Manila validation per tenant: builds a test VM image, creates
an NFS share, boots a VM, attaches a floating IP, grants share access,
and prints mount instructions.

```bash
# Create shares and VMs for all tenants
cd /opt/genestack/ansible/roles/manila_enablement_techpreview/files
./manage-test-tenant-shares.sh create

# Custom share size and flavor
./manage-test-tenant-shares.sh create --size 10 --flavor m1.large

# Tear down shares, VMs, routers, security groups
./manage-test-tenant-shares.sh destroy
```

The script requires `manage-test-tenants.sh create` to have been run
first (it reads from `/home/ubuntu/customers/clouds.yaml`).

## Manual tenant provisioning (without helper scripts)

For an existing tenant project that has no networking, compute, or
storage resources, a cloud operator can provision Manila access using
standard OpenStack CLI commands as admin (`--os-cloud=default`).

This example assumes:
- A project called `customer-a` already exists
- A user called `customer-a-admin` already exists with `member` role
- The external/provider network is called `PUBLICNET` (lab environments
  may use `flat` instead; adjust accordingly)
- Manila is deployed with the `generic` share type

```bash
# All commands as admin
OS="openstack --os-cloud=default"

# --- Networking ---

# Create a tenant network (Geneve overlay)
$OS network create customer-a-network \
  --project customer-a \
  --provider-network-type geneve \
  --internal

# Create a subnet
$OS subnet create customer-a-subnet \
  --project customer-a \
  --network customer-a-network \
  --subnet-range 192.168.100.0/24 \
  --gateway 192.168.100.1 \
  --dhcp

# Create a router with an external gateway
$OS router create customer-a-router --project customer-a
$OS router set customer-a-router --external-gateway PUBLICNET
$OS router add subnet customer-a-router customer-a-subnet

# --- Security group ---

$OS security group create customer-a-sg \
  --project customer-a \
  --description "Allow SSH, ICMP, NFS"

$OS security group rule create customer-a-sg \
  --protocol tcp --dst-port 22 --ingress
$OS security group rule create customer-a-sg \
  --protocol icmp --ingress
$OS security group rule create customer-a-sg \
  --protocol tcp --dst-port 2049 --ingress
$OS security group rule create customer-a-sg \
  --protocol tcp --dst-port 20048 --ingress
$OS security group rule create customer-a-sg \
  --protocol tcp --dst-port 111 --ingress
$OS security group rule create customer-a-sg \
  --protocol udp --dst-port 111 --ingress

# --- SSH keypair ---

ssh-keygen -t ed25519 -f /tmp/customer-a-key -N "" -q
$OS keypair create --public-key /tmp/customer-a-key.pub \
  --user customer-a-admin customer-a-keypair

# --- Boot a VM ---

$OS server create customer-a-vm \
  --project customer-a \
  --flavor m1.medium \
  --image "Ubuntu 24.04 Test Tenant" \
  --network customer-a-network \
  --security-group customer-a-sg \
  --key-name customer-a-keypair \
  --wait

# --- Floating IP ---

FIP=$($OS floating ip create PUBLICNET -f value -c floating_ip_address)
$OS server add floating ip customer-a-vm "$FIP"

# --- Manila share network ---
# Get the network and subnet IDs
NET_ID=$($OS network show customer-a-network -f value -c id)
SUB_ID=$($OS subnet show customer-a-subnet -f value -c id)

$OS share network create \
  --name customer-a-share-network \
  --neutron-net-id "$NET_ID" \
  --neutron-subnet-id "$SUB_ID" \
  --project customer-a

# --- Create an NFS share ---

$OS share create NFS 5 \
  --name customer-a-share \
  --share-network customer-a-share-network \
  --share-type generic \
  --project customer-a

# Wait for the share to become available
$OS share show customer-a-share -f value -c status

# --- Grant access ---
# Use the VM's fixed IP (192.168.100.x)
VM_IP=$($OS server show customer-a-vm -f value -c addresses \
  | grep -oP '192\.168\.100\.\d+')

$OS share access create customer-a-share ip "$VM_IP"

# --- Get the export path ---
$OS share export location list customer-a-share

# SSH to the VM and mount
ssh -i /tmp/customer-a-key ubuntu@"$FIP"
# On the VM:
#   sudo mkdir -p /mnt/share
#   sudo mount -t nfs <export_path> /mnt/share
```