### PR TITLE
chore(ceilometer): Add swift to messaging URLs

### DIFF
--- a/bin/install-ceilometer.sh
+++ b/bin/install-ceilometer.sh
@@ -145,7 +145,8 @@ rabbit://cinder:$(kubectl --namespace openstack get secret cinder-rabbitmq-passw
 rabbit://heat:$(kubectl --namespace openstack get secret heat-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)@rabbitmq.openstack.svc.cluster.local:5672/heat,\
 rabbit://octavia:$(kubectl --namespace openstack get secret octavia-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)@rabbitmq.openstack.svc.cluster.local:5672/octavia,\
 rabbit://blazar:$(kubectl --namespace openstack get secret blazar-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)@rabbitmq.openstack.svc.cluster.local:5672/blazar,\
-rabbit://magnum:$(kubectl --namespace openstack get secret magnum-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)@rabbitmq.openstack.svc.cluster.local:5672/magnum}"
+rabbit://magnum:$(kubectl --namespace openstack get secret magnum-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)@rabbitmq.openstack.svc.cluster.local:5672/magnum,\
+rabbit://swift:$(kubectl --namespace openstack get secret swift-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)@rabbitmq.openstack.svc.cluster.local:5672/swift}"
 )
 
 


### PR DESCRIPTION
The swift messaging url needs to be built and supplied with the stored password from k8s so that ceilometer can poll the swift vhost.