### PR TITLE
feat: add trove_enablement_techpreview ansible role

### DIFF
--- a/ansible/playbooks/trove-enablement-techpreview.yaml
+++ b/ansible/playbooks/trove-enablement-techpreview.yaml
@@ -1,0 +1,67 @@
+- name: Pre-requisites for enabling Trove (Database as a Service)
+  hosts: localhost
+  vars:
+    trove_os_endpoint_type: internal
+    trove_os_interface: "{{ trove_os_endpoint_type }}"
+    trove_os_username: admin
+    trove_os_project_name: admin
+    trove_os_tenant_name: "{{ trove_os_project_name }}"
+    trove_os_auth_type: password
+    trove_os_auth_url: http://keystone-api.openstack.svc.cluster.local:5000/v3
+    trove_os_user_domain_name: default
+    trove_os_project_domain_name: "{{ trove_os_user_domain_name }}"
+    trove_os_region_name: RegionOne
+    trove_os_identity_api_version: 3
+    trove_os_auth_version: 3
+  pre_tasks:
+    - name: Retrieve Keystone admin password from K8s secret
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Secret
+        name: keystone-admin
+        namespace: openstack
+      register: keystone_secret
+      no_log: true
+      tags:
+        - always
+
+    - name: Set trove_os_password from K8s secret
+      ansible.builtin.set_fact:
+        trove_os_password: "{{ keystone_secret.resources[0].data.password | b64decode }}"
+      no_log: true
+      when: keystone_secret.resources | length > 0
+      tags:
+        - always
+
+    - name: Check for credentials
+      ansible.builtin.fail:
+        msg: >-
+          Could not retrieve the Keystone admin password. Ensure the
+          keystone-admin secret exists in the openstack namespace, or
+          pass -e trove_os_password=<password> on the command line.
+      when: trove_os_password is undefined or trove_os_password | length == 0
+      tags:
+        - always
+
+    - name: Set OpenStack environment facts
+      ansible.builtin.set_fact:
+        trove_os_env:
+          OS_ENDPOINT_TYPE: "{{ trove_os_endpoint_type }}"
+          OS_INTERFACE: "{{ trove_os_interface }}"
+          OS_USERNAME: "{{ trove_os_username }}"
+          OS_PASSWORD: "{{ trove_os_password }}"
+          OS_PROJECT_NAME: "{{ trove_os_project_name }}"
+          OS_TENANT_NAME: "admin"
+          OS_AUTH_TYPE: password
+          OS_AUTH_URL: "{{ trove_os_auth_url }}"
+          OS_USER_DOMAIN_NAME: "{{ trove_os_user_domain_name }}"
+          OS_PROJECT_DOMAIN_NAME: "{{ trove_os_project_domain_name }}"
+          OS_REGION_NAME: "{{ trove_os_region_name }}"
+          OS_IDENTITY_API_VERSION: "{{ trove_os_identity_api_version }}"
+          OS_AUTH_VERSION: "{{ trove_os_auth_version }}"
+      no_log: true
+      tags:
+        - always
+  roles:
+    - role: trove_enablement_techpreview
+      environment: "{{ trove_os_env }}"

--- a/ansible/roles/trove_enablement_techpreview/README.md
+++ b/ansible/roles/trove_enablement_techpreview/README.md
@@ -1,0 +1,73 @@
+# trove_enablement_techpreview
+
+End-to-end enablement of OpenStack Trove (Database as a Service) for Genestack deployments.
+
+## What It Does
+
+1. **Installs python-troveclient** in the genestack virtualenv
+2. **Builds a MySQL guest image** using virt-customize (Ubuntu 22.04 + MySQL + trove-guestagent)
+3. **Uploads the image** to Glance with proper tags and properties
+4. **Configures gateway and kustomize** — Envoy listener, HTTPRoute, kustomize overlay, endpoint merge
+5. **Deep-merges Helm config** — management network, security group, keypair into trove-helm-overrides.yaml
+6. **Creates datastore type and version** (post-deploy) — links the Glance image to Trove
+
+## Prerequisites
+
+- Ansible >= 2.15.8
+- Kubernetes collections (`kubernetes.core`)
+- Keystone, Nova, Neutron, Cinder, Glance deployed and operational
+- Trove Helm chart deployed (API running for post-deploy tasks)
+- Trove pre-configuration complete (keypair, security group created via `hclab_service_conf`)
+
+## Usage
+
+### Full Run (build image + configure + datastore setup)
+
+```bash
+ansible-playbook ansible/playbooks/trove-enablement-techpreview.yaml
+```
+
+### Post-Deploy Only (datastore setup after Trove is running)
+
+```bash
+ansible-playbook ansible/playbooks/trove-enablement-techpreview.yaml --tags post_deploy
+```
+
+### Force Rebuild Image
+
+```bash
+ansible-playbook ansible/playbooks/trove-enablement-techpreview.yaml \
+  -e force_rebuild_image=true
+```
+
+### Force Full Recreation
+
+```bash
+ansible-playbook ansible/playbooks/trove-enablement-techpreview.yaml \
+  -e force_full_recreation=true
+```
+
+## Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `trove_guest_image_name` | `trove-mysql-8.4` | Name of the Glance image |
+| `trove_mysql_version` | `8.4` | MySQL version to install |
+| `trove_datastore_name` | `mysql` | Trove datastore type name |
+| `trove_datastore_version_name` | `8.4` | Trove datastore version |
+| `trove_keypair_name` | `trove-access-keypair` | Nova keypair for instance access |
+| `trove_secgroup_name` | `trove-access-secgroup` | Security group for Trove instances |
+| `trove_flat_network_name` | `flat` | Management network name |
+| `force_rebuild_image` | `false` | Force rebuild and re-upload guest image |
+| `force_full_recreation` | `false` | Nuclear option — rebuild everything |
+
+## Tags
+
+| Tag | Scope |
+|-----|-------|
+| `always` | Client install, image build, gateway, helm config |
+| `post_deploy` | Datastore type and version creation |
+
+## License
+
+Apache-2.0

--- a/ansible/roles/trove_enablement_techpreview/defaults/main.yml
+++ b/ansible/roles/trove_enablement_techpreview/defaults/main.yml
@@ -1,0 +1,87 @@
+---
+# defaults file for trove_enablement_techpreview
+
+# =========================================================================
+# Trove guest image (built with diskimage-builder, mirroring Manila pattern)
+# =========================================================================
+trove_guest_image_name: trove-mysql-8.4
+trove_guest_image_os_release: jammy
+trove_dib_distribution_mirror: "http://mirror.rackspace.com/ubuntu"
+trove_mysql_version: "8.4"
+# OpenStack release branch to clone for DIB elements (e.g. 2024.2, 2025.1).
+trove_openstack_release: "2024.2"
+
+# =========================================================================
+# Trove datastore
+# =========================================================================
+trove_datastore_name: mysql
+trove_datastore_version_name: "8.4"
+trove_datastore_packages: "mysql-server"
+
+# =========================================================================
+# Trove networking and access
+# =========================================================================
+trove_keypair_name: trove-access-keypair
+trove_secgroup_name: trove-access-secgroup
+trove_secgroup_remote_ip: "0.0.0.0/0"
+trove_flat_network_name: flat
+trove_mgmt_network_name: trove-mgmt-net
+lab_tenant_subnet_cidr: 192.168.100.0/24
+trove_services_port_name: trove-services-vip-port
+trove_services_secgroup_name: trove-services-secgroup
+trove_ssh_key_filename: trove_ssh_key
+
+# =========================================================================
+# MetalLB VIP — used in cloud-init /etc/hosts for guest VM connectivity
+metal_lb_ip: ""
+
+# Build paths and environment
+# =========================================================================
+trove_tmp_dir: /tmp
+trove_build_dir: "{{ trove_tmp_dir }}/trove-image-build"
+trove_venv_dir: "{{ trove_tmp_dir }}/trove-image-build/trove-dib-build"
+genestack_rc: /opt/genestack/scripts/genestack.rc
+genestack_venv: /home/ubuntu/.venvs/genestack
+ubuntu_home: /home/ubuntu
+trove_region_name: RegionOne
+trove_os_endpoint_type: internal
+os_cloud: default
+
+# =========================================================================
+# Helm config — driver template to merge into the existing overrides file.
+# The selected template is deep-merged into the trove-helm-overrides.yaml
+# that already lives at /etc/genestack/helm-configs/trove/.
+# =========================================================================
+trove_helm_config_template: trove_default_helm_config.yaml
+helm_config_base: /etc/genestack/helm-configs
+
+# =========================================================================
+# Gateway and kustomize
+# =========================================================================
+# The region component used in gateway hostnames
+# (e.g. trove.api.<region_lower>.rackspacecloud.com).
+# Auto-detected from /etc/genestack/helm-configs/global_overrides/endpoints.yaml
+# at runtime; this default is the fallback.
+trove_gateway_region_lower: ""
+
+# =========================================================================
+# Force / mode flags for image builder
+# =========================================================================
+# Default (no flags):
+#   Idempotent — skip image build if the Glance image already exists.
+#
+# force_rebuild_image=true:
+#   Deletes existing Glance image, rebuilds, re-uploads.
+#
+# force_full_recreation=true (nuclear):
+#   Deletes and re-creates OpenStack keypair, security group,
+#   rebuilds guest image, re-uploads, re-registers datastore.
+force_rebuild_image: false
+force_full_recreation: false
+
+# trove_force_recreate_secrets=true:
+#   Deletes and regenerates the four Trove K8s secrets (rabbitmq, db,
+#   admin, ssh) and syncs new RabbitMQ/MariaDB passwords into the
+#   running backing services.  Leave false unless you know you need to
+#   rotate — regeneration can break running clusters.
+trove_force_recreate_secrets: false

--- a/ansible/roles/trove_enablement_techpreview/files/create_trove_k8s_secrets.sh
+++ b/ansible/roles/trove_enablement_techpreview/files/create_trove_k8s_secrets.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -xe
+
+cd /tmp
+
+REGION=$1
+
+generate_password() {
+    < /dev/urandom tr -dc _A-Za-z0-9 | head -c${1:-32}
+}
+
+trove_ssh_public_key=$(ssh-keygen -qt ed25519 -N '' -C "trove_ssh" -f trove_ssh_key && cat trove_ssh_key.pub)
+trove_ssh_private_key=$(cat trove_ssh_key)
+trove_rabbitmq_password=$(generate_password 64)
+trove_db_password=$(generate_password 32)
+trove_admin_password=$(generate_password 32)
+
+OUTPUT_FILE="/tmp/trove_secrets.yml"
+
+if [[ -f ${OUTPUT_FILE} ]]; then
+    echo "Error: ${OUTPUT_FILE} already exists. Please remove it before running this script."
+    echo "       This will replace an existing file and will lead to mass rotation, which is"
+    echo "       likely not what you want to do. If you really want to break your system, please"
+    echo "       make sure you know what you're doing."
+    exit 99
+fi
+
+cat <<EOF > $OUTPUT_FILE
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: trove-rabbitmq-password
+  namespace: openstack
+type: Opaque
+data:
+  username: $(echo -n "trove" | base64)
+  password: $(echo -n $trove_rabbitmq_password | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: trove-db-password
+  namespace: openstack
+type: Opaque
+data:
+  password: $(echo -n $trove_db_password | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: trove-admin
+  namespace: openstack
+type: Opaque
+data:
+  password: $(echo -n $trove_admin_password | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: trove-ssh
+  namespace: openstack
+  annotations:
+    meta.helm.sh/release-name: trove
+    meta.helm.sh/release-namespace: openstack
+  labels:
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+data:
+  public-key: $(echo $trove_ssh_public_key | base64 -w0)
+  private-key: $(echo "$trove_ssh_private_key" | base64 -w0)
+EOF
+
+# Clean up SSH key files
+rm -f trove_ssh_key trove_ssh_key.pub
+chmod 0640 ${OUTPUT_FILE}

--- a/ansible/roles/trove_enablement_techpreview/files/deep_merge_yaml.py
+++ b/ansible/roles/trove_enablement_techpreview/files/deep_merge_yaml.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Deep-merge a YAML fragment into an existing YAML file.
+
+Usage:
+    python3 deep_merge_yaml.py BASE_FILE FRAGMENT_FILE
+
+If BASE_FILE does not exist it is created. The fragment values win on conflict.
+"""
+import copy
+import os
+import sys
+import yaml
+
+
+def deep_merge(base, overlay):
+    """Recursively merge overlay into base. Overlay values win."""
+    result = copy.deepcopy(base)
+    for key, value in overlay.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = copy.deepcopy(value)
+    return result
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} BASE_FILE FRAGMENT_FILE", file=sys.stderr)
+        sys.exit(1)
+
+    base_file = sys.argv[1]
+    fragment_file = sys.argv[2]
+
+    if os.path.exists(base_file):
+        with open(base_file, "r") as fh:
+            base = yaml.safe_load(fh) or {}
+    else:
+        base = {}
+
+    with open(fragment_file, "r") as fh:
+        fragment = yaml.safe_load(fh) or {}
+
+    merged = deep_merge(base, fragment)
+
+    with open(base_file, "w") as fh:
+        yaml.dump(merged, fh, default_flow_style=False, sort_keys=False, width=200)
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible/roles/trove_enablement_techpreview/files/merge_endpoints.py
+++ b/ansible/roles/trove_enablement_techpreview/files/merge_endpoints.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Deep-merge a Manila endpoints fragment into global_overrides/endpoints.yaml.
+
+Preserves the _region YAML anchor line that safe_load would otherwise drop.
+
+Usage:
+    python3 merge_endpoints.py ENDPOINTS_FILE FRAGMENT_FILE
+"""
+import copy
+import os
+import sys
+import yaml
+
+
+def deep_merge(base, overlay):
+    """Recursively merge overlay into base. Overlay values win."""
+    result = copy.deepcopy(base)
+    for key, value in overlay.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = copy.deepcopy(value)
+    return result
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} ENDPOINTS_FILE FRAGMENT_FILE", file=sys.stderr)
+        sys.exit(1)
+
+    endpoints_file = sys.argv[1]
+    fragment_file = sys.argv[2]
+    anchor_line = ""
+
+    if os.path.exists(endpoints_file):
+        with open(endpoints_file, "r") as fh:
+            content = fh.read()
+            base = yaml.safe_load(content) or {}
+            for line in content.splitlines():
+                if line.strip().startswith("_region:"):
+                    anchor_line = line
+                    break
+    else:
+        base = {}
+
+    with open(fragment_file, "r") as fh:
+        fragment = yaml.safe_load(fh) or {}
+
+    merged = deep_merge(base, fragment)
+
+    with open(endpoints_file, "w") as fh:
+        if anchor_line:
+            fh.write(anchor_line + "\n\n")
+        # Remove _region from the dict so it is not dumped twice
+        merged.pop("_region", None)
+        yaml.dump(merged, fh, default_flow_style=False, sort_keys=False, width=200)
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible/roles/trove_enablement_techpreview/handlers/main.yml
+++ b/ansible/roles/trove_enablement_techpreview/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for trove_enablement_techpreview

--- a/ansible/roles/trove_enablement_techpreview/meta/main.yml
+++ b/ansible/roles/trove_enablement_techpreview/meta/main.yml
@@ -1,0 +1,8 @@
+galaxy_info:
+  author: Dan With
+  description: End-to-end enablement of OpenStack Trove (Database as a Service) — tech preview
+  company: Rackspace Technology
+  license: Apache-2.0
+  min_ansible_version: 2.15.8
+  galaxy_tags: []
+dependencies: []

--- a/ansible/roles/trove_enablement_techpreview/tasks/main.yml
+++ b/ansible/roles/trove_enablement_techpreview/tasks/main.yml
@@ -1,0 +1,53 @@
+---
+# tasks file for trove_enablement_techpreview
+#
+# Tag strategy:
+#   --tags secrets       → pre-create Trove K8s secrets (rabbitmq, db, admin, ssh)
+#   --tags client        → install python-troveclient in genestack venv
+#   --tags image_build   → guest image build/upload (requires troveclient)
+#   --tags pre_deploy    → secrets, gateway, kustomize, endpoints, helm config
+#   --tags post_deploy   → datastore version creation (requires Trove API running)
+#   (no tags)            → runs everything in order
+
+- name: Import tasks to pre-create Trove K8s secrets
+  import_tasks: trove_k8s_secrets.yml
+  tags:
+    - secrets
+    - pre_deploy
+
+- name: Import tasks to install python-troveclient
+  import_tasks: trove_client_install.yml
+  tags:
+    - client
+
+- name: Import tasks to create keypair, security group, and openrc
+  import_tasks: trove_preconf.yml
+  tags:
+    - pre_deploy
+
+- name: Import tasks to build and upload Trove guest image
+  import_tasks: trove_guest_image_builder.yml
+  become: true
+  become_user: ubuntu
+  tags:
+    - image_build
+
+- name: Import tasks to create gateway listener, route, kustomize overlay, and endpoints
+  import_tasks: trove_gateway_and_kustomize.yml
+  tags:
+    - pre_deploy
+
+- name: Import tasks to configure Trove Helm values
+  import_tasks: trove_helm_config.yml
+  tags:
+    - pre_deploy
+
+- name: Import tasks to create Trove keypair (requires trove Keystone user)
+  import_tasks: trove_preconf_keypair.yml
+  tags:
+    - post_deploy
+
+- name: Import tasks to create Trove datastore and version
+  import_tasks: trove_datastore_setup.yml
+  tags:
+    - post_deploy

--- a/ansible/roles/trove_enablement_techpreview/tasks/trove_client_install.yml
+++ b/ansible/roles/trove_enablement_techpreview/tasks/trove_client_install.yml
@@ -1,0 +1,39 @@
+---
+# Install python-troveclient in the genestack virtualenv so that the
+# 'openstack database' CLI commands are available for datastore management.
+
+# =========================================================================
+# PART 1: CHECK IF TROVECLIENT IS ALREADY INSTALLED
+# =========================================================================
+
+- name: Check if python-troveclient is installed in genestack venv
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      {{ genestack_venv }}/bin/pip show python-troveclient 2>/dev/null | grep -q "^Name:"
+    executable: /bin/bash
+  register: _troveclient_check
+  changed_when: false
+  failed_when: false
+
+# =========================================================================
+# PART 2: INSTALL TROVECLIENT
+# =========================================================================
+
+- name: Install python-troveclient in genestack venv
+  ansible.builtin.command:
+    cmd: "{{ genestack_venv }}/bin/pip install python-troveclient"
+  when: _troveclient_check.rc != 0
+  register: _troveclient_install
+  changed_when: "'Successfully installed' in _troveclient_install.stdout"
+
+- name: Verify troveclient is functional
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      python3 -c "import troveclient; print(troveclient.__version__)"
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  changed_when: false
+  when: _troveclient_check.rc != 0

--- a/ansible/roles/trove_enablement_techpreview/tasks/trove_datastore_setup.yml
+++ b/ansible/roles/trove_enablement_techpreview/tasks/trove_datastore_setup.yml
@@ -1,0 +1,154 @@
+---
+# Post-deploy: create the Trove datastore type and version, linking to the
+# guest image in Glance.
+#
+# Run with: ansible-playbook ... --tags post_deploy
+# This requires the Trove API to be running.
+
+# =========================================================================
+# PART 1: CHECK TROVE API AVAILABILITY
+# =========================================================================
+
+- name: Check if Trove API is reachable
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      openstack --os-cloud {{ os_cloud }} datastore list
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _trove_api_check
+  changed_when: false
+  failed_when: false
+
+- name: Skip datastore setup if Trove API is not reachable
+  ansible.builtin.debug:
+    msg: >-
+      Trove API is not reachable (rc={{ _trove_api_check.rc }}).
+      Skipping datastore setup. Run again with --tags post_deploy
+      after Trove has been deployed and is running.
+  when: _trove_api_check.rc != 0
+
+# =========================================================================
+# PART 2: RESOLVE GUEST IMAGE ID
+# =========================================================================
+
+- name: Get Trove guest image ID from Glance (if not already set)
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      source {{ genestack_venv }}/bin/activate
+      openstack --os-cloud {{ os_cloud }} image show "{{ trove_guest_image_name }}" \
+        -f value -c id
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _trove_ds_image_id
+  changed_when: false
+  when:
+    - _trove_api_check.rc == 0
+    - trove_guest_image_id is not defined or trove_guest_image_id | length == 0
+
+- name: Set resolved image ID
+  ansible.builtin.set_fact:
+    _trove_resolved_image_id: >-
+      {{ trove_guest_image_id | default('')
+         if (trove_guest_image_id is defined and trove_guest_image_id | length > 0)
+         else (_trove_ds_image_id.stdout | default('') | trim) }}
+  when: _trove_api_check.rc == 0
+
+- name: Fail if no guest image found
+  ansible.builtin.fail:
+    msg: >-
+      No Trove guest image found. Build the image first by running
+      the playbook without --tags (full run), or manually upload
+      an image named '{{ trove_guest_image_name }}' to Glance.
+  when:
+    - _trove_api_check.rc == 0
+    - _trove_resolved_image_id | default('') | length == 0
+
+# =========================================================================
+# PART 3: CREATE DATASTORE VERSION
+# =========================================================================
+# The Trove API auto-creates the datastore type when the first version is
+# created — there is no separate 'datastore create' CLI command.
+
+- name: Check if datastore version '{{ trove_datastore_version_name }}' exists
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      source {{ genestack_venv }}/bin/activate
+      openstack --os-cloud {{ os_cloud }} datastore version list "{{ trove_datastore_name }}" \
+        -f value -c Name 2>/dev/null | grep -q "^{{ trove_datastore_version_name }}$"
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _trove_dsv_check
+  changed_when: false
+  failed_when: false
+  when: _trove_api_check.rc == 0
+
+- name: Create datastore version '{{ trove_datastore_version_name }}'
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      openstack --os-cloud {{ os_cloud }} datastore version create
+      "{{ trove_datastore_version_name }}"
+      "{{ trove_datastore_name }}"
+      "{{ trove_datastore_name }}"
+      ""
+      --image-tags trove,{{ trove_datastore_name }}
+      --active
+      --default
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when:
+    - _trove_api_check.rc == 0
+    - _trove_dsv_check.rc != 0
+
+# =========================================================================
+# PART 4: VERIFY AND REPORT
+# =========================================================================
+
+- name: List datastores for verification
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      openstack --os-cloud {{ os_cloud }} datastore list
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _trove_ds_list
+  changed_when: false
+  when: _trove_api_check.rc == 0
+
+- name: List datastore versions for verification
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      openstack --os-cloud {{ os_cloud }} datastore version list "{{ trove_datastore_name }}"
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _trove_dsv_list
+  changed_when: false
+  when: _trove_api_check.rc == 0
+
+- name: Display datastore setup results
+  ansible.builtin.debug:
+    msg: |
+      ================================================================
+        TROVE DATASTORE SETUP — COMPLETE
+      ================================================================
+
+      Datastores:
+      {{ _trove_ds_list.stdout | default('(not available)') }}
+
+      Datastore versions ({{ trove_datastore_name }}):
+      {{ _trove_dsv_list.stdout | default('(not available)') }}
+
+      Guest image: {{ trove_guest_image_name }} ({{ _trove_resolved_image_id | default('unknown') }})
+
+      ================================================================
+  when: _trove_api_check.rc == 0

--- a/ansible/roles/trove_enablement_techpreview/tasks/trove_gateway_and_kustomize.yml
+++ b/ansible/roles/trove_enablement_techpreview/tasks/trove_gateway_and_kustomize.yml
@@ -1,0 +1,256 @@
+---
+# Generate gateway listener, route, kustomize overlay, and endpoint overrides
+# for Trove in /etc/genestack, then patch the envoy gateway and apply the route.
+#
+# These files land inside the /etc/genestack git tree, so the role finishes
+# with a summary telling the operator what changed and that a commit is needed.
+
+# -------------------------------------------------------------------------
+# Discover the region from the existing endpoints.yaml anchor (_region)
+# or fall back to trove_region_name from defaults.
+# -------------------------------------------------------------------------
+- name: Detect region from existing endpoints.yaml
+  ansible.builtin.shell: |
+    if [ -f /etc/genestack/helm-configs/global_overrides/endpoints.yaml ]; then
+      grep -oP '^\s*_region:\s*&\w+\s+\K\S+' \
+        /etc/genestack/helm-configs/global_overrides/endpoints.yaml 2>/dev/null || true
+    fi
+  args:
+    executable: /bin/bash
+  register: _detected_region
+  changed_when: false
+
+- name: Set trove_gateway_region_lower fact
+  ansible.builtin.set_fact:
+    trove_gateway_region_lower: >-
+      {{ (_detected_region.stdout | trim | lower)
+         if (_detected_region.stdout | trim | length > 0)
+         else (trove_region_name | lower) }}
+
+- name: Display resolved gateway region
+  ansible.builtin.debug:
+    msg: "Gateway hostname region component: {{ trove_gateway_region_lower }}"
+
+# -------------------------------------------------------------------------
+# Track files changed for the summary message
+# -------------------------------------------------------------------------
+- name: Initialise list of changed files
+  ansible.builtin.set_fact:
+    _trove_preconf_changed_files: []
+
+# -------------------------------------------------------------------------
+# 1) Envoy gateway listener — /etc/genestack/gateway-api/listeners/
+# -------------------------------------------------------------------------
+- name: Ensure gateway-api listeners directory exists
+  ansible.builtin.file:
+    path: /etc/genestack/gateway-api/listeners
+    state: directory
+    mode: "0755"
+
+- name: Template Trove HTTPS listener JSON
+  ansible.builtin.template:
+    src: trove-https-listener.json.j2
+    dest: /etc/genestack/gateway-api/listeners/trove-https.json
+    mode: "0644"
+  register: _listener_result
+
+- name: Record listener change  # noqa: no-handler
+  ansible.builtin.set_fact:
+    _trove_preconf_changed_files: "{{ _trove_preconf_changed_files + ['/etc/genestack/gateway-api/listeners/trove-https.json'] }}"
+  when: _listener_result.changed
+
+# -------------------------------------------------------------------------
+# 2) Gateway route — /etc/genestack/gateway-api/routes/
+# -------------------------------------------------------------------------
+- name: Ensure gateway-api routes directory exists
+  ansible.builtin.file:
+    path: /etc/genestack/gateway-api/routes
+    state: directory
+    mode: "0755"
+
+- name: Template Trove gateway route
+  ansible.builtin.template:
+    src: custom-trove-gateway-route.yaml.j2
+    dest: /etc/genestack/gateway-api/routes/custom-trove-gateway-route.yaml
+    mode: "0644"
+  register: _route_result
+
+- name: Record route change  # noqa: no-handler
+  ansible.builtin.set_fact:
+    _trove_preconf_changed_files: "{{ _trove_preconf_changed_files + ['/etc/genestack/gateway-api/routes/custom-trove-gateway-route.yaml'] }}"
+  when: _route_result.changed
+
+# -------------------------------------------------------------------------
+# 3) Kustomize overlay — /etc/genestack/kustomize/trove/
+# -------------------------------------------------------------------------
+- name: Ensure kustomize trove overlay directory exists
+  ansible.builtin.file:
+    path: /etc/genestack/kustomize/trove/overlay
+    state: directory
+    mode: "0755"
+
+- name: Create symlink to base-kustomize/trove/aio
+  ansible.builtin.file:
+    src: /opt/genestack/base-kustomize/trove/aio
+    dest: /etc/genestack/kustomize/trove/aio
+    state: link
+    force: true
+  register: _aio_link_result
+
+- name: Record aio symlink change  # noqa: no-handler
+  ansible.builtin.set_fact:
+    _trove_preconf_changed_files: "{{ _trove_preconf_changed_files + ['/etc/genestack/kustomize/trove/aio'] }}"
+  when: _aio_link_result.changed
+
+- name: Create symlink to base-kustomize/trove/base
+  ansible.builtin.file:
+    src: /opt/genestack/base-kustomize/trove/base
+    dest: /etc/genestack/kustomize/trove/base
+    state: link
+    force: true
+  register: _base_link_result
+
+- name: Record base symlink change  # noqa: no-handler
+  ansible.builtin.set_fact:
+    _trove_preconf_changed_files: "{{ _trove_preconf_changed_files + ['/etc/genestack/kustomize/trove/base'] }}"
+  when: _base_link_result.changed
+
+- name: Template kustomization.yaml for Trove overlay
+  ansible.builtin.template:
+    src: trove-kustomization.yaml.j2
+    dest: /etc/genestack/kustomize/trove/overlay/kustomization.yaml
+    mode: "0644"
+  register: _kustomization_result
+
+- name: Record kustomization change  # noqa: no-handler
+  ansible.builtin.set_fact:
+    _trove_preconf_changed_files: "{{ _trove_preconf_changed_files + ['/etc/genestack/kustomize/trove/overlay/kustomization.yaml'] }}"
+  when: _kustomization_result.changed
+
+# -------------------------------------------------------------------------
+# 4) Endpoints — deep-merge Trove stanzas into global_overrides/endpoints.yaml
+# -------------------------------------------------------------------------
+- name: Ensure global_overrides directory exists
+  ansible.builtin.file:
+    path: /etc/genestack/helm-configs/global_overrides
+    state: directory
+    mode: "0755"
+
+- name: Template Trove endpoints fragment
+  ansible.builtin.template:
+    src: trove-endpoints-fragment.yaml.j2
+    dest: /tmp/trove_endpoints_fragment.yaml
+    mode: "0644"
+
+- name: Deep-merge Trove endpoints into global_overrides/endpoints.yaml
+  ansible.builtin.script:
+    cmd: >-
+      merge_endpoints.py
+      /etc/genestack/helm-configs/global_overrides/endpoints.yaml
+      /tmp/trove_endpoints_fragment.yaml
+    executable: python3
+  register: _endpoints_result
+  changed_when: true
+
+- name: Record endpoints change
+  ansible.builtin.set_fact:
+    _trove_preconf_changed_files: "{{ _trove_preconf_changed_files + ['/etc/genestack/helm-configs/global_overrides/endpoints.yaml'] }}"
+
+- name: Remove temporary endpoints fragment
+  ansible.builtin.file:
+    path: /tmp/trove_endpoints_fragment.yaml
+    state: absent
+
+# -------------------------------------------------------------------------
+# 5) Patch the envoy gateway with the Trove listener
+# -------------------------------------------------------------------------
+- name: Patch envoy gateway with Trove HTTPS listener
+  ansible.builtin.shell: |
+    set -o pipefail
+    source {{ genestack_venv }}/bin/activate
+
+    # Only patch if the listener is not already present
+    EXISTING=$(kubectl -n envoy-gateway get gateway flex-gateway -o json 2>/dev/null \
+      | jq -r '.spec.listeners[]? | select(.name == "trove-https") | .name' 2>/dev/null)
+
+    if [ "$EXISTING" = "trove-https" ]; then
+      echo "Trove HTTPS listener already present on flex-gateway — skipping patch"
+    else
+      kubectl patch -n envoy-gateway gateway flex-gateway \
+        --type='json' \
+        --patch-file /etc/genestack/gateway-api/listeners/trove-https.json
+      echo "Patched flex-gateway with Trove HTTPS listener"
+    fi
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _gw_patch_result
+  changed_when: "'Patched' in _gw_patch_result.stdout"
+
+- name: Show gateway patch result
+  ansible.builtin.debug:
+    msg: "{{ _gw_patch_result.stdout }}"
+
+# -------------------------------------------------------------------------
+# 6) Apply the Trove gateway route
+# -------------------------------------------------------------------------
+- name: Apply Trove gateway route
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    kubectl apply -f /etc/genestack/gateway-api/routes/custom-trove-gateway-route.yaml
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _route_apply_result
+  changed_when: "'created' in _route_apply_result.stdout or 'configured' in _route_apply_result.stdout"
+
+- name: Show route apply result
+  ansible.builtin.debug:
+    msg: "{{ _route_apply_result.stdout }}"
+
+# -------------------------------------------------------------------------
+# 7) Summary — tell the operator what changed and that /etc/genestack is dirty
+# -------------------------------------------------------------------------
+- name: Build preconf summary
+  ansible.builtin.set_fact:
+    _trove_preconf_summary: |
+      ================================================================
+        TROVE ENABLEMENT — FILE CHANGE SUMMARY
+      ================================================================
+
+      The following files/directories were created or modified under
+      /etc/genestack:
+
+      {% for f in _trove_preconf_changed_files %}
+        - {{ f }}
+      {% endfor %}
+      {% if _trove_preconf_changed_files | length == 0 %}
+        (no file changes — all files already existed with correct content)
+      {% endif %}
+
+      Additional runtime actions taken:
+        - Envoy gateway listener: {{ _gw_patch_result.stdout | trim }}
+        - Gateway route: {{ _route_apply_result.stdout | trim }}
+
+      ================================================================
+        ACTION REQUIRED
+      ================================================================
+      The /etc/genestack git tree is likely dirty with uncommitted
+      changes. Before proceeding with install-trove.sh, please:
+
+        cd /etc/genestack
+        git status
+        git add -A
+        git commit -m "Add Trove gateway, kustomize, and endpoint configuration"
+        git push
+
+      ================================================================
+
+- name: Display preconf summary
+  ansible.builtin.debug:
+    msg: "{{ _trove_preconf_summary }}"

--- a/ansible/roles/trove_enablement_techpreview/tasks/trove_guest_image_builder.yml
+++ b/ansible/roles/trove_enablement_techpreview/tasks/trove_guest_image_builder.yml
@@ -1,0 +1,379 @@
+---
+# Build a Trove guest image using diskimage-builder (mirroring the Manila
+# service image builder pattern), upload to Glance, and share with the
+# required projects.
+#
+# The Trove repo ships DIB elements at integration/scripts/files/elements/.
+# We clone the repo, create an isolated build virtualenv with
+# diskimage-builder, and call disk-image-create with the upstream elements.
+#
+# NOTE: trove-guestagent.conf is NOT baked into the image.  The Trove
+# taskmanager injects it at instance creation time via Nova config-drive
+# (see trove/instance/models.py:get_injected_files).  The DIB image only
+# needs the guest-agent binary, Docker, and the directory structure.
+
+# =========================================================================
+# PART 1: BOOTSTRAP
+# =========================================================================
+
+- name: Install python-troveclient into genestack virtualenv
+  ansible.builtin.pip:
+    virtualenv: "{{ genestack_venv }}"
+    name: python-troveclient
+    state: present
+
+- name: Create build directory
+  ansible.builtin.file:
+    path: "{{ trove_build_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Delete old trove repo directory if it exists
+  ansible.builtin.file:
+    path: "{{ trove_build_dir }}/trove"
+    state: absent
+  become: true
+  become_user: root
+
+- name: Clone trove repository (stable/{{ trove_openstack_release }})
+  ansible.builtin.git:
+    repo: https://opendev.org/openstack/trove.git
+    dest: "{{ trove_build_dir }}/trove"
+    version: "stable/{{ trove_openstack_release }}"
+    update: true
+    force: false
+
+# qemu-utils provides qemu-img; debootstrap and kpartx are required by
+# diskimage-builder for base image creation and partition handling.
+- name: Install QEMU and image-build system dependencies
+  ansible.builtin.apt:
+    name:
+      - qemu-system
+      - qemu-system-x86
+      - qemu-utils
+      - debootstrap
+      - kpartx
+    state: present
+    update_cache: true
+  become: true
+  become_user: root
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+
+- name: Create Trove build virtualenv
+  ansible.builtin.pip:
+    virtualenv: "{{ trove_venv_dir }}"
+    virtualenv_command: python3 -m venv
+    name: pip
+    state: present
+
+- name: Install diskimage-builder into build virtualenv
+  ansible.builtin.pip:
+    virtualenv: "{{ trove_venv_dir }}"
+    name:
+      - diskimage-builder
+      - setuptools
+      - wheel
+    state: present
+
+# =========================================================================
+# PART 2: ENSURE clouds.yaml EXISTS
+# =========================================================================
+
+- name: Check if clouds.yaml already exists
+  ansible.builtin.stat:
+    path: "{{ ubuntu_home }}/.config/openstack/clouds.yaml"
+  register: _trove_clouds_yaml_stat
+
+- name: Generate clouds.yaml via setup-openstack-rc.sh (safety net)
+  ansible.builtin.shell:
+    cmd: |
+      source {{ genestack_venv }}/bin/activate
+      set -a
+      source {{ genestack_rc }}
+      set +a
+      bash /opt/genestack/bin/setup-openstack-rc.sh
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: not _trove_clouds_yaml_stat.stat.exists
+
+# =========================================================================
+# PART 3: STATE DETECTION
+# =========================================================================
+
+- name: Check if Trove guest image exists in Glance
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      source {{ genestack_venv }}/bin/activate
+      openstack --os-cloud {{ os_cloud }} image show "{{ trove_guest_image_name }}" \
+        -f value -c id 2>/dev/null
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _trove_image_check
+  changed_when: false
+  failed_when: false
+
+- name: Derive image build action flags
+  ansible.builtin.set_fact:
+    _trove_image_exists: "{{ _trove_image_check.rc == 0 and _trove_image_check.stdout | trim | length > 0 }}"
+    _trove_do_build: >-
+      {{
+        (_trove_image_check.rc != 0 or _trove_image_check.stdout | trim | length == 0)
+        or (force_rebuild_image | bool)
+        or (force_full_recreation | bool)
+      }}
+
+- name: Report image state
+  ansible.builtin.debug:
+    msg: >-
+      Image '{{ trove_guest_image_name }}' exists={{ _trove_image_exists }},
+      do_build={{ _trove_do_build }},
+      force_rebuild={{ force_rebuild_image }},
+      force_full={{ force_full_recreation }}
+
+# =========================================================================
+# PART 4: BUILD GUEST IMAGE WITH DISKIMAGE-BUILDER
+# =========================================================================
+
+- name: Delete local qcow2 to ensure a clean rebuild
+  ansible.builtin.file:
+    path: "{{ trove_build_dir }}/{{ trove_guest_image_name }}.qcow2"
+    state: absent
+  become: true
+  become_user: root
+  when: _trove_do_build | bool
+
+- name: Clean up any stale diskimage-builder build directories
+  ansible.builtin.shell: |
+    for d in /tmp/dib_build.* /tmp/dib_image.*; do
+      [ -d "$d" ] || continue
+      umount -lR "$d" 2>/dev/null || true
+      rm -rf "$d"
+    done
+  args:
+    executable: /bin/bash
+  become: true
+  become_user: root
+  changed_when: false
+  when: _trove_do_build | bool
+
+- name: Build Trove guest image with disk-image-create
+  ansible.builtin.shell: |
+    source {{ trove_venv_dir }}/bin/activate
+    cd {{ trove_build_dir }}/trove
+    disk-image-create -a amd64 \
+      -o {{ trove_build_dir }}/{{ trove_guest_image_name }} \
+      -t qcow2 \
+      --image-size 5 \
+      -x \
+      base vm ubuntu-minimal cloud-init-datasources \
+      pip-cache guest-agent ubuntu-docker
+  args:
+    executable: /bin/bash
+  become: true
+  become_user: root
+  register: _trove_dib_build
+  retries: 3
+  delay: 30
+  until: _trove_dib_build.rc == 0
+  environment:
+    HOME: "{{ ubuntu_home }}"
+    ELEMENTS_PATH: "{{ trove_build_dir }}/trove/integration/scripts/files/elements"
+    DIB_RELEASE: "{{ trove_guest_image_os_release }}"
+    DIB_DISTRIBUTION_MIRROR: "{{ trove_dib_distribution_mirror }}"
+    DIB_CLOUD_INIT_DATASOURCES: "ConfigDrive"
+    DIB_CLOUD_INIT_ETC_HOSTS: "localhost"
+    DISTRO_NAME: ubuntu
+    GUEST_USERNAME: ubuntu
+    DEV_MODE: "false"
+    SYNC_LOG_TO_CONTROLLER: "False"
+  when: _trove_do_build | bool
+
+# =========================================================================
+# PART 5: DELETE OLD GLANCE IMAGE AND UPLOAD NEW ONE
+# =========================================================================
+
+- name: Delete existing Glance image before re-upload
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      openstack --os-cloud {{ os_cloud }} image delete "{{ trove_guest_image_name }}"
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when:
+    - _trove_do_build | bool
+    - _trove_image_exists | bool
+  failed_when: false
+
+- name: Ensure glance_admin role exists and is assigned to admin user
+  ansible.builtin.shell:
+    cmd: |
+      source {{ genestack_venv }}/bin/activate
+      openstack --os-cloud {{ os_cloud }} role create glance_admin 2>/dev/null || true
+      openstack --os-cloud {{ os_cloud }} role add \
+        --user admin --project admin glance_admin 2>/dev/null || true
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  changed_when: false
+  when: _trove_do_build | bool
+
+- name: Upload Trove guest image to Glance
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      source {{ genestack_venv }}/bin/activate
+      openstack --os-cloud {{ os_cloud }} image create \
+        --disk-format qcow2 \
+        --container-format bare \
+        --shared \
+        --property os_type=linux \
+        --property os_distro=ubuntu \
+        --property os_version=22.04 \
+        --property trove_datastore={{ trove_datastore_name }} \
+        --property trove_datastore_version={{ trove_datastore_version_name }} \
+        --tag trove \
+        --tag {{ trove_datastore_name }} \
+        --file "{{ trove_build_dir }}/{{ trove_guest_image_name }}.qcow2" \
+        "{{ trove_guest_image_name }}" \
+        -f value -c id
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _trove_image_upload
+  when: _trove_do_build | bool
+
+- name: Set trove_guest_image_id fact
+  ansible.builtin.set_fact:
+    trove_guest_image_id: "{{ _trove_image_upload.stdout | trim }}"
+  when: _trove_do_build | bool
+
+- name: Set trove_guest_image_id from existing image
+  ansible.builtin.set_fact:
+    trove_guest_image_id: "{{ _trove_image_check.stdout | trim }}"
+  when: not (_trove_do_build | bool)
+
+# =========================================================================
+# PART 6: SHARE IMAGE WITH SERVICE AND ADMIN PROJECTS
+# =========================================================================
+
+- name: Get admin project ID
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      source {{ genestack_venv }}/bin/activate
+      openstack --os-cloud {{ os_cloud }} project show admin -f value -c id
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _trove_admin_project_id
+  changed_when: false
+  when: _trove_do_build | bool
+
+- name: Get service project ID
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      source {{ genestack_venv }}/bin/activate
+      openstack --os-cloud {{ os_cloud }} project show service -f value -c id
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _trove_service_project_id
+  changed_when: false
+  when: _trove_do_build | bool
+
+- name: Add service and admin projects as image members
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      openstack --os-cloud {{ os_cloud }} image add project
+      "{{ trove_guest_image_name }}" {{ item }}
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  loop:
+    - "{{ _trove_service_project_id.stdout | trim }}"
+    - "{{ _trove_admin_project_id.stdout | trim }}"
+  when: _trove_do_build | bool
+  failed_when: false
+
+- name: Accept image membership for service project
+  ansible.builtin.shell:
+    cmd: |
+      source {{ genestack_venv }}/bin/activate
+      openstack --os-cloud {{ os_cloud }} image set \
+        --project {{ _trove_service_project_id.stdout | trim }} \
+        --accept {{ trove_guest_image_id }}
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: _trove_do_build | bool
+  failed_when: false
+
+- name: Accept image membership for admin project
+  ansible.builtin.shell:
+    cmd: |
+      source {{ genestack_venv }}/bin/activate
+      openstack --os-cloud {{ os_cloud }} image set \
+        --project {{ _trove_admin_project_id.stdout | trim }} \
+        --accept {{ trove_guest_image_id }}
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: _trove_do_build | bool
+  failed_when: false
+
+- name: List image members
+  ansible.builtin.shell:
+    cmd: |
+      source {{ genestack_venv }}/bin/activate
+      openstack --os-cloud {{ os_cloud }} image member list {{ trove_guest_image_id }}
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _trove_image_members
+  changed_when: false
+  when: _trove_do_build | bool
+
+- name: Display image members
+  ansible.builtin.debug:
+    msg: "{{ _trove_image_members.stdout_lines }}"
+  when: _trove_do_build | bool
+
+- name: Report image upload result
+  ansible.builtin.debug:
+    msg: >-
+      Trove guest image '{{ trove_guest_image_name }}'
+      ID={{ trove_guest_image_id }}
+      ({{ 'newly built' if (_trove_do_build | bool) else 'pre-existing' }})
+
+# =========================================================================
+# PART 7: CLEANUP BUILD ARTIFACTS
+# =========================================================================
+
+- name: Clean up Trove build directory
+  ansible.builtin.file:
+    path: "{{ trove_build_dir }}"
+    state: absent
+  become: true
+  become_user: root
+  when: _trove_do_build | bool
+
+- name: Clean up any remaining diskimage-builder temp directories
+  ansible.builtin.shell: |
+    for d in /tmp/dib_build.* /tmp/dib_image.*; do
+      [ -d "$d" ] || continue
+      umount -lR "$d" 2>/dev/null || true
+      rm -rf "$d"
+    done
+  args:
+    executable: /bin/bash
+  become: true
+  become_user: root
+  changed_when: false
+  when: _trove_do_build | bool

--- a/ansible/roles/trove_enablement_techpreview/tasks/trove_helm_config.yml
+++ b/ansible/roles/trove_enablement_techpreview/tasks/trove_helm_config.yml
@@ -1,0 +1,261 @@
+---
+# Configure Trove Helm values by deep-merging the driver config template
+# into the existing trove-helm-overrides.yaml.
+
+# =========================================================================
+# PART 1: GATHER REQUIRED IDS
+# =========================================================================
+
+- name: Get Trove management network ID for management_networks
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      source {{ genestack_venv }}/bin/activate
+      openstack --os-cloud {{ os_cloud }} network show {{ trove_mgmt_network_name }} \
+        -f value -c id
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _trove_mgmt_network_id
+  changed_when: false
+
+- name: Get trove security group ID
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      source {{ genestack_venv }}/bin/activate
+      openstack --os-cloud {{ os_cloud }} security group show {{ trove_secgroup_name }} \
+        -f value -c id
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _trove_secgroup_id
+  changed_when: false
+
+- name: Get trove admin password from K8s secret (if not already set)
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      kubectl --namespace openstack get secret trove-admin \
+        -o jsonpath='{.data.password}' | base64 -d
+    executable: /bin/bash
+  register: _trove_admin_password_helm
+  changed_when: false
+  no_log: true
+  when: _trove_admin_password is not defined or _trove_admin_password.stdout is not defined
+
+- name: Resolve trove admin password
+  ansible.builtin.set_fact:
+    _trove_resolved_admin_pw: >-
+      {{ (_trove_admin_password.stdout | default(''))
+         if (_trove_admin_password is defined and _trove_admin_password.stdout is defined)
+         else (_trove_admin_password_helm.stdout | default('')) }}
+  no_log: true
+
+# =========================================================================
+# PART 2: TEMPLATE THE HELM CONFIG FRAGMENT
+# =========================================================================
+
+- name: Ensure trove helm config directory exists
+  ansible.builtin.file:
+    path: "{{ helm_config_base }}/trove"
+    state: directory
+    mode: "0755"
+
+- name: Template Trove helm config fragment
+  ansible.builtin.template:
+    src: "{{ trove_helm_config_template }}"
+    dest: /tmp/trove_helm_config_fragment.yaml
+    mode: "0644"
+
+# =========================================================================
+# PART 3: DEEP-MERGE INTO EXISTING OVERRIDES
+# =========================================================================
+
+- name: Deep-merge Trove helm config into trove-helm-overrides.yaml
+  ansible.builtin.script:
+    cmd: >-
+      deep_merge_yaml.py
+      {{ helm_config_base }}/trove/trove-helm-overrides.yaml
+      /tmp/trove_helm_config_fragment.yaml
+    executable: python3
+  register: _helm_merge_result
+  changed_when: true
+
+- name: Remove temporary helm config fragment
+  ansible.builtin.file:
+    path: /tmp/trove_helm_config_fragment.yaml
+    state: absent
+
+- name: Report Trove helm config merge
+  ansible.builtin.debug:
+    msg: >-
+      Trove helm overrides updated at {{ helm_config_base }}/trove/trove-helm-overrides.yaml
+      (management_networks={{ _trove_mgmt_network_id.stdout | trim }},
+       management_security_groups={{ _trove_secgroup_id.stdout | trim }},
+       nova_keypair={{ trove_keypair_name }})
+
+# =========================================================================
+# PART 4: GUEST VM CONNECTIVITY VIA MGMT NETWORK
+# =========================================================================
+# Trove guest VMs attach to the mgmt provider network and need to reach
+# RabbitMQ and Keystone. We create a Neutron port on the mgmt network
+# (OVN-managed, security-group-enforced), then use MetalLB to bind
+# K8s services to that IP. Cloud-init injects /etc/hosts so the
+# guestagent.conf hostnames resolve to the mgmt-network IP.
+
+# --- Step 1: Create Neutron port on mgmt network for services VIP ---
+
+- name: Check if Trove services VIP port exists on mgmt network
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      openstack --os-cloud {{ os_cloud }} port show {{ trove_services_port_name }}
+      -f value -c fixed_ips
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _trove_svc_port_check
+  changed_when: false
+  failed_when: false
+
+- name: Create Trove services VIP port on management provider network
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      openstack --os-cloud {{ os_cloud }} port create
+      --network {{ trove_mgmt_network_name }}
+      --security-group {{ trove_services_secgroup_name }}
+      {{ trove_services_port_name }}
+      -f value -c fixed_ips
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _trove_svc_port_create
+  when: _trove_svc_port_check.rc != 0
+
+- name: Get Trove services VIP IP address
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      openstack --os-cloud {{ os_cloud }} port show {{ trove_services_port_name }}
+      -f json
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _trove_svc_port_info
+  changed_when: false
+
+- name: Extract Trove services VIP IP
+  ansible.builtin.set_fact:
+    trove_services_vip: >-
+      {{ (_trove_svc_port_info.stdout | from_json).fixed_ips[0].ip_address }}
+
+- name: Report Trove services VIP
+  ansible.builtin.debug:
+    msg: "Trove services VIP on mgmt network: {{ trove_services_vip }}"
+
+# --- Step 2: Create MetalLB pool for the mgmt network VIP ---
+
+- name: Apply MetalLB IPAddressPool and L2Advertisement for Trove services
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      cat <<'EOF' | kubectl apply -f -
+      apiVersion: metallb.io/v1beta1
+      kind: IPAddressPool
+      metadata:
+        name: trove-services-pool
+        namespace: metallb-system
+      spec:
+        addresses:
+          - {{ trove_services_vip }}/32
+        autoAssign: false
+      ---
+      apiVersion: metallb.io/v1beta1
+      kind: L2Advertisement
+      metadata:
+        name: trove-services-advertisement
+        namespace: metallb-system
+      spec:
+        ipAddressPools:
+          - trove-services-pool
+      EOF
+    executable: /bin/bash
+  changed_when: true
+
+# --- Step 3: Create/update K8s services on the mgmt network VIP ---
+
+- name: Apply RabbitMQ and Keystone LoadBalancer services for Trove
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      cat <<'EOF' | kubectl apply -f -
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: rabbitmq-trove-flat
+        namespace: openstack
+        annotations:
+          metallb.universe.tf/address-pool: trove-services-pool
+          metallb.universe.tf/allow-shared-ip: "trove-services-vip"
+      spec:
+        type: LoadBalancer
+        loadBalancerIP: {{ trove_services_vip }}
+        ports:
+          - name: amqp
+            port: 5672
+            targetPort: 5672
+            protocol: TCP
+        selector:
+          app.kubernetes.io/name: rabbitmq
+      ---
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: keystone-trove-flat
+        namespace: openstack
+        annotations:
+          metallb.universe.tf/address-pool: trove-services-pool
+          metallb.universe.tf/allow-shared-ip: "trove-services-vip"
+      spec:
+        type: LoadBalancer
+        loadBalancerIP: {{ trove_services_vip }}
+        ports:
+          - name: ks-pub
+            port: 5000
+            targetPort: ks-pub
+            protocol: TCP
+        selector:
+          application: keystone
+          component: api
+      EOF
+    executable: /bin/bash
+  changed_when: true
+
+# --- Step 4: Cloud-init ConfigMap for /etc/hosts injection ---
+
+- name: Template Trove guest cloud-init file
+  ansible.builtin.template:
+    src: trove-mysql-cloudinit.j2
+    dest: /tmp/mysql.cloudinit
+    mode: "0644"
+  vars:
+    trove_services_vip_ip: "{{ trove_services_vip }}"
+
+- name: Create or update trove-guest-cloudinit ConfigMap
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      kubectl create configmap trove-guest-cloudinit \
+        --namespace openstack \
+        --from-file=mysql.cloudinit=/tmp/mysql.cloudinit \
+        --dry-run=client -o yaml | kubectl apply -f -
+    executable: /bin/bash
+  register: _cloudinit_cm_result
+  changed_when: "'configured' in _cloudinit_cm_result.stdout or 'created' in _cloudinit_cm_result.stdout"
+
+- name: Remove temporary cloud-init file
+  ansible.builtin.file:
+    path: /tmp/mysql.cloudinit
+    state: absent

--- a/ansible/roles/trove_enablement_techpreview/tasks/trove_k8s_secrets.yml
+++ b/ansible/roles/trove_enablement_techpreview/tasks/trove_k8s_secrets.yml
@@ -1,0 +1,176 @@
+---
+# Create Trove K8s secrets (rabbitmq, db, admin, SSH keypair).
+# Mirrors the Manila pattern: pre-create secrets BEFORE the Helm install
+# so all values are available for preconf (keypair, security group,
+# helm overrides) and the Helm chart deploys with correct config in one pass.
+
+- name: Derive effective secrets recreation flag
+  ansible.builtin.set_fact:
+    _recreate_all_secrets: "{{ (trove_force_recreate_secrets | default(false) | bool) or (force_full_recreation | default(false) | bool) }}"
+
+- name: Remove stale secrets temp files from previous runs
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /tmp/trove_secrets.yml
+    - /tmp/trove_ssh_key
+    - /tmp/trove_ssh_key.pub
+
+- name: Delete existing Trove K8s secrets
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    for secret in trove-rabbitmq-password trove-db-password trove-admin trove-ssh; do
+      kubectl -n openstack delete secret "$secret" --ignore-not-found=true
+    done
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: _recreate_all_secrets | bool
+
+- name: Check if Trove K8s secrets already exist
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    kubectl -n openstack get secret trove-rabbitmq-password -o name 2>/dev/null
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _trove_secrets_check
+  changed_when: false
+  failed_when: false
+
+- name: Determine if secrets need to be generated
+  ansible.builtin.set_fact:
+    _do_generate_secrets: "{{ (_trove_secrets_check.rc != 0) or (_recreate_all_secrets | bool) }}"
+
+- name: Generate Trove secrets
+  ansible.builtin.script:
+    cmd: create_trove_k8s_secrets.sh {{ trove_region_name }}
+  when: _do_generate_secrets | bool
+
+- name: Apply Trove secrets to Kubernetes
+  ansible.builtin.shell: |
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+    kubectl apply -f /tmp/trove_secrets.yml
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: _do_generate_secrets | bool
+
+- name: Clean up temporary secrets file
+  ansible.builtin.file:
+    path: /tmp/trove_secrets.yml
+    state: absent
+
+# --------------------------------------------------------------------------
+# When secrets are created or recreated the new RabbitMQ password
+# must be synced to the backing service, otherwise Trove pods crash with
+# ACCESS_REFUSED.
+# --------------------------------------------------------------------------
+
+- name: Sync new RabbitMQ password into the RabbitMQ cluster
+  ansible.builtin.shell: |
+    set -o pipefail
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+
+    NEW_PASS=$(kubectl -n openstack get secret trove-rabbitmq-password \
+      -o jsonpath='{.data.password}' | base64 -d)
+
+    # Check if the trove user exists in RabbitMQ
+    if kubectl -n openstack exec rabbitmq-server-0 -- \
+        rabbitmqctl list_users 2>/dev/null | grep -q '^trove'; then
+      echo "Updating existing trove user password in RabbitMQ..."
+      kubectl -n openstack exec rabbitmq-server-0 -- \
+        rabbitmqctl change_password trove "$NEW_PASS"
+    else
+      echo "Creating trove user in RabbitMQ..."
+      kubectl -n openstack exec rabbitmq-server-0 -- \
+        rabbitmqctl add_user trove "$NEW_PASS"
+      kubectl -n openstack exec rabbitmq-server-0 -- \
+        rabbitmqctl set_permissions trove ".*" ".*" ".*"
+      kubectl -n openstack exec rabbitmq-server-0 -- \
+        rabbitmqctl set_user_tags trove management policymaker
+    fi
+
+    echo "Verifying RabbitMQ authentication..."
+    kubectl -n openstack exec rabbitmq-server-0 -- \
+      rabbitmqctl authenticate_user trove "$NEW_PASS"
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _rabbitmq_sync
+  when: _do_generate_secrets | bool
+
+- name: Show RabbitMQ sync result
+  ansible.builtin.debug:
+    msg: "{{ _rabbitmq_sync.stdout_lines }}"
+  when: _rabbitmq_sync is not skipped
+
+- name: Sync new DB password into MariaDB
+  ansible.builtin.shell: |
+    set -o pipefail
+    source {{ genestack_venv }}/bin/activate
+    set -a
+    source {{ genestack_rc }}
+    set +a
+
+    NEW_DB_PASS=$(kubectl -n openstack get secret trove-db-password \
+      -o jsonpath='{.data.password}' | base64 -d)
+
+    # Find a running MariaDB pod
+    MARIADB_POD=$(kubectl -n openstack get pods -l application=mariadb \
+      --field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+
+    if [ -z "$MARIADB_POD" ]; then
+      echo "WARNING: No running MariaDB pod found — skipping DB password sync."
+      echo "         The DB password will be applied during Helm install."
+      exit 0
+    fi
+
+    # Get the MariaDB root password
+    ROOT_PASS=$(kubectl -n openstack get secret mariadb \
+      -o jsonpath='{.data.root-password}' 2>/dev/null | base64 -d) || true
+
+    if [ -z "$ROOT_PASS" ]; then
+      echo "WARNING: Could not retrieve MariaDB root password — skipping DB password sync."
+      exit 0
+    fi
+
+    echo "Updating trove DB user password in MariaDB..."
+    kubectl -n openstack exec "$MARIADB_POD" -- \
+      mariadb -u root -p"$ROOT_PASS" -e \
+        "ALTER USER IF EXISTS 'trove'@'%' IDENTIFIED BY '$NEW_DB_PASS'; FLUSH PRIVILEGES;" 2>/dev/null
+
+    echo "DB password synced for user 'trove'."
+  args:
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _db_sync
+  failed_when: false
+  when: _do_generate_secrets | bool
+
+- name: Show DB sync result
+  ansible.builtin.debug:
+    msg: "{{ _db_sync.stdout_lines }}"
+  when: _db_sync is not skipped
+
+- name: Set flag indicating secrets were recreated
+  ansible.builtin.set_fact:
+    trove_secrets_recreated: "{{ _do_generate_secrets | bool }}"

--- a/ansible/roles/trove_enablement_techpreview/tasks/trove_preconf.yml
+++ b/ansible/roles/trove_enablement_techpreview/tasks/trove_preconf.yml
@@ -1,0 +1,136 @@
+---
+# Trove pre-configuration (pre-deploy): security group creation.
+# Must run AFTER Keystone and Neutron are deployed.
+# Keypair creation is in trove_preconf_keypair.yml (post-deploy) because
+# the trove Keystone user doesn't exist until the Trove helm chart runs.
+
+# =========================================================================
+# PART 1: ENSURE clouds.yaml EXISTS
+# =========================================================================
+
+- name: Check if clouds.yaml already exists
+  ansible.builtin.stat:
+    path: "{{ ubuntu_home }}/.config/openstack/clouds.yaml"
+  register: _trove_clouds_yaml_stat
+
+- name: Generate clouds.yaml via setup-openstack-rc.sh (safety net)
+  ansible.builtin.shell:
+    cmd: |
+      source {{ genestack_venv }}/bin/activate
+      set -a
+      source {{ genestack_rc }}
+      set +a
+      bash /opt/genestack/bin/setup-openstack-rc.sh
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: not _trove_clouds_yaml_stat.stat.exists
+
+# =========================================================================
+# PART 2: CREATE SECURITY GROUP
+# =========================================================================
+
+- name: Check if trove security group exists
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      openstack --os-cloud {{ os_cloud }} security group show {{ trove_secgroup_name }} -f json
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _trove_secgroup_check
+  changed_when: false
+  failed_when: false
+
+- name: Create trove access security group
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      openstack --os-cloud {{ os_cloud }} security group create
+      --description "Security group for Trove instances" {{ trove_secgroup_name }}
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: _trove_secgroup_check.rc != 0
+
+- name: Create ICMP rule for trove security group
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      openstack --os-cloud {{ os_cloud }} security group rule create
+      --protocol icmp --remote-ip {{ trove_secgroup_remote_ip }} {{ trove_secgroup_name }}
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: _trove_secgroup_check.rc != 0
+
+- name: Create SSH rule for trove security group
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      openstack --os-cloud {{ os_cloud }} security group rule create
+      --protocol tcp --dst-port 22 --remote-ip {{ trove_secgroup_remote_ip }} {{ trove_secgroup_name }}
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: _trove_secgroup_check.rc != 0
+
+- name: Create MySQL rule for trove security group
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      openstack --os-cloud {{ os_cloud }} security group rule create
+      --protocol tcp --dst-port 3306 --remote-ip {{ trove_secgroup_remote_ip }} {{ trove_secgroup_name }}
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: _trove_secgroup_check.rc != 0
+
+# =========================================================================
+# PART 3: CREATE SERVICES VIP SECURITY GROUP
+# =========================================================================
+
+- name: Check if trove services security group exists
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      openstack --os-cloud {{ os_cloud }} security group show {{ trove_services_secgroup_name }} -f json
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _trove_svc_secgroup_check
+  changed_when: false
+  failed_when: false
+
+- name: Create trove services security group
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      openstack --os-cloud {{ os_cloud }} security group create
+      --description "Security group for Trove services VIP (RabbitMQ, Keystone)" {{ trove_services_secgroup_name }}
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: _trove_svc_secgroup_check.rc != 0
+
+- name: Create RabbitMQ rule for trove services security group
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      openstack --os-cloud {{ os_cloud }} security group rule create
+      --protocol tcp --dst-port 5672 --remote-ip {{ lab_tenant_subnet_cidr }} {{ trove_services_secgroup_name }}
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: _trove_svc_secgroup_check.rc != 0
+
+- name: Create Keystone rule for trove services security group
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      openstack --os-cloud {{ os_cloud }} security group rule create
+      --protocol tcp --dst-port 5000 --remote-ip {{ lab_tenant_subnet_cidr }} {{ trove_services_secgroup_name }}
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: _trove_svc_secgroup_check.rc != 0

--- a/ansible/roles/trove_enablement_techpreview/tasks/trove_preconf_keypair.yml
+++ b/ansible/roles/trove_enablement_techpreview/tasks/trove_preconf_keypair.yml
@@ -1,0 +1,94 @@
+---
+# Trove keypair creation (post-deploy): must run AFTER the Trove helm chart
+# is installed, because the trove-ks-user job creates the Keystone user.
+# Nova keypairs are scoped to user+project — the keypair must be created
+# as the 'trove' user in the 'service' project.
+
+# =========================================================================
+# PART 1: GET TROVE CREDENTIALS FROM K8S SECRETS
+# =========================================================================
+
+- name: Get trove SSH public key from K8s secret
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      kubectl get secret trove-ssh -n openstack \
+        -o jsonpath='{.data.public-key}' | base64 --decode
+    executable: /bin/bash
+  register: _trove_ssh_public_key
+  changed_when: false
+
+- name: Get trove admin password from K8s secret
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      kubectl --namespace openstack get secret trove-admin \
+        -o jsonpath='{.data.password}' | base64 -d
+    executable: /bin/bash
+  register: _trove_admin_password
+  changed_when: false
+  no_log: true
+
+# =========================================================================
+# PART 2: WRITE TROVE OPENRC
+# =========================================================================
+
+- name: Write trove-openrc file
+  ansible.builtin.copy:
+    content: |
+      export OS_AUTH_URL=http://keystone-api.openstack.svc.cluster.local:5000/v3
+      export OS_PROJECT_NAME=service
+      export OS_TENANT_NAME=default
+      export OS_PROJECT_DOMAIN_NAME=service
+      export OS_USERNAME=trove
+      export OS_PASSWORD={{ _trove_admin_password.stdout }}
+      export OS_USER_DOMAIN_NAME=service
+      export OS_REGION_NAME=RegionOne
+      export OS_INTERFACE=internal
+      export OS_IDENTITY_API_VERSION="3"
+    dest: "{{ ubuntu_home }}/openrc-trove"
+    owner: ubuntu
+    group: ubuntu
+    mode: "0600"
+  no_log: true
+
+# =========================================================================
+# PART 3: CREATE KEYPAIR (as trove service user)
+# =========================================================================
+
+- name: Check if trove keypair exists (as trove service user)
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      source {{ ubuntu_home }}/openrc-trove &&
+      openstack keypair show {{ trove_keypair_name }} -f json
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  register: _trove_keypair_check
+  changed_when: false
+  failed_when: false
+
+- name: Write trove SSH public key to temp file
+  ansible.builtin.copy:
+    content: "{{ _trove_ssh_public_key.stdout }}"
+    dest: /tmp/trove-access-key.pub
+    mode: "0644"
+  when: _trove_keypair_check.rc != 0
+
+- name: Create trove access keypair (as trove service user)
+  ansible.builtin.shell:
+    cmd: >
+      source {{ genestack_venv }}/bin/activate &&
+      source {{ ubuntu_home }}/openrc-trove &&
+      openstack keypair create
+      --public-key /tmp/trove-access-key.pub {{ trove_keypair_name }}
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  when: _trove_keypair_check.rc != 0
+
+- name: Remove temp public key file
+  ansible.builtin.file:
+    path: /tmp/trove-access-key.pub
+    state: absent

--- a/ansible/roles/trove_enablement_techpreview/templates/custom-trove-gateway-route.yaml.j2
+++ b/ansible/roles/trove_enablement_techpreview/templates/custom-trove-gateway-route.yaml.j2
@@ -1,0 +1,21 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: custom-trove-gateway-route
+  namespace: openstack
+  labels:
+    application: gateway-api
+    service: HTTPRoute
+    route: trove
+spec:
+  parentRefs:
+    - name: flex-gateway
+      sectionName: trove-https
+      namespace: envoy-gateway
+  hostnames:
+    - "trove.api.{{trove_gateway_region_lower}}.rackspacecloud.com"
+  rules:
+    - backendRefs:
+        - name: trove-api
+          port: 8779

--- a/ansible/roles/trove_enablement_techpreview/templates/keystone-trove-lb.yaml.j2
+++ b/ansible/roles/trove_enablement_techpreview/templates/keystone-trove-lb.yaml.j2
@@ -1,0 +1,22 @@
+---
+# Keystone LoadBalancer service for Trove guest VM connectivity.
+# Shares the MetalLB VIP with the Envoy Gateway (ports 80/443)
+# and RabbitMQ (port 5672). No port conflicts on port 5000.
+apiVersion: v1
+kind: Service
+metadata:
+  name: keystone-api-external
+  namespace: openstack
+  annotations:
+    metallb.universe.tf/address-pool: gateway-api-external
+    metallb.universe.tf/allow-shared-ip: "openstack-shared-vip"
+spec:
+  type: LoadBalancer
+  ports:
+    - name: ks-pub
+      port: 5000
+      targetPort: ks-pub
+      protocol: TCP
+  selector:
+    application: keystone
+    component: api

--- a/ansible/roles/trove_enablement_techpreview/templates/trove-endpoints-fragment.yaml.j2
+++ b/ansible/roles/trove_enablement_techpreview/templates/trove-endpoints-fragment.yaml.j2
@@ -1,0 +1,15 @@
+endpoints:
+  identity:
+    auth:
+      trove:
+        region_name: {{trove_region_name}}
+  database:
+    host_fqdn_override:
+      public:
+        tls: {}
+        host: trove.api.{{trove_gateway_region_lower}}.rackspacecloud.com
+    port:
+      api:
+        public: 443
+    scheme:
+      public: https

--- a/ansible/roles/trove_enablement_techpreview/templates/trove-https-listener.json.j2
+++ b/ansible/roles/trove_enablement_techpreview/templates/trove-https-listener.json.j2
@@ -1,0 +1,27 @@
+[
+    {
+        "op": "add",
+        "path": "/spec/listeners/-",
+        "value": {
+            "name": "trove-https",
+            "port": 443,
+            "protocol": "HTTPS",
+            "hostname": "trove.api.{{trove_gateway_region_lower}}.rackspacecloud.com",
+            "allowedRoutes": {
+                "namespaces": {
+                    "from": "All"
+                }
+            },
+            "tls": {
+                "certificateRefs": [
+                    {
+                        "group": "",
+                        "kind": "Secret",
+                        "name": "trove-gw-tls-secret"
+                    }
+                ],
+                "mode": "Terminate"
+            }
+        }
+    }
+]

--- a/ansible/roles/trove_enablement_techpreview/templates/trove-kustomization.yaml.j2
+++ b/ansible/roles/trove_enablement_techpreview/templates/trove-kustomization.yaml.j2
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base

--- a/ansible/roles/trove_enablement_techpreview/templates/trove-mysql-cloudinit.j2
+++ b/ansible/roles/trove_enablement_techpreview/templates/trove-mysql-cloudinit.j2
@@ -1,0 +1,16 @@
+Content-Type: multipart/mixed; boundary="==TROVE_BOUNDARY=="
+MIME-Version: 1.0
+
+--==TROVE_BOUNDARY==
+Content-Type: text/x-shellscript; charset="us-ascii"
+MIME-Version: 1.0
+
+#!/bin/bash
+# K8s service reachability via Neutron port on flat network
+echo '{{ trove_services_vip_ip }} rabbitmq.openstack.svc.cluster.local' >> /etc/hosts
+echo '{{ trove_services_vip_ip }} keystone-api.openstack.svc.cluster.local' >> /etc/hosts
+
+--==TROVE_BOUNDARY==
+Content-Type: text/cloud-config; charset="us-ascii"
+MIME-Version: 1.0
+

--- a/ansible/roles/trove_enablement_techpreview/templates/trove_default_helm_config.yaml
+++ b/ansible/roles/trove_enablement_techpreview/templates/trove_default_helm_config.yaml
@@ -1,0 +1,55 @@
+---
+# Trove helm config fragment — deep-merged into trove-helm-overrides.yaml
+# by the trove_enablement_techpreview role.
+#
+# This template resolves runtime values: network ID, security group ID,
+# keypair name, and guest image ID.
+
+images:
+  tags:
+    bootstrap: "ghcr.io/rackerlabs/genestack-images/openstack-client:latest"
+    trove_api: "ghcr.io/rackerlabs/genestack-images/trove:2025.1-latest"
+    trove_conductor: "ghcr.io/rackerlabs/genestack-images/trove:2025.1-latest"
+    trove_taskmanager: "ghcr.io/rackerlabs/genestack-images/trove:2025.1-latest"
+    trove_db_sync: "ghcr.io/rackerlabs/genestack-images/trove:2025.1-latest"
+    db_drop: "ghcr.io/rackerlabs/genestack-images/openstack-client:latest"
+    db_init: "ghcr.io/rackerlabs/genestack-images/openstack-client:latest"
+    dep_check: "ghcr.io/rackerlabs/genestack-images/kubernetes-entrypoint:latest"
+    image_repo_sync: null
+    ks_endpoints: "ghcr.io/rackerlabs/genestack-images/openstack-client:latest"
+    ks_service: "ghcr.io/rackerlabs/genestack-images/openstack-client:latest"
+    ks_user: "ghcr.io/rackerlabs/genestack-images/openstack-client:latest"
+    rabbit_init: null
+    test: null
+
+conf:
+  trove:
+    DEFAULT:
+      management_networks: "{{_trove_mgmt_network_id.stdout | trim}}"
+      management_security_groups: "{{_trove_secgroup_id.stdout | trim}}"
+      nova_keypair: "{{trove_keypair_name}}"
+      default_datastore: "{{trove_datastore_name}}"
+      network_driver: trove.network.neutron.NeutronDriver
+      taskmanager_manager: trove.taskmanager.manager.Manager
+      use_nova_server_config_drive: true
+      trove_volume_support: true
+      volume_support: true
+      volume_fstype: ext4
+      cinder_volume_type: Standard
+      enable_volume_az: true
+    mysql:
+      volume_support: true
+
+pod:
+  mounts:
+    trove_taskmanager:
+      init_container: null
+      trove_taskmanager:
+        volumeMounts:
+          - name: trove-guest-cloudinit
+            mountPath: /etc/trove/cloudinit
+            readOnly: true
+        volumes:
+          - name: trove-guest-cloudinit
+            configMap:
+              name: trove-guest-cloudinit

--- a/ansible/roles/trove_enablement_techpreview/vars/main.yml
+++ b/ansible/roles/trove_enablement_techpreview/vars/main.yml
@@ -1,0 +1,3 @@
+---
+# vars file for trove_enablement_techpreview
+# Reserved for future use — override-proof variables go here.


### PR DESCRIPTION
Adds a pre/post-configuration Ansible role and playbook for deploying Trove (Database as a Service) on Genestack. The role handles everything that must happen before and after `helm install` so that Trove is fully operational with MySQL 8.4.

The `trove_enablement_techpreview` role performs seven phases, controlled by Ansible tags:

| Tag | Phase | Description |
|-----|-------|-------------|
| `client` | Troveclient | Installs `python-troveclient` in the genestack virtualenv | | `pre_deploy` | Security Groups | Creates `trove-access-secgroup` (MySQL/SSH/ICMP) and `trove-services-secgroup` (RabbitMQ/Keystone) | | `image_build` | Guest Image | Builds a MySQL 8.4 guest image with virt-customize, uploads to Glance as `trove-mysql-8.4`, shares with service and admin projects | | `pre_deploy` | Gateway & Kustomize | Generates the Envoy gateway HTTPS listener/route, kustomize overlay, and merges Trove endpoints into the global overrides | | `pre_deploy` | Helm Config | Resolves network/security-group IDs and deep-merges Helm values into `trove-helm-overrides.yaml` | | `post_deploy` | Keypair | Creates `trove-access-keypair` as the Trove service user in Nova (requires Trove Keystone user from Helm install) | | `post_deploy` | Datastore | Creates the `mysql` datastore type and `8.4` version, linking the Glance guest image to Trove |

Running the playbook without tags executes all phases in order.

```bash
cd /opt/genestack
ansible-playbook ansible/playbooks/trove-enablement-techpreview.yaml
```

This runs the client, image_build, and pre_deploy phases. When complete it prints a summary of files written under /etc/genestack/. Commit those changes to the /etc/genestack git tree before proceeding.

```bash
/opt/genestack/bin/install-trove.sh
```

The install script reads overrides from:
- /opt/genestack/base-helm-configs/trove/ (base)
- /etc/genestack/helm-configs/global_overrides/ (endpoints)
- /etc/genestack/helm-configs/trove/ (driver config from the role)

```bash
ansible-playbook ansible/playbooks/trove-enablement-techpreview.yaml \
  --tags post_deploy
```

This creates the Trove keypair as the service user and registers the MySQL 8.4 datastore type and version. Both tasks are idempotent and skip gracefully if the Trove API is not yet reachable.