### PR TITLE
feat: add mariadb-operator text based upgrade runbooks

### DIFF
--- a/docs/openstack-mariadb-operator-upgrade.md
+++ b/docs/openstack-mariadb-operator-upgrade.md
@@ -507,8 +507,10 @@ Skip 25.08.0
 
     and you can directly jump from `0.38.1 → 25.8.4`
 
-!!! warning "Kubernetes version requirement"
-    25.8.4 requires Kubernetes >= 1.34.
+!!! warning "Kubernetes version compatibility"
+    Confirm Kubernetes version compatibility against the upstream chart metadata
+    before performing the `0.38.1 -> 25.8.4` hop. Do not assume a fixed
+    minimum cluster version from this runbook alone.
 
 ??? bug "Known Issue: Webhook cert validation loop"
     If operator pods are stuck logging:
@@ -552,13 +554,14 @@ No special steps required beyond the standard preflight and upgrade.
 !!! note "References"
     - [Release 26.3.0](https://github.com/mariadb-operator/mariadb-operator/releases/tag/26.3.0)
 
-!!! danger "Breaking Change: `syncBinlog` type change (Replication clusters)"
-    `syncBinlog` changed from **boolean** to **integer**. This affects
-    **Primary/Replica (replication)** clusters. Galera clusters without
-    `replication` in their spec are not affected.
+!!! danger "Replication config change carried into 26.3.0"
+    In the `25.x` replication line, `syncBinlog` changed from **boolean** to
+    **integer**. This affects **Primary/Replica (replication)** clusters.
+    Galera clusters without `replication` in their spec are not affected.
 
-    If the existing MariaDB CR has `syncBinlog: true`, the new webhook will
-    reject patches. Remove the webhook before patching:
+    If the existing MariaDB CR still stores `syncBinlog: true`, the newer
+    webhook can reject updates during the `25.10.4 -> 26.3.0` hop. Remove the
+    webhook before patching:
 
     ```bash
     kubectl delete validatingwebhookconfiguration mariadb-operator-webhook
@@ -569,13 +572,14 @@ No special steps required beyond the standard preflight and upgrade.
     Then re-run the install script to restore the webhook.
 
 !!! danger "Breaking Change: Image configuration format"
-    Image configuration in Helm values changed from string to structured format:
+    Review the `26.3.0` Helm values schema carefully before upgrading.
+    Several image sections now use structured `repository` + `tag` values.
 
     === "Old Format"
 
         ```yaml
         config:
-          mariadbImageName: repo/image:tag_version
+          mariadbImageName: repo/image
         ```
 
     === "New Format"
@@ -588,7 +592,10 @@ No special steps required beyond the standard preflight and upgrade.
         ```
 
     Ensure `/etc/genestack/helm-configs/mariadb-operator/mariadb-operator-helm-overrides.yaml`
-    uses the new format for `maxscaleImage, exporterImage, exporterMaxscaleImage` image sections before upgrading to 26.3.0.
+    matches the `26.3.0` schema for `maxscaleImage`, `exporterImage`, and
+    `exporterMaxscaleImage` before upgrading. Do not assume that every legacy
+    image-related key disappears; compare the full overrides file against the
+    target chart schema.
 
 !!! info "New CRD"
     A new CRD is added with this version: `pointintimerecoveries.k8s.mariadb.com`

--- a/docs/storage-longhorn.md
+++ b/docs/storage-longhorn.md
@@ -131,9 +131,9 @@ Longhorn upgrades in Genestack should follow the supported staged maintenance ho
 
 Operator runbooks for each hop are available under `maintenances/`:
 
-- `maintenances/maintenance-longhorn-1.8.0-to-1.9.1.md`
-- `maintenances/maintenance-longhorn-1.9.1-to-1.10.2.md`
-- `maintenances/maintenance-longhorn-1.10.2-to-1.11.1.md`
+- `maintenances/maintenance-longhorn-1.8.0-to-1.9.1.txt`
+- `maintenances/maintenance-longhorn-1.9.1-to-1.10.2.txt`
+- `maintenances/maintenance-longhorn-1.10.2-to-1.11.1.txt`
 
 !!! warning
 

--- a/maintenances/maintenance-component-template.txt
+++ b/maintenances/maintenance-component-template.txt
@@ -1,13 +1,13 @@
-### Component Maintenance: <component-name> <from-version> to <to-version>
+Component Maintenance: <component-name> <from-version> to <to-version>
 
-## Notes
+Notes
 
 (opt) refers to /opt, the standard install path for Genestack.
 (etc) refers to /etc, the standard override path for Genestack.
 Replace all placeholder values in angle brackets before using this runbook.
 Keep this runbook operational. Prefer exact commands, exact file paths, expected outputs, and explicit validation steps.
 
-## Validation
+Validation
 
 State the validated source version.
 State the validated target version.
@@ -15,15 +15,15 @@ State the validated Kubernetes version or platform dependency, if relevant.
 State whether the upgrade path is directly supported or if intermediate versions are required.
 State the major operational risks for this maintenance.
 
-## Goal
+Goal
 
 Describe the exact maintenance outcome in one or two lines.
 Example:
 Upgrade <component-name> from <from-version> to <to-version> without service regression and with all workloads returning healthy.
 
-## Prep
+Prep
 
-# Deployment Node
+Deployment Node
 
 Identify the deployment host or bastion that should be used for the maintenance.
 
@@ -52,7 +52,7 @@ Expected:
 
 If backups are required but missing, stop and create them before continuing.
 
-# Configuration Review
+Configuration Review
 
 Identify the configuration files or values that control this component:
     # <path>
@@ -63,7 +63,7 @@ Verify the current config:
 
 If any non-standard override exists, document it in the maintenance log before continuing.
 
-# Pre-Change Safety Checks
+Pre-Change Safety Checks
 
 Check for unhealthy pods, jobs, or dependent services:
     # <command>
@@ -73,9 +73,9 @@ Check for open alerts or known blockers:
 
 If any critical dependency is unhealthy, stop and resolve it first.
 
-## Execute
+Execute
 
-# Update the Target Version
+Update the Target Version
 
 Edit the version source of truth:
     # <path>
@@ -85,7 +85,7 @@ Set:
 
 If this maintenance requires an intermediate version, perform each hop separately and validate after each hop.
 
-# Apply Required Overrides or Patches
+Apply Required Overrides or Patches
 
 Update the required override file:
     # <path>
@@ -95,7 +95,7 @@ Set:
 
 If no overrides are required, explicitly say so in the final runbook.
 
-# Run the Maintenance
+Run the Maintenance
 
 Run a dry-run or blast-radius check if one exists:
     # <command>
@@ -108,7 +108,7 @@ Run the maintenance command:
 
 If the maintenance must be split into stages, list each stage as a separate command block with validation after each stage.
 
-# UI Steps
+UI Steps
 
 If UI actions are required, list them one line at a time.
 <Component UI> -> <Section>
@@ -118,7 +118,7 @@ Save
 
 If no UI steps are required, remove this subsection.
 
-## Post-Maint
+Post-Maint
 
 Verify the deployed version:
     # <command>
@@ -147,15 +147,15 @@ Expected:
 Re-enable anything disabled during prep:
     # <command>
 
-## Troubleshooting
+Troubleshooting
 
-# Common Failure Signal
+Common Failure Signal
 
 Describe the most likely failure indicator.
 Example:
 If the upgrade fails with <specific error>, stop and do not continue to post-maint validation.
 
-# Rollback
+Rollback
 
 List the rollback trigger.
 List the rollback command or procedure:
@@ -164,7 +164,7 @@ List the rollback command or procedure:
 Expected:
     # <expected rollback state>
 
-# Additional Recovery Actions
+Additional Recovery Actions
 
 If pods remain stuck:
     # <command>
@@ -178,7 +178,7 @@ Select <object>
 Set <field> to <value>
 Save
 
-## Sources
+Sources
 
 <raw URL>
 <raw URL>

--- a/maintenances/maintenance-kubespray-kubernetes-1.33.x-to-1.34.3.txt
+++ b/maintenances/maintenance-kubespray-kubernetes-1.33.x-to-1.34.3.txt
@@ -1,15 +1,15 @@
-### Flex Kubespray and Kubernetes Upgrade from 1.33.x to 1.34.3
+Flex Kubespray and Kubernetes Upgrade from 1.33.x to 1.34.3
 
-## Notes
+Notes
 
 (opt) refers to /opt, the standard install path for Genestack.
 (etc) refers to /etc, the standard override path for Genestack.
 The version of Kubernetes and Kubespray is bundled with the specific release of Genestack unless explicitly overridden.
 Kubernetes does not support skipping multiple minor releases in a single upgrade. Step through each minor version.
 
-## Prep
+Prep
 
-# Deployment Node
+Deployment Node
 
 Create a tmux logging directory:
     mkdir -p ~/maintenances
@@ -40,9 +40,9 @@ Disable the self-healing Octavia LB systemd service:
 Raise file descriptor limits in the current shell:
     ulimit -n 65535
 
-## Kubespray
+Kubespray
 
-# Validate Kubespray Version
+Validate Kubespray Version
 
 For Kubernetes 1.34.3, Kubespray v2.30.0 is required.
 
@@ -58,7 +58,7 @@ If Kubespray is not at the desired version:
     git fetch --tags
     git checkout v2.30.0
 
-# Ensure kubeadm Upgrade Task Is Patched
+Ensure kubeadm Upgrade Task Is Patched
 
 This patch must exist so controller upgrades do not block on the CreateJob preflight check:
     # diff --git a/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml b/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml
@@ -80,7 +80,7 @@ If the change is missing, edit this file:
 Add this line:
     # --ignore-preflight-errors=CreateJob
 
-# Validate Inventory and Node Reachability
+Validate Inventory and Node Reachability
 
 Confirm all inventory nodes are reachable:
     ansible -m ping all
@@ -98,7 +98,7 @@ Example cleanup flow for a dead node:
     # kubectl get pods -A -o wide | grep <node-name>
     # kubectl delete pod <pod_name> -n <namespace> --force --grace-period=0
 
-# Refresh Ansible Facts
+Refresh Ansible Facts
 
 Refresh Ansible facts:
     cd /opt/genestack/submodules/kubespray
@@ -108,9 +108,9 @@ If fact regeneration fails and stale facts need cleanup:
     cd /tmp
     # rm -f <fact-cache-pattern>
 
-## Kubernetes
+Kubernetes
 
-# Determine the Target Kubernetes Version
+Determine the Target Kubernetes Version
 
 The bundled version can be found in:
     /opt/genestack/ansible/inventory/genestack/group_vars/k8s_cluster/k8s_cluster.yaml
@@ -123,7 +123,7 @@ If you must override it, edit:
 Set:
     kube_version: 1.34.3
 
-# Upgrade the Control Plane and etcd Nodes First
+Upgrade the Control Plane and etcd Nodes First
 
 Run the control plane and etcd upgrade:
     cd /opt/genestack/submodules/kubespray
@@ -134,7 +134,7 @@ Run the control plane and etcd upgrade:
 Expected:
     # Control-plane and etcd nodes report Kubernetes version 1.34.3
 
-# Upgrade OpenStack Worker and Network Nodes
+Upgrade OpenStack Worker and Network Nodes
 
 Run the worker and network node upgrade:
     ansible-playbook cluster.yml -e upgrade_cluster_setup=true -e kube_version=1.34.3 --become --limit "openstack_control_plane:ovn_network_nodes" --list-hosts
@@ -144,7 +144,7 @@ Run the worker and network node upgrade:
 Expected:
     # OpenStack worker and network nodes report Kubernetes version 1.34.3
 
-# Upgrade Compute Nodes
+Upgrade Compute Nodes
 
 Run the compute node upgrade:
     ansible-playbook cluster.yml -e upgrade_cluster_setup=true -e kube_version=1.34.3 --become --limit "flex_compute_nodes" --list-hosts
@@ -154,7 +154,7 @@ Run the compute node upgrade:
 Expected:
     # Compute nodes report Kubernetes version 1.34.3
 
-# Upgrade Block Nodes
+Upgrade Block Nodes
 
 Run the block node upgrade:
     ansible-playbook cluster.yml -e upgrade_cluster_setup=true -e kube_version=1.34.3 --become --limit "storage_nodes" --list-hosts
@@ -164,12 +164,12 @@ Run the block node upgrade:
 Expected:
     # Block nodes report Kubernetes version 1.34.3
 
-# Install a Matching kubectl
+Install a Matching kubectl
 
 Install the matching kubectl version:
     /opt/genestack/scripts/install_kubectl.sh
 
-## Post-Maint
+Post-Maint
 
 Re-enable HPA:
     cd ~/maintenances
@@ -193,15 +193,15 @@ Create an instance.
 Create a volume.
 Create a container.
 
-## Troubleshooting
+Troubleshooting
 
-# Manual kubeadm Upgrade on the First Controller
+Manual kubeadm Upgrade on the First Controller
 
 If the health check fails during upgrade, manually upgrade the first controller:
     sudo /usr/local/bin/kubeadm upgrade apply -y 1.34.3 --config=/etc/kubernetes/kubeadm-config.yaml --ignore-preflight-errors=CreateJob
     sudo /usr/local/bin/kubeadm upgrade node
 
-# Re-Apply the kubeadm Upgrade Task Patch
+Re-Apply the kubeadm Upgrade Task Patch
 
 If the prior workaround still fails, re-check this patch:
     # diff --git a/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml b/roles/kubernetes/control-plane/tasks/kubeadm-upgrade.yml

--- a/maintenances/maintenance-longhorn-1.10.2-to-1.11.1.txt
+++ b/maintenances/maintenance-longhorn-1.10.2-to-1.11.1.txt
@@ -1,45 +1,31 @@
-### Longhorn Maintenance: 1.8.0 to 1.9.1
+Longhorn Maintenance: 1.10.2 to 1.11.1
 
-## Validation
+Validation
 
-Kubernetes 1.33.4 satisfies the upstream Longhorn requirement of Kubernetes v1.25+ for upgrades to Longhorn v1.8.0 or newer.
-Upstream explicitly supports upgrading Longhorn v1.9.1 from v1.8.x.
-Upstream node-selector guidance for v1.9.1 confirms that both user-deployed components and system-managed components must be constrained, and warns that instance-manager changes may not apply immediately while volumes remain attached.
+Kubernetes 1.33.4 satisfies the published Longhorn minimum of Kubernetes v1.25+.
+Upstream explicitly supports upgrading Longhorn v1.11.1 from v1.10.x.
+The latest stable 1.11.x release is 1.11.1.
+Upstream recommends manual checks before upgrade. Ensure no important volume is faulted, avoid failed BackingImage objects, and create a Longhorn system backup first.
 
-## Goal
+Goal
 
-Upgrade Genestack Longhorn from 1.8.0 to 1.9.1 while ensuring Longhorn pods and replicas only run on nodes labeled longhorn.io/storage-node=enabled.
+Upgrade Longhorn from 1.10.2 to 1.11.1 while preserving the storage-node placement restrictions already introduced in earlier maintenance.
 
-## Prep
+Prep
 
-# Deployment Node
+Deployment Node
 
-Verify Kubernetes and current Longhorn state:
+Confirm current health:
     kubectl version
     kubectl -n longhorn-system get pods -o wide
-    kubectl -n longhorn-system get nodes.longhorn.io
+    kubectl -n longhorn-system get volumes.longhorn.io -o custom-columns=VOLUME:.metadata.name,STATE:.status.state,ROBUSTNESS:.status.robustness
+    kubectl -n longhorn-system get backingimages.longhorn.io
+
+Confirm selector settings are still correct:
+    kubectl get nodes -L longhorn.io/storage-node
     kubectl -n longhorn-system get settings.longhorn.io system-managed-components-node-selector -o yaml
 
-Inventory current node labels and current Longhorn placement:
-    kubectl get nodes -L longhorn.io/storage-node,openstack-compute-node,openstack-storage-node
-    kubectl get pv -o custom-columns=PV:.metadata.name,CLAIM_NS:.spec.claimRef.namespace,CLAIM:.spec.claimRef.name,SC:.spec.storageClassName,VOLUME:.spec.csi.volumeHandle
-    kubectl -n longhorn-system get replicas.longhorn.io -o custom-columns=REPLICA:.metadata.name,VOLUME:.spec.volumeName,NODE:.spec.nodeID,STATE:.status.currentState
-
-Confirm volumes are healthy before maintenance:
-    kubectl -n longhorn-system get volumes.longhorn.io -o custom-columns=VOLUME:.metadata.name,STATE:.status.state,ROBUSTNESS:.status.robustness,OWNER:.status.ownerID
-
-If any important volume is faulted, stop and resolve that first.
-
-# Select Storage Nodes
-
-Apply the Longhorn storage label only to nodes that are allowed to host Longhorn pods and volume replicas:
-    # kubectl label node <node-a> longhorn.io/storage-node=enabled --overwrite
-    # kubectl label node <node-b> longhorn.io/storage-node=enabled --overwrite
-
-Verify:
-    kubectl get nodes -L longhorn.io/storage-node
-
-# Prevent Longhorn from Using Unlabeled Nodes
+Prevent Longhorn from Using Unlabeled Nodes
 
 Disable Longhorn scheduling on any node that does not have longhorn.io/storage-node=enabled:
     for node in $(kubectl get nodes -l 'longhorn.io/storage-node!=enabled' -o name | sed 's|node/||'); do
@@ -59,23 +45,25 @@ Set Scheduling to Disable
 Set Eviction Requested to Enable
 Save
 
-Watch replica movement until no replicas remain on disallowed nodes:
-    kubectl -n longhorn-system get replicas.longhorn.io -o custom-columns=REPLICA:.metadata.name,VOLUME:.spec.volumeName,NODE:.spec.nodeID,STATE:.status.currentState --watch
-
 After replicas are gone, remove the Longhorn node CR for any node that should remain in Kubernetes but should no longer remain in Longhorn:
     for node in $(kubectl get nodes -l 'longhorn.io/storage-node!=enabled' -o name | sed 's|node/||'); do
       kubectl -n longhorn-system delete nodes.longhorn.io "$node"
     done
 
-If you need to confirm or repair a node manually, use the Longhorn UI.
-Longhorn UI -> Node
-Select the node
-Confirm no replicas remain
-Delete
+Optional but recommended. Create a Longhorn system backup before the hop.
+Longhorn UI -> System Backup
+Create
+Wait for backup completion before upgrading
 
-# Update Longhorn Overrides
+Execute
 
-Create or update /etc/genestack/helm-configs/longhorn/longhorn.yaml with:
+Bump the Chart Version
+
+Edit /etc/genestack/helm-chart-versions.yaml:
+    charts:
+      longhorn: 1.11.1
+
+Retain the node-selector override file:
     ---
     global:
       nodeSelector:
@@ -111,35 +99,26 @@ Create or update /etc/genestack/helm-configs/longhorn/longhorn.yaml with:
     #   nodeSelector:
     #     longhorn.io/storage-node: "enabled"
 
-# Bump the Chart Version
-
-Edit /etc/genestack/helm-chart-versions.yaml:
-    charts:
-      longhorn: 1.9.1
-
-## Execute
+Execute the Upgrade
 
 Run the upgrade:
     /opt/genestack/bin/install-longhorn.sh
 
-## Post-Maint
+Post-Maint
 
-Confirm pods are running only on allowed nodes:
+Confirm all Longhorn pods are healthy and scheduled only on labeled nodes:
     kubectl -n longhorn-system get pods -o wide --sort-by=.spec.nodeName
 
-Confirm the setting was applied:
+Confirm Longhorn settings survived the hop:
     kubectl -n longhorn-system get settings.longhorn.io system-managed-components-node-selector -o yaml
 
-Expected:
-    # value: longhorn.io/storage-node:enabled
-
-Confirm Longhorn nodes not intended for storage are unschedulable or absent:
-    kubectl -n longhorn-system get nodes.longhorn.io -o yaml | egrep 'name:|allowScheduling:'
-
-Confirm volumes remain healthy:
+Confirm all volumes remain healthy:
     kubectl -n longhorn-system get volumes.longhorn.io -o custom-columns=VOLUME:.metadata.name,STATE:.status.state,ROBUSTNESS:.status.robustness
 
-Check for attached volumes still running through an old instance-manager image:
+Confirm no failed pre-upgrade checks were recorded:
+    kubectl -n longhorn-system get events --sort-by=.lastTimestamp | tail -n 40
+
+Check for attached volumes still running through an out-of-date instance-manager image:
     VERSION_FILE=/etc/genestack/helm-chart-versions.yaml /opt/genestack/scripts/longhorn-old-instance-managers.sh
 
 Filter the report to a single workload family while keeping the header row:
@@ -147,7 +126,7 @@ Filter the report to a single workload family while keeping the header row:
 
 If the script returns rows, the volume engine is already upgraded but the workload is still attached through an older instance-manager pod. These old instance-manager pods are not removed until the workload pod is restarted or otherwise detached from the volume.
 
-# Workload Restart Patterns After 1.8.0 to 1.9.1
+Workload Restart Patterns After 1.10.2 to 1.11.1
 
 This cleanup is optional and is not required for a successful Longhorn upgrade. It is expected Longhorn behavior for older instance-manager pods to remain while attached workloads continue using them. These old instance-manager pods will be removed naturally as the associated volumes are recreated, detached, or reattached over time.
 
@@ -308,25 +287,9 @@ Suggested restart order by risk:
     3. Operator managed clustered data services one replica at a time after confirming quorum and replication health.
     4. Primaries, leaders, or shared-volume consumers that require tighter coordination.
 
-## Troubleshooting
+Troubleshooting
 
-# If System-Managed Pods Stay on the Wrong Nodes
-
-System-managed node-selector changes may not apply immediately while volumes are attached.
-
-If needed, detach remaining volumes or stop workloads that keep them attached.
-
-Re-save the System Managed Components Node Selector setting in the Longhorn UI.
-Longhorn UI -> Setting
-General
-System Managed Components Node Selector
-Set to longhorn.io/storage-node:enabled
-Save
-
-Re-check pod placement:
-    kubectl -n longhorn-system get pods -o wide --sort-by=.spec.nodeName
-
-# If Old Instance-Managers Remain After the Upgrade
+If Old Instance-Managers Remain After the Upgrade
 
 Do not delete old instance-manager pods directly while attached workloads are still using them.
 
@@ -344,11 +307,8 @@ Examples:
     kubectl -n prometheus delete pod prometheus-kube-prometheus-stack-prometheus-0
     VERSION_FILE=/etc/genestack/helm-chart-versions.yaml /opt/genestack/scripts/longhorn-old-instance-managers.sh --search rabbitmq
 
-For operator managed clustered services such as RabbitMQ or PostgreSQL, restart only one member at a time and verify cluster health between restarts.
+Sources
 
-## Sources
-
-https://longhorn.io/docs/1.9.1/deploy/upgrade/longhorn-manager/
-https://longhorn.io/docs/1.9.1/advanced-resources/deploy/node-selector/
-https://longhorn.io/docs/1.9.1/references/settings/
+https://longhorn.io/docs/1.11.1/deploy/upgrade/longhorn-manager/
 https://longhorn.io/docs/1.11.1/important-notes/
+https://github.com/longhorn/longhorn

--- a/maintenances/maintenance-longhorn-1.8.0-to-1.9.1.txt
+++ b/maintenances/maintenance-longhorn-1.8.0-to-1.9.1.txt
@@ -1,30 +1,45 @@
-### Longhorn Maintenance: 1.9.1 to 1.10.2
+Longhorn Maintenance: 1.8.0 to 1.9.1
 
-## Validation
+Validation
 
-Kubernetes 1.33.4 satisfies the published Longhorn minimum of Kubernetes v1.25+.
-Upstream explicitly supports upgrading Longhorn v1.10.1 from v1.9.x. 1.10.2 is the latest stable 1.10.x patch.
-This is the highest-risk hop because Longhorn v1.10 removes the longhorn.io/v1beta1 API and the deprecated replica.status.evictionRequested field.
-Upstream documents a mandatory CRD stored-version migration and verification step before the 1.10 upgrade, and there is a real 1.33.4 field report showing upgrade failure when v1beta1 remained in CRD stored versions.
+Kubernetes 1.33.4 satisfies the upstream Longhorn requirement of Kubernetes v1.25+ for upgrades to Longhorn v1.8.0 or newer.
+Upstream explicitly supports upgrading Longhorn v1.9.1 from v1.8.x.
+Upstream node-selector guidance for v1.9.1 confirms that both user-deployed components and system-managed components must be constrained, and warns that instance-manager changes may not apply immediately while volumes remain attached.
 
-## Goal
+Goal
 
-Upgrade Longhorn from 1.9.1 to 1.10.2 only after confirming CRDs no longer store v1beta1 data.
+Upgrade Genestack Longhorn from 1.8.0 to 1.9.1 while ensuring Longhorn pods and replicas only run on nodes labeled longhorn.io/storage-node=enabled.
 
-## Prep
+Prep
 
-# Deployment Node
+Deployment Node
 
-Confirm current version and cluster health:
+Verify Kubernetes and current Longhorn state:
     kubectl version
     kubectl -n longhorn-system get pods -o wide
-    kubectl -n longhorn-system get volumes.longhorn.io -o custom-columns=VOLUME:.metadata.name,STATE:.status.state,ROBUSTNESS:.status.robustness
-
-Confirm node-selector settings still restrict Longhorn to storage nodes:
-    kubectl get nodes -L longhorn.io/storage-node
+    kubectl -n longhorn-system get nodes.longhorn.io
     kubectl -n longhorn-system get settings.longhorn.io system-managed-components-node-selector -o yaml
 
-# Prevent Longhorn from Using Unlabeled Nodes
+Inventory current node labels and current Longhorn placement:
+    kubectl get nodes -L longhorn.io/storage-node,openstack-compute-node,openstack-storage-node
+    kubectl get pv -o custom-columns=PV:.metadata.name,CLAIM_NS:.spec.claimRef.namespace,CLAIM:.spec.claimRef.name,SC:.spec.storageClassName,VOLUME:.spec.csi.volumeHandle
+    kubectl -n longhorn-system get replicas.longhorn.io -o custom-columns=REPLICA:.metadata.name,VOLUME:.spec.volumeName,NODE:.spec.nodeID,STATE:.status.currentState
+
+Confirm volumes are healthy before maintenance:
+    kubectl -n longhorn-system get volumes.longhorn.io -o custom-columns=VOLUME:.metadata.name,STATE:.status.state,ROBUSTNESS:.status.robustness,OWNER:.status.ownerID
+
+If any important volume is faulted, stop and resolve that first.
+
+Select Storage Nodes
+
+Apply the Longhorn storage label only to nodes that are allowed to host Longhorn pods and volume replicas:
+    # kubectl label node <node-a> longhorn.io/storage-node=enabled --overwrite
+    # kubectl label node <node-b> longhorn.io/storage-node=enabled --overwrite
+
+Verify:
+    kubectl get nodes -L longhorn.io/storage-node
+
+Prevent Longhorn from Using Unlabeled Nodes
 
 Disable Longhorn scheduling on any node that does not have longhorn.io/storage-node=enabled:
     for node in $(kubectl get nodes -l 'longhorn.io/storage-node!=enabled' -o name | sed 's|node/||'); do
@@ -44,47 +59,23 @@ Set Scheduling to Disable
 Set Eviction Requested to Enable
 Save
 
+Watch replica movement until no replicas remain on disallowed nodes:
+    kubectl -n longhorn-system get replicas.longhorn.io -o custom-columns=REPLICA:.metadata.name,VOLUME:.spec.volumeName,NODE:.spec.nodeID,STATE:.status.currentState --watch
+
 After replicas are gone, remove the Longhorn node CR for any node that should remain in Kubernetes but should no longer remain in Longhorn:
     for node in $(kubectl get nodes -l 'longhorn.io/storage-node!=enabled' -o name | sed 's|node/||'); do
       kubectl -n longhorn-system delete nodes.longhorn.io "$node"
     done
 
-Verify CRD stored versions before the upgrade:
-    kubectl get crd -l app.kubernetes.io/name=longhorn -o=jsonpath='{range .items[*]}{.metadata.name}{": "}{.status.storedVersions}{"\n"}{end}'
+If you need to confirm or repair a node manually, use the Longhorn UI.
+Longhorn UI -> Node
+Select the node
+Confirm no replicas remain
+Delete
 
-If every Longhorn CRD already shows only ["v1beta2"], skip the migration section and continue.
+Update Longhorn Overrides
 
-## Execute
-
-# Required CRD Migration for the 1.10 Upgrade
-
-Run the upstream migration procedure before the upgrade:
-    kubectl patch validatingwebhookconfiguration longhorn-webhook-validator --type=merge -p "$(kubectl get validatingwebhookconfiguration longhorn-webhook-validator -o json | jq '.webhooks[0].rules |= map(if .apiGroups == ["longhorn.io"] and .resources == ["settings"] then .operations |= map(select(. != "UPDATE")) else . end)')"
-    migration_time="$(date +%Y-%m-%dT%H:%M:%S)"
-    crds=($(kubectl get crd -l app.kubernetes.io/name=longhorn -o json | jq -r '.items[] | select(.status.storedVersions | index("v1beta1")) | .metadata.name'))
-    for crd in "${crds[@]}"; do
-      echo "Migrating ${crd} ..."
-      for name in $(kubectl -n longhorn-system get "$crd" -o jsonpath='{.items[*].metadata.name}'); do
-        kubectl patch "${crd}" "${name}" -n longhorn-system --type=merge -p='{"metadata":{"annotations":{"migration-time":"'"${migration_time}"'"}}}'
-      done
-      kubectl patch crd "${crd}" --subresource=status --type=merge -p '{"status":{"storedVersions":["v1beta2"]}}'
-    done
-
-Verify migration success:
-    kubectl get crd -l app.kubernetes.io/name=longhorn -o=jsonpath='{range .items[*]}{.metadata.name}{": "}{.status.storedVersions}{"\n"}{end}'
-
-Expected:
-    # Every Longhorn CRD shows only ["v1beta2"]
-
-Do not proceed until every Longhorn CRD shows only ["v1beta2"].
-
-# Bump the Chart Version
-
-Edit /etc/genestack/helm-chart-versions.yaml:
-    charts:
-      longhorn: 1.10.2
-
-Keep the same node-selector override file in /etc/genestack/helm-configs/longhorn/longhorn.yaml:
+Create or update /etc/genestack/helm-configs/longhorn/longhorn.yaml with:
     ---
     global:
       nodeSelector:
@@ -120,29 +111,35 @@ Keep the same node-selector override file in /etc/genestack/helm-configs/longhor
     #   nodeSelector:
     #     longhorn.io/storage-node: "enabled"
 
-# Execute the Upgrade
+Bump the Chart Version
+
+Edit /etc/genestack/helm-chart-versions.yaml:
+    charts:
+      longhorn: 1.9.1
+
+Execute
 
 Run the upgrade:
     /opt/genestack/bin/install-longhorn.sh
 
-## Post-Maint
+Post-Maint
 
-Confirm the pre-upgrade check did not fail:
-    kubectl -n longhorn-system get events --sort-by=.lastTimestamp | tail -n 40
-
-Confirm all Longhorn pods are running:
+Confirm pods are running only on allowed nodes:
     kubectl -n longhorn-system get pods -o wide --sort-by=.spec.nodeName
 
-Confirm CRDs still show only v1beta2:
-    kubectl get crd -l app.kubernetes.io/name=longhorn -o=jsonpath='{range .items[*]}{.metadata.name}{": "}{.status.storedVersions}{"\n"}{end}'
+Confirm the setting was applied:
+    kubectl -n longhorn-system get settings.longhorn.io system-managed-components-node-selector -o yaml
 
 Expected:
-    # Every Longhorn CRD shows only ["v1beta2"]
+    # value: longhorn.io/storage-node:enabled
 
-Confirm volumes are healthy:
+Confirm Longhorn nodes not intended for storage are unschedulable or absent:
+    kubectl -n longhorn-system get nodes.longhorn.io -o yaml | egrep 'name:|allowScheduling:'
+
+Confirm volumes remain healthy:
     kubectl -n longhorn-system get volumes.longhorn.io -o custom-columns=VOLUME:.metadata.name,STATE:.status.state,ROBUSTNESS:.status.robustness
 
-Check for attached volumes still running through an out-of-date instance-manager image:
+Check for attached volumes still running through an old instance-manager image:
     VERSION_FILE=/etc/genestack/helm-chart-versions.yaml /opt/genestack/scripts/longhorn-old-instance-managers.sh
 
 Filter the report to a single workload family while keeping the header row:
@@ -150,7 +147,7 @@ Filter the report to a single workload family while keeping the header row:
 
 If the script returns rows, the volume engine is already upgraded but the workload is still attached through an older instance-manager pod. These old instance-manager pods are not removed until the workload pod is restarted or otherwise detached from the volume.
 
-# Workload Restart Patterns After 1.9.1 to 1.10.2
+Workload Restart Patterns After 1.8.0 to 1.9.1
 
 This cleanup is optional and is not required for a successful Longhorn upgrade. It is expected Longhorn behavior for older instance-manager pods to remain while attached workloads continue using them. These old instance-manager pods will be removed naturally as the associated volumes are recreated, detached, or reattached over time.
 
@@ -311,21 +308,29 @@ Suggested restart order by risk:
     3. Operator managed clustered data services one replica at a time after confirming quorum and replication health.
     4. Primaries, leaders, or shared-volume consumers that require tighter coordination.
 
-## Troubleshooting
+Troubleshooting
 
-# Rollback Signal
+If System-Managed Pods Stay on the Wrong Nodes
 
-If the upgrade fails with an error mentioning status.storedVersions[0]: Invalid value: "v1beta1", stop and roll back. That indicates the CRD migration was incomplete.
+System-managed node-selector changes may not apply immediately while volumes are attached.
 
-Helm rollback pattern:
-    helm history longhorn -n longhorn-system
-    # helm rollback longhorn <REVISION> -n longhorn-system
+If needed, detach remaining volumes or stop workloads that keep them attached.
 
-# If Old Instance-Managers Remain After the Upgrade
+Re-save the System Managed Components Node Selector setting in the Longhorn UI.
+Longhorn UI -> Setting
+General
+System Managed Components Node Selector
+Set to longhorn.io/storage-node:enabled
+Save
 
-Longhorn may keep an older instance-manager pod alive until each attached workload pod is restarted and its volume is detached and reattached through the new instance-manager image.
+Re-check pod placement:
+    kubectl -n longhorn-system get pods -o wide --sort-by=.spec.nodeName
 
-Safe workflow:
+If Old Instance-Managers Remain After the Upgrade
+
+Do not delete old instance-manager pods directly while attached workloads are still using them.
+
+Instead:
     1. Run VERSION_FILE=/etc/genestack/helm-chart-versions.yaml /opt/genestack/scripts/longhorn-old-instance-managers.sh
     2. Group results by workload type and controller.
     3. Use --search <workload-name> to focus on one workload family while keeping the header row.
@@ -339,9 +344,11 @@ Examples:
     kubectl -n prometheus delete pod prometheus-kube-prometheus-stack-prometheus-0
     VERSION_FILE=/etc/genestack/helm-chart-versions.yaml /opt/genestack/scripts/longhorn-old-instance-managers.sh --search rabbitmq
 
-## Sources
+For operator managed clustered services such as RabbitMQ or PostgreSQL, restart only one member at a time and verify cluster health between restarts.
 
-https://longhorn.io/docs/1.10.1/deploy/upgrade/longhorn-manager/
-https://longhorn.io/docs/1.10.0/important-notes/
+Sources
+
+https://longhorn.io/docs/1.9.1/deploy/upgrade/longhorn-manager/
+https://longhorn.io/docs/1.9.1/advanced-resources/deploy/node-selector/
+https://longhorn.io/docs/1.9.1/references/settings/
 https://longhorn.io/docs/1.11.1/important-notes/
-https://github.com/longhorn/longhorn/issues/11886

--- a/maintenances/maintenance-longhorn-1.9.1-to-1.10.2.txt
+++ b/maintenances/maintenance-longhorn-1.9.1-to-1.10.2.txt
@@ -1,31 +1,30 @@
-### Longhorn Maintenance: 1.10.2 to 1.11.1
+Longhorn Maintenance: 1.9.1 to 1.10.2
 
-## Validation
+Validation
 
 Kubernetes 1.33.4 satisfies the published Longhorn minimum of Kubernetes v1.25+.
-Upstream explicitly supports upgrading Longhorn v1.11.1 from v1.10.x.
-The latest stable 1.11.x release is 1.11.1.
-Upstream recommends manual checks before upgrade. Ensure no important volume is faulted, avoid failed BackingImage objects, and create a Longhorn system backup first.
+Upstream explicitly supports upgrading Longhorn v1.10.1 from v1.9.x. 1.10.2 is the latest stable 1.10.x patch.
+This is the highest-risk hop because Longhorn v1.10 removes the longhorn.io/v1beta1 API and the deprecated replica.status.evictionRequested field.
+Upstream documents a mandatory CRD stored-version migration and verification step before the 1.10 upgrade, and there is a real 1.33.4 field report showing upgrade failure when v1beta1 remained in CRD stored versions.
 
-## Goal
+Goal
 
-Upgrade Longhorn from 1.10.2 to 1.11.1 while preserving the storage-node placement restrictions already introduced in earlier maintenance.
+Upgrade Longhorn from 1.9.1 to 1.10.2 only after confirming CRDs no longer store v1beta1 data.
 
-## Prep
+Prep
 
-# Deployment Node
+Deployment Node
 
-Confirm current health:
+Confirm current version and cluster health:
     kubectl version
     kubectl -n longhorn-system get pods -o wide
     kubectl -n longhorn-system get volumes.longhorn.io -o custom-columns=VOLUME:.metadata.name,STATE:.status.state,ROBUSTNESS:.status.robustness
-    kubectl -n longhorn-system get backingimages.longhorn.io
 
-Confirm selector settings are still correct:
+Confirm node-selector settings still restrict Longhorn to storage nodes:
     kubectl get nodes -L longhorn.io/storage-node
     kubectl -n longhorn-system get settings.longhorn.io system-managed-components-node-selector -o yaml
 
-# Prevent Longhorn from Using Unlabeled Nodes
+Prevent Longhorn from Using Unlabeled Nodes
 
 Disable Longhorn scheduling on any node that does not have longhorn.io/storage-node=enabled:
     for node in $(kubectl get nodes -l 'longhorn.io/storage-node!=enabled' -o name | sed 's|node/||'); do
@@ -50,20 +49,42 @@ After replicas are gone, remove the Longhorn node CR for any node that should re
       kubectl -n longhorn-system delete nodes.longhorn.io "$node"
     done
 
-Optional but recommended. Create a Longhorn system backup before the hop.
-Longhorn UI -> System Backup
-Create
-Wait for backup completion before upgrading
+Verify CRD stored versions before the upgrade:
+    kubectl get crd -l app.kubernetes.io/name=longhorn -o=jsonpath='{range .items[*]}{.metadata.name}{": "}{.status.storedVersions}{"\n"}{end}'
 
-## Execute
+If every Longhorn CRD already shows only ["v1beta2"], skip the migration section and continue.
 
-# Bump the Chart Version
+Execute
+
+Required CRD Migration for the 1.10 Upgrade
+
+Run the upstream migration procedure before the upgrade:
+    kubectl patch validatingwebhookconfiguration longhorn-webhook-validator --type=merge -p "$(kubectl get validatingwebhookconfiguration longhorn-webhook-validator -o json | jq '.webhooks[0].rules |= map(if .apiGroups == ["longhorn.io"] and .resources == ["settings"] then .operations |= map(select(. != "UPDATE")) else . end)')"
+    migration_time="$(date +%Y-%m-%dT%H:%M:%S)"
+    crds=($(kubectl get crd -l app.kubernetes.io/name=longhorn -o json | jq -r '.items[] | select(.status.storedVersions | index("v1beta1")) | .metadata.name'))
+    for crd in "${crds[@]}"; do
+      echo "Migrating ${crd} ..."
+      for name in $(kubectl -n longhorn-system get "$crd" -o jsonpath='{.items[*].metadata.name}'); do
+        kubectl patch "${crd}" "${name}" -n longhorn-system --type=merge -p='{"metadata":{"annotations":{"migration-time":"'"${migration_time}"'"}}}'
+      done
+      kubectl patch crd "${crd}" --subresource=status --type=merge -p '{"status":{"storedVersions":["v1beta2"]}}'
+    done
+
+Verify migration success:
+    kubectl get crd -l app.kubernetes.io/name=longhorn -o=jsonpath='{range .items[*]}{.metadata.name}{": "}{.status.storedVersions}{"\n"}{end}'
+
+Expected:
+    # Every Longhorn CRD shows only ["v1beta2"]
+
+Do not proceed until every Longhorn CRD shows only ["v1beta2"].
+
+Bump the Chart Version
 
 Edit /etc/genestack/helm-chart-versions.yaml:
     charts:
-      longhorn: 1.11.1
+      longhorn: 1.10.2
 
-Retain the node-selector override file:
+Keep the same node-selector override file in /etc/genestack/helm-configs/longhorn/longhorn.yaml:
     ---
     global:
       nodeSelector:
@@ -99,24 +120,27 @@ Retain the node-selector override file:
     #   nodeSelector:
     #     longhorn.io/storage-node: "enabled"
 
-# Execute the Upgrade
+Execute the Upgrade
 
 Run the upgrade:
     /opt/genestack/bin/install-longhorn.sh
 
-## Post-Maint
+Post-Maint
 
-Confirm all Longhorn pods are healthy and scheduled only on labeled nodes:
+Confirm the pre-upgrade check did not fail:
+    kubectl -n longhorn-system get events --sort-by=.lastTimestamp | tail -n 40
+
+Confirm all Longhorn pods are running:
     kubectl -n longhorn-system get pods -o wide --sort-by=.spec.nodeName
 
-Confirm Longhorn settings survived the hop:
-    kubectl -n longhorn-system get settings.longhorn.io system-managed-components-node-selector -o yaml
+Confirm CRDs still show only v1beta2:
+    kubectl get crd -l app.kubernetes.io/name=longhorn -o=jsonpath='{range .items[*]}{.metadata.name}{": "}{.status.storedVersions}{"\n"}{end}'
 
-Confirm all volumes remain healthy:
+Expected:
+    # Every Longhorn CRD shows only ["v1beta2"]
+
+Confirm volumes are healthy:
     kubectl -n longhorn-system get volumes.longhorn.io -o custom-columns=VOLUME:.metadata.name,STATE:.status.state,ROBUSTNESS:.status.robustness
-
-Confirm no failed pre-upgrade checks were recorded:
-    kubectl -n longhorn-system get events --sort-by=.lastTimestamp | tail -n 40
 
 Check for attached volumes still running through an out-of-date instance-manager image:
     VERSION_FILE=/etc/genestack/helm-chart-versions.yaml /opt/genestack/scripts/longhorn-old-instance-managers.sh
@@ -126,7 +150,7 @@ Filter the report to a single workload family while keeping the header row:
 
 If the script returns rows, the volume engine is already upgraded but the workload is still attached through an older instance-manager pod. These old instance-manager pods are not removed until the workload pod is restarted or otherwise detached from the volume.
 
-# Workload Restart Patterns After 1.10.2 to 1.11.1
+Workload Restart Patterns After 1.9.1 to 1.10.2
 
 This cleanup is optional and is not required for a successful Longhorn upgrade. It is expected Longhorn behavior for older instance-manager pods to remain while attached workloads continue using them. These old instance-manager pods will be removed naturally as the associated volumes are recreated, detached, or reattached over time.
 
@@ -287,13 +311,21 @@ Suggested restart order by risk:
     3. Operator managed clustered data services one replica at a time after confirming quorum and replication health.
     4. Primaries, leaders, or shared-volume consumers that require tighter coordination.
 
-## Troubleshooting
+Troubleshooting
 
-# If Old Instance-Managers Remain After the Upgrade
+Rollback Signal
 
-Do not delete old instance-manager pods directly while attached workloads are still using them.
+If the upgrade fails with an error mentioning status.storedVersions[0]: Invalid value: "v1beta1", stop and roll back. That indicates the CRD migration was incomplete.
 
-Instead:
+Helm rollback pattern:
+    helm history longhorn -n longhorn-system
+    # helm rollback longhorn <REVISION> -n longhorn-system
+
+If Old Instance-Managers Remain After the Upgrade
+
+Longhorn may keep an older instance-manager pod alive until each attached workload pod is restarted and its volume is detached and reattached through the new instance-manager image.
+
+Safe workflow:
     1. Run VERSION_FILE=/etc/genestack/helm-chart-versions.yaml /opt/genestack/scripts/longhorn-old-instance-managers.sh
     2. Group results by workload type and controller.
     3. Use --search <workload-name> to focus on one workload family while keeping the header row.
@@ -307,8 +339,9 @@ Examples:
     kubectl -n prometheus delete pod prometheus-kube-prometheus-stack-prometheus-0
     VERSION_FILE=/etc/genestack/helm-chart-versions.yaml /opt/genestack/scripts/longhorn-old-instance-managers.sh --search rabbitmq
 
-## Sources
+Sources
 
-https://longhorn.io/docs/1.11.1/deploy/upgrade/longhorn-manager/
+https://longhorn.io/docs/1.10.1/deploy/upgrade/longhorn-manager/
+https://longhorn.io/docs/1.10.0/important-notes/
 https://longhorn.io/docs/1.11.1/important-notes/
-https://github.com/longhorn/longhorn
+https://github.com/longhorn/longhorn/issues/11886

--- a/maintenances/maintenance-mariadb-operator-galera-0.36.0-to-0.37.1.txt
+++ b/maintenances/maintenance-mariadb-operator-galera-0.36.0-to-0.37.1.txt
@@ -1,0 +1,142 @@
+MariaDB Operator Galera Maintenance: 0.36.0 to 0.37.1
+
+Validation
+
+This maintenance upgrades the MariaDB Operator for a Galera-backed MariaDB cluster from 0.36.0 to 0.37.1.
+Skip 0.37.0 and upgrade directly to 0.37.1.
+Never delete MariaDB CRDs during this maintenance. Deleting the CRDs will delete the MariaDB pods.
+
+Major operational risks:
+- Deleting MariaDB CRDs will remove the MariaDB pods.
+- Updating the primary before replicas risks losing Galera quorum.
+
+Goal
+
+Upgrade the MariaDB Operator from 0.36.0 to 0.37.1 for a Galera cluster and return the cluster to a healthy Primary state.
+
+Prep
+
+Deployment Node
+
+Run this maintenance from the Genestack deployment host.
+
+Verify current installed versions:
+
+helm list -A | grep mariadb
+helm status mariadb-operator -n mariadb-system
+helm status mariadb-operator-crds -n mariadb-system
+helm repo update mariadb-operator
+helm search repo mariadb-operator/mariadb-operator --versions | head -20
+
+Expected:
+- The current version is 0.36.0.
+- The target version 0.37.1 is available.
+
+Retrieve the MariaDB root password and current primary:
+
+export MARIADB_ROOT_PASSWORD=$(kubectl get secret mariadb -n openstack \
+  -o jsonpath='{.data.root-password}' | base64 -d)
+export PRIMARY_POD=$(kubectl get mariadb mariadb-cluster -n openstack -o jsonpath="{.status.currentPrimary}")
+
+Confirm this cluster is Galera:
+
+kubectl get mariadb mariadb-cluster -n openstack -o jsonpath="{.spec.galera.enabled}"
+
+Expected:
+- The command returns true.
+
+Create and verify a backup:
+
+kubectl exec -i "$PRIMARY_POD" -n openstack -- mariadb-dump \
+  -u root -p"$MARIADB_ROOT_PASSWORD" --all-databases --single-transaction \
+  --routines --triggers > mariadb-cluster-full-backup-$(date +%Y%m%d-%H%M).sql
+ls -lh mariadb-cluster-full-backup-*.sql | tail -1
+
+Verify Galera health:
+
+kubectl exec -it "$PRIMARY_POD" -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW STATUS LIKE 'wsrep_cluster_size';
+SHOW STATUS LIKE 'wsrep_cluster_status';
+SHOW STATUS LIKE 'wsrep_ready';"
+kubectl get mariadb -n openstack
+kubectl get pods -l app.kubernetes.io/name=mariadb -n openstack
+kubectl get crd | grep mariadb
+
+Expected:
+- wsrep_cluster_status is Primary.
+- wsrep_ready is ON.
+
+Execute
+
+Update the Target Version
+
+Edit /etc/genestack/helm-chart-versions.yaml:
+
+mariadb-operator: 0.37.1
+
+Confirm:
+
+grep mariadb-operator /etc/genestack/helm-chart-versions.yaml
+
+Apply Required Overrides or Patches
+
+Update the MariaDB image in /etc/genestack/kustomize/mariadb-cluster/base/mariadb-replication.yaml to the image compatible with 0.37.1, then enable autoUpdateDataPlane: true in the overlay or base manifest and apply:
+
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+Run the Maintenance
+
+Scale down the operator and remove webhooks:
+
+kubectl scale deployment mariadb-operator -n mariadb-system --replicas=0
+kubectl scale deployment mariadb-operator-webhook -n mariadb-system --replicas=0
+kubectl delete validatingwebhookconfiguration mariadb-operator-webhook
+kubectl delete mutatingwebhookconfiguration mariadb-operator-webhook 2>/dev/null || true
+
+Reinstall the operator:
+
+helm uninstall mariadb-operator -n mariadb-system
+/opt/genestack/bin/install-mariadb-operator.sh
+
+Disable autoUpdateDataPlane after the hop finishes and reapply:
+
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+Post-Maint
+
+Verify the release and pods:
+
+helm list -A | grep mariadb
+helm status mariadb-operator -n mariadb-system
+kubectl get pods -n mariadb-system -o wide
+kubectl get pods -n openstack | grep mariadb
+kubectl get mariadb -n openstack
+
+Re-run Galera health checks:
+
+kubectl exec -it "$PRIMARY_POD" -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW STATUS LIKE 'wsrep_cluster_size';
+SHOW STATUS LIKE 'wsrep_cluster_status';
+SHOW STATUS LIKE 'wsrep_ready';"
+
+Expected:
+- The operator version is 0.37.1.
+- wsrep_cluster_status is Primary.
+- wsrep_ready is ON.
+
+Troubleshooting
+
+Common Failure Signal
+
+If the cluster loses quorum or the operator does not reconcile after reinstall, stop and do not continue.
+
+Rollback
+
+Restore the last known good chart version in /etc/genestack/helm-chart-versions.yaml, keep the CRDs in place, and rerun:
+
+/opt/genestack/bin/install-mariadb-operator.sh
+
+Sources
+
+https://github.com/mariadb-operator/mariadb-operator/releases/tag/0.37.1
+https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_0.37.1.md

--- a/maintenances/maintenance-mariadb-operator-galera-0.36.0-to-26.3.0.txt
+++ b/maintenances/maintenance-mariadb-operator-galera-0.36.0-to-26.3.0.txt
@@ -1,0 +1,256 @@
+MariaDB Operator Galera Maintenance: 0.36.0 to 26.3.0
+
+Validation
+
+This maintenance upgrades the MariaDB Operator for a Galera-backed MariaDB cluster from 0.36.0 to 26.3.0 using the required staged path:
+0.36.0 -> 0.37.1 -> 0.38.1 -> 25.8.4 -> 25.10.4 -> 26.3.0.
+Do not skip outside this path. Complete the prep, execute, and post-maint validation for each hop before moving to the next hop.
+
+Never delete MariaDB CRDs during this maintenance. Deleting the CRDs will delete the MariaDB pods. Uninstalling only the Helm release does not by itself cause database downtime.
+
+Validated intermediate version rules:
+- Skip 0.37.0 and upgrade directly to 0.37.1.
+- Skip 0.38.0 and upgrade directly to 0.38.1.
+- Do not step through every 25.8.x patch. Upgrade directly from 0.38.1 to 25.8.4.
+- Do not step through every 25.10.x patch. Upgrade directly to 25.10.4.
+
+Validated platform dependency:
+- Confirm Kubernetes version compatibility against the upstream chart metadata before the 0.38.1 -> 25.8.4 hop.
+
+Major operational risks for this maintenance:
+- Deleting MariaDB CRDs will remove the MariaDB pods.
+- Updating the primary before the replicas can break Galera quorum.
+- The 26.3.0 Helm overrides require the 26.3.0 image schema for maxscaleImage, exporterImage, and exporterMaxscaleImage.
+- A webhook certificate validation loop can block reconciliation after the 25.8.4 hop.
+
+Goal
+
+Upgrade the MariaDB Operator for a Galera cluster from 0.36.0 to 26.3.0 without deleting CRDs, without losing Galera quorum, and with the cluster healthy after every required hop.
+
+Prep
+
+Deployment Node
+
+Run this maintenance from the Genestack deployment host with access to:
+- /etc/genestack/helm-chart-versions.yaml
+- /etc/genestack/helm-configs/mariadb-operator/mariadb-operator-helm-overrides.yaml
+- /etc/genestack/kustomize/mariadb-cluster/...
+- /opt/genestack/bin/install-mariadb-operator.sh
+
+Verify current installed versions:
+
+helm list -A | grep mariadb
+helm status mariadb-operator -n mariadb-system
+helm status mariadb-operator-crds -n mariadb-system
+
+Verify the Helm repo metadata and visible versions:
+
+helm repo update mariadb-operator
+helm search repo mariadb-operator/mariadb-operator --versions | head -20
+
+Expected:
+- The current operator release matches the hop you are about to upgrade from.
+- The target hop version is visible in the Helm repo output.
+
+If the current installed version does not match the expected source hop, stop and reassess before proceeding.
+
+Repeat the following checks before every hop.
+
+Retrieve the MariaDB root password and current primary:
+
+export MARIADB_ROOT_PASSWORD=$(kubectl get secret mariadb -n openstack \
+  -o jsonpath='{.data.root-password}' | base64 -d)
+export PRIMARY_POD=$(kubectl get mariadb mariadb-cluster -n openstack -o jsonpath="{.status.currentPrimary}")
+echo "Primary pod: $PRIMARY_POD"
+
+Create a full database backup from the current primary:
+
+kubectl exec -i "$PRIMARY_POD" -n openstack -- mariadb-dump \
+  -u root -p"$MARIADB_ROOT_PASSWORD" \
+  --all-databases \
+  --single-transaction \
+  --routines \
+  --triggers > mariadb-cluster-full-backup-$(date +%Y%m%d-%H%M).sql
+
+Verify the backup:
+
+ls -lh mariadb-cluster-full-backup-*.sql | tail -1
+
+Check database sizes:
+
+kubectl exec -it "$PRIMARY_POD" -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SELECT
+  table_schema AS 'Database',
+  ROUND(SUM(data_length + index_length) / 1024 / 1024, 2) AS 'Size_MB'
+FROM information_schema.tables
+WHERE table_schema NOT IN ('information_schema', 'performance_schema', 'mysql', 'sys')
+GROUP BY table_schema
+ORDER BY Size_MB DESC;"
+
+Confirm this cluster is Galera:
+
+kubectl get mariadb mariadb-cluster -n openstack -o jsonpath="{.spec.galera.enabled}"
+
+Expected:
+- The command returns true.
+
+Verify Galera health:
+
+kubectl exec -it "$PRIMARY_POD" -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW STATUS LIKE 'wsrep_cluster_size';
+SHOW STATUS LIKE 'wsrep_cluster_status';
+SHOW STATUS LIKE 'wsrep_ready';"
+
+Expected:
+- wsrep_cluster_size reports the expected member count.
+- wsrep_cluster_status is Primary.
+- wsrep_ready is ON.
+
+Verify current cluster and pod status:
+
+kubectl get mariadb -n openstack
+kubectl get pods -l app.kubernetes.io/name=mariadb -n openstack
+kubectl get mariadb -n openstack -o yaml | grep -B1 autoFailover
+kubectl get crd | grep mariadb
+
+Verify current operator, webhook, and MariaDB container images:
+
+kubectl get pods -n mariadb-system -o wide
+kubectl get pods \
+  $(kubectl get pods \
+  -l app.kubernetes.io/name=mariadb-operator \
+  -n mariadb-system \
+  -o jsonpath='{.items[0].metadata.name}') \
+  -n mariadb-system \
+  -o jsonpath="{..image}" | tr -s '[:space:]' '\n' | sort -u
+kubectl get pods \
+  $(kubectl get pods \
+  -l app.kubernetes.io/name=mariadb-operator-webhook \
+  -n mariadb-system \
+  -o jsonpath='{.items[0].metadata.name}') \
+  -n mariadb-system \
+  -o jsonpath="{..image}" | tr -s '[:space:]' '\n' | sort -u
+kubectl get pods "$PRIMARY_POD" \
+  -n openstack \
+  -o jsonpath="{..image}" \
+  | tr -s '[:space:]' '\n' | sort -u
+
+Execute
+
+Perform every version hop separately in this order:
+- 0.36.0 -> 0.37.1
+- 0.37.1 -> 0.38.1
+- 0.38.1 -> 25.8.4
+- 25.8.4 -> 25.10.4
+- 25.10.4 -> 26.3.0
+
+Repeat the prep and post-maint validation for each hop before moving to the next hop.
+
+Update the Target Version
+
+Edit /etc/genestack/helm-chart-versions.yaml and set the next target hop:
+
+mariadb-operator: <TARGET_VERSION>
+
+Apply Required Overrides or Patches
+
+For every hop, update the MariaDB image in /etc/genestack/kustomize/mariadb-cluster/base/mariadb-replication.yaml to the image compatible with the target operator chart version.
+
+Enable autoUpdateDataPlane: true before upgrading the operator and apply the cluster config:
+
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+For the 26.3.0 hop, verify the new structured image sections exist in /etc/genestack/helm-configs/mariadb-operator/mariadb-operator-helm-overrides.yaml for:
+- maxscaleImage
+- exporterImage
+- exporterMaxscaleImage
+
+Run the Maintenance
+
+Scale down the operator and remove webhooks:
+
+kubectl scale deployment mariadb-operator -n mariadb-system --replicas=0
+kubectl scale deployment mariadb-operator-webhook -n mariadb-system --replicas=0
+kubectl delete validatingwebhookconfiguration mariadb-operator-webhook
+kubectl delete mutatingwebhookconfiguration mariadb-operator-webhook 2>/dev/null || true
+
+Uninstall and reinstall the operator:
+
+helm uninstall mariadb-operator -n mariadb-system
+/opt/genestack/bin/install-mariadb-operator.sh
+
+Disable autoUpdateDataPlane after the hop finishes and the cluster is healthy by restoring the intended value in the overlay or base manifest and reapplying:
+
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+Version-specific execution notes:
+- 0.37.1: skip 0.37.0 and follow the standard hop flow.
+- 0.38.1: skip 0.38.0 and follow the standard hop flow.
+- 25.8.4: skip 25.08.0 and verify Kubernetes version compatibility against the upstream chart metadata before proceeding.
+- 25.10.4: no extra hop-specific procedure beyond the standard flow.
+- 26.3.0: complete the image-format changes before reinstalling the operator.
+
+Post-Maint
+
+Verify the deployed version and release state:
+
+helm list -A | grep mariadb
+helm status mariadb-operator -n mariadb-system
+helm status mariadb-operator-crds -n mariadb-system
+
+Verify operator, webhook, and MariaDB pod health:
+
+kubectl get pods -n mariadb-system -o wide
+kubectl get pods -n openstack | grep mariadb
+kubectl get mariadb -n openstack
+kubectl get crd | grep mariadb
+
+For the 26.3.0 hop, verify the new CRD exists:
+
+kubectl get crd pointintimerecoveries.k8s.mariadb.com
+
+Re-run Galera health checks:
+
+kubectl exec -it "$PRIMARY_POD" -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW STATUS LIKE 'wsrep_cluster_size';
+SHOW STATUS LIKE 'wsrep_cluster_status';
+SHOW STATUS LIKE 'wsrep_ready';"
+
+Verify logs and recent events for reconciliation or rollout failures:
+
+kubectl logs -n mariadb-system deploy/mariadb-operator --tail=200
+kubectl logs -n mariadb-system deploy/mariadb-operator-webhook --tail=200
+kubectl get events -A --sort-by=.lastTimestamp | tail -n 50
+
+Troubleshooting
+
+Common Failure Signal
+
+If the upgrade stalls with webhook validation errors, cert validation loops, or Galera quorum loss after a hop, stop and do not continue to the next version until the current hop is healthy.
+
+Rollback
+
+Stop at the current hop, keep the CRDs in place, restore the previous known-good chart version in /etc/genestack/helm-chart-versions.yaml, and rerun:
+
+/opt/genestack/bin/install-mariadb-operator.sh
+
+Additional Recovery Actions
+
+If operator pods are stuck in a Validating certs loop:
+
+kubectl get certificate -n mariadb-system
+kubectl delete secret mariadb-operator-webhook-cert -n mariadb-system
+kubectl delete deployment mariadb-operator-webhook -n mariadb-system
+/opt/genestack/bin/install-mariadb-operator.sh
+
+Sources
+
+https://github.com/mariadb-operator/mariadb-operator/releases/tag/0.37.1
+https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_0.37.1.md
+https://github.com/mariadb-operator/mariadb-operator/releases/tag/0.38.1
+https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_0.38.0.md
+https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_0.38.1.md
+https://github.com/mariadb-operator/mariadb-operator/releases/tag/25.8.1
+https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_25.08.0.md
+https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_25.8.1.md
+https://github.com/mariadb-operator/mariadb-operator/releases/tag/26.3.0

--- a/maintenances/maintenance-mariadb-operator-galera-0.37.1-to-0.38.1.txt
+++ b/maintenances/maintenance-mariadb-operator-galera-0.37.1-to-0.38.1.txt
@@ -1,0 +1,110 @@
+MariaDB Operator Galera Maintenance: 0.37.1 to 0.38.1
+
+Validation
+
+This maintenance upgrades the MariaDB Operator for a Galera-backed MariaDB cluster from 0.37.1 to 0.38.1.
+Skip 0.38.0 and upgrade directly to 0.38.1.
+Never delete MariaDB CRDs during this maintenance.
+
+Major operational risks:
+- Deleting MariaDB CRDs will remove the MariaDB pods.
+- Updating the primary before replicas risks losing Galera quorum.
+
+Goal
+
+Upgrade the MariaDB Operator from 0.37.1 to 0.38.1 for a Galera cluster and keep the cluster healthy throughout the hop.
+
+Prep
+
+Deployment Node
+
+Run this maintenance from the Genestack deployment host.
+
+Verify current versions and target availability:
+
+helm list -A | grep mariadb
+helm status mariadb-operator -n mariadb-system
+helm repo update mariadb-operator
+helm search repo mariadb-operator/mariadb-operator --versions | head -20
+
+Expected:
+- The current version is 0.37.1.
+- The target version 0.38.1 is available.
+
+Retrieve the MariaDB root password and current primary:
+
+export MARIADB_ROOT_PASSWORD=$(kubectl get secret mariadb -n openstack \
+  -o jsonpath='{.data.root-password}' | base64 -d)
+export PRIMARY_POD=$(kubectl get mariadb mariadb-cluster -n openstack -o jsonpath="{.status.currentPrimary}")
+
+Confirm this cluster is Galera and healthy:
+
+kubectl get mariadb mariadb-cluster -n openstack -o jsonpath="{.spec.galera.enabled}"
+kubectl exec -it "$PRIMARY_POD" -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW STATUS LIKE 'wsrep_cluster_size';
+SHOW STATUS LIKE 'wsrep_cluster_status';
+SHOW STATUS LIKE 'wsrep_ready';"
+kubectl get mariadb -n openstack
+kubectl get pods -l app.kubernetes.io/name=mariadb -n openstack
+
+Create and verify a backup:
+
+kubectl exec -i "$PRIMARY_POD" -n openstack -- mariadb-dump \
+  -u root -p"$MARIADB_ROOT_PASSWORD" --all-databases --single-transaction \
+  --routines --triggers > mariadb-cluster-full-backup-$(date +%Y%m%d-%H%M).sql
+ls -lh mariadb-cluster-full-backup-*.sql | tail -1
+
+Execute
+
+Update the Target Version
+
+Edit /etc/genestack/helm-chart-versions.yaml:
+
+mariadb-operator: 0.38.1
+
+Apply Required Overrides or Patches
+
+Update the MariaDB image for 0.38.1 compatibility, enable autoUpdateDataPlane: true, and apply:
+
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+Run the Maintenance
+
+kubectl scale deployment mariadb-operator -n mariadb-system --replicas=0
+kubectl scale deployment mariadb-operator-webhook -n mariadb-system --replicas=0
+kubectl delete validatingwebhookconfiguration mariadb-operator-webhook
+kubectl delete mutatingwebhookconfiguration mariadb-operator-webhook 2>/dev/null || true
+helm uninstall mariadb-operator -n mariadb-system
+/opt/genestack/bin/install-mariadb-operator.sh
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+Post-Maint
+
+Verify the release and Galera health:
+
+helm list -A | grep mariadb
+kubectl get pods -n mariadb-system -o wide
+kubectl get pods -n openstack | grep mariadb
+kubectl exec -it "$PRIMARY_POD" -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW STATUS LIKE 'wsrep_cluster_size';
+SHOW STATUS LIKE 'wsrep_cluster_status';
+SHOW STATUS LIKE 'wsrep_ready';"
+
+Expected:
+- The operator version is 0.38.1.
+- wsrep_cluster_status is Primary.
+- wsrep_ready is ON.
+
+Troubleshooting
+
+Rollback
+
+Restore the previous chart version in /etc/genestack/helm-chart-versions.yaml and rerun:
+
+/opt/genestack/bin/install-mariadb-operator.sh
+
+Sources
+
+https://github.com/mariadb-operator/mariadb-operator/releases/tag/0.38.1
+https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_0.38.0.md
+https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_0.38.1.md

--- a/maintenances/maintenance-mariadb-operator-galera-0.38.1-to-25.8.4.txt
+++ b/maintenances/maintenance-mariadb-operator-galera-0.38.1-to-25.8.4.txt
@@ -1,0 +1,117 @@
+MariaDB Operator Galera Maintenance: 0.38.1 to 25.8.4
+
+Validation
+
+This maintenance upgrades the MariaDB Operator for a Galera-backed MariaDB cluster from 0.38.1 to 25.8.4.
+Do not step through every 25.8.x patch. Upgrade directly to 25.8.4.
+Confirm Kubernetes version compatibility against the upstream chart metadata before this hop.
+Never delete MariaDB CRDs during this maintenance.
+
+Major operational risks:
+- Deleting MariaDB CRDs will remove the MariaDB pods.
+- Updating the primary before replicas risks losing Galera quorum.
+- A webhook certificate validation loop can block reconciliation after the hop.
+
+Goal
+
+Upgrade the MariaDB Operator from 0.38.1 to 25.8.4 for a Galera cluster and keep the cluster healthy throughout the hop.
+
+Prep
+
+Deployment Node
+
+Verify current versions, target availability, and Kubernetes level:
+
+helm list -A | grep mariadb
+helm status mariadb-operator -n mariadb-system
+helm repo update mariadb-operator
+helm search repo mariadb-operator/mariadb-operator --versions | head -20
+kubectl version
+
+Expected:
+- The current version is 0.38.1.
+- The target version 25.8.4 is available.
+- Kubernetes is 1.34 or newer.
+
+Retrieve the MariaDB root password and current primary:
+
+export MARIADB_ROOT_PASSWORD=$(kubectl get secret mariadb -n openstack \
+  -o jsonpath='{.data.root-password}' | base64 -d)
+export PRIMARY_POD=$(kubectl get mariadb mariadb-cluster -n openstack -o jsonpath="{.status.currentPrimary}")
+
+Verify Galera health and create a backup:
+
+kubectl exec -it "$PRIMARY_POD" -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW STATUS LIKE 'wsrep_cluster_size';
+SHOW STATUS LIKE 'wsrep_cluster_status';
+SHOW STATUS LIKE 'wsrep_ready';"
+kubectl exec -i "$PRIMARY_POD" -n openstack -- mariadb-dump \
+  -u root -p"$MARIADB_ROOT_PASSWORD" --all-databases --single-transaction \
+  --routines --triggers > mariadb-cluster-full-backup-$(date +%Y%m%d-%H%M).sql
+ls -lh mariadb-cluster-full-backup-*.sql | tail -1
+
+Execute
+
+Update the Target Version
+
+Edit /etc/genestack/helm-chart-versions.yaml:
+
+mariadb-operator: 25.8.4
+
+Apply Required Overrides or Patches
+
+Update the MariaDB image for 25.8.4 compatibility, enable autoUpdateDataPlane: true, and apply:
+
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+Run the Maintenance
+
+kubectl scale deployment mariadb-operator -n mariadb-system --replicas=0
+kubectl scale deployment mariadb-operator-webhook -n mariadb-system --replicas=0
+kubectl delete validatingwebhookconfiguration mariadb-operator-webhook
+kubectl delete mutatingwebhookconfiguration mariadb-operator-webhook 2>/dev/null || true
+helm uninstall mariadb-operator -n mariadb-system
+/opt/genestack/bin/install-mariadb-operator.sh
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+If operator pods are stuck in a Validating certs loop, recover before continuing:
+
+kubectl get certificate -n mariadb-system
+kubectl delete secret mariadb-operator-webhook-cert -n mariadb-system
+kubectl delete deployment mariadb-operator-webhook -n mariadb-system
+/opt/genestack/bin/install-mariadb-operator.sh
+
+Post-Maint
+
+Verify the release and Galera health:
+
+helm list -A | grep mariadb
+kubectl get pods -n mariadb-system -o wide
+kubectl get pods -n openstack | grep mariadb
+kubectl exec -it "$PRIMARY_POD" -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW STATUS LIKE 'wsrep_cluster_size';
+SHOW STATUS LIKE 'wsrep_cluster_status';
+SHOW STATUS LIKE 'wsrep_ready';"
+
+Expected:
+- The operator version is 25.8.4.
+- wsrep_cluster_status is Primary.
+- wsrep_ready is ON.
+
+Troubleshooting
+
+Common Failure Signal
+
+If the operator logs are stuck on Validating certs, stop and repair the webhook cert before continuing.
+
+Rollback
+
+Restore the previous chart version in /etc/genestack/helm-chart-versions.yaml and rerun:
+
+/opt/genestack/bin/install-mariadb-operator.sh
+
+Sources
+
+https://github.com/mariadb-operator/mariadb-operator/releases/tag/25.8.1
+https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_25.08.0.md
+https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_25.8.1.md

--- a/maintenances/maintenance-mariadb-operator-galera-25.10.4-to-26.3.0.txt
+++ b/maintenances/maintenance-mariadb-operator-galera-25.10.4-to-26.3.0.txt
@@ -1,0 +1,101 @@
+MariaDB Operator Galera Maintenance: 25.10.4 to 26.3.0
+
+Validation
+
+This maintenance upgrades the MariaDB Operator for a Galera-backed MariaDB cluster from 25.10.4 to 26.3.0.
+Never delete MariaDB CRDs during this maintenance.
+
+Major operational risks:
+- Deleting MariaDB CRDs will remove the MariaDB pods.
+- Updating the primary before replicas risks losing Galera quorum.
+- The 26.3.0 Helm overrides require the 26.3.0 image schema for maxscaleImage, exporterImage, and exporterMaxscaleImage.
+
+Goal
+
+Upgrade the MariaDB Operator from 25.10.4 to 26.3.0 for a Galera cluster and keep the cluster healthy throughout the hop.
+
+Prep
+
+Deployment Node
+
+Verify current versions and target availability:
+
+helm list -A | grep mariadb
+helm status mariadb-operator -n mariadb-system
+helm repo update mariadb-operator
+helm search repo mariadb-operator/mariadb-operator --versions | head -20
+grep -n "mariadbImageName\\|mariadbImage:\\|maxscaleImage\\|exporterImage\\|exporterMaxscaleImage" \
+  /etc/genestack/helm-configs/mariadb-operator/mariadb-operator-helm-overrides.yaml
+
+Expected:
+- The current version is 25.10.4.
+- The target version is 26.3.0.
+- The override file has been reviewed against the 26.3.0 image schema where required.
+
+Retrieve the MariaDB root password and current primary, verify Galera health, and create a backup:
+
+export MARIADB_ROOT_PASSWORD=$(kubectl get secret mariadb -n openstack \
+  -o jsonpath='{.data.root-password}' | base64 -d)
+export PRIMARY_POD=$(kubectl get mariadb mariadb-cluster -n openstack -o jsonpath="{.status.currentPrimary}")
+kubectl exec -it "$PRIMARY_POD" -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW STATUS LIKE 'wsrep_cluster_size';
+SHOW STATUS LIKE 'wsrep_cluster_status';
+SHOW STATUS LIKE 'wsrep_ready';"
+kubectl exec -i "$PRIMARY_POD" -n openstack -- mariadb-dump \
+  -u root -p"$MARIADB_ROOT_PASSWORD" --all-databases --single-transaction \
+  --routines --triggers > mariadb-cluster-full-backup-$(date +%Y%m%d-%H%M).sql
+ls -lh mariadb-cluster-full-backup-*.sql | tail -1
+
+Execute
+
+Update the Target Version
+
+Edit /etc/genestack/helm-chart-versions.yaml:
+
+mariadb-operator: 26.3.0
+
+Apply Required Overrides or Patches
+
+Update the MariaDB image for 26.3.0 compatibility, verify the 26.3.0 image schema in /etc/genestack/helm-configs/mariadb-operator/mariadb-operator-helm-overrides.yaml, enable autoUpdateDataPlane: true, and apply:
+
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+Run the Maintenance
+
+kubectl scale deployment mariadb-operator -n mariadb-system --replicas=0
+kubectl scale deployment mariadb-operator-webhook -n mariadb-system --replicas=0
+kubectl delete validatingwebhookconfiguration mariadb-operator-webhook
+kubectl delete mutatingwebhookconfiguration mariadb-operator-webhook 2>/dev/null || true
+helm uninstall mariadb-operator -n mariadb-system
+/opt/genestack/bin/install-mariadb-operator.sh
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+Post-Maint
+
+Verify the release, new CRD, and Galera health:
+
+helm list -A | grep mariadb
+kubectl get crd pointintimerecoveries.k8s.mariadb.com
+kubectl get pods -n mariadb-system -o wide
+kubectl get pods -n openstack | grep mariadb
+kubectl exec -it "$PRIMARY_POD" -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW STATUS LIKE 'wsrep_cluster_size';
+SHOW STATUS LIKE 'wsrep_cluster_status';
+SHOW STATUS LIKE 'wsrep_ready';"
+
+Expected:
+- The operator version is 26.3.0.
+- pointintimerecoveries.k8s.mariadb.com exists.
+- wsrep_cluster_status is Primary.
+
+Troubleshooting
+
+Rollback
+
+Restore the previous chart version in /etc/genestack/helm-chart-versions.yaml and rerun:
+
+/opt/genestack/bin/install-mariadb-operator.sh
+
+Sources
+
+https://github.com/mariadb-operator/mariadb-operator/releases/tag/26.3.0

--- a/maintenances/maintenance-mariadb-operator-galera-25.8.4-to-25.10.4.txt
+++ b/maintenances/maintenance-mariadb-operator-galera-25.8.4-to-25.10.4.txt
@@ -1,0 +1,98 @@
+MariaDB Operator Galera Maintenance: 25.8.4 to 25.10.4
+
+Validation
+
+This maintenance upgrades the MariaDB Operator for a Galera-backed MariaDB cluster from 25.8.4 to 25.10.4.
+Do not step through every 25.10.x patch. Upgrade directly to 25.10.4.
+Never delete MariaDB CRDs during this maintenance.
+
+Major operational risks:
+- Deleting MariaDB CRDs will remove the MariaDB pods.
+- Updating the primary before replicas risks losing Galera quorum.
+
+Goal
+
+Upgrade the MariaDB Operator from 25.8.4 to 25.10.4 for a Galera cluster and return the cluster healthy after the hop.
+
+Prep
+
+Deployment Node
+
+Verify current versions and target availability:
+
+helm list -A | grep mariadb
+helm status mariadb-operator -n mariadb-system
+helm repo update mariadb-operator
+helm search repo mariadb-operator/mariadb-operator --versions | head -20
+
+Expected:
+- The current version is 25.8.4.
+- The target version is 25.10.4.
+
+Retrieve the MariaDB root password and current primary, verify Galera health, and create a backup:
+
+export MARIADB_ROOT_PASSWORD=$(kubectl get secret mariadb -n openstack \
+  -o jsonpath='{.data.root-password}' | base64 -d)
+export PRIMARY_POD=$(kubectl get mariadb mariadb-cluster -n openstack -o jsonpath="{.status.currentPrimary}")
+kubectl exec -it "$PRIMARY_POD" -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW STATUS LIKE 'wsrep_cluster_size';
+SHOW STATUS LIKE 'wsrep_cluster_status';
+SHOW STATUS LIKE 'wsrep_ready';"
+kubectl exec -i "$PRIMARY_POD" -n openstack -- mariadb-dump \
+  -u root -p"$MARIADB_ROOT_PASSWORD" --all-databases --single-transaction \
+  --routines --triggers > mariadb-cluster-full-backup-$(date +%Y%m%d-%H%M).sql
+ls -lh mariadb-cluster-full-backup-*.sql | tail -1
+
+Execute
+
+Update the Target Version
+
+Edit /etc/genestack/helm-chart-versions.yaml:
+
+mariadb-operator: 25.10.4
+
+Apply Required Overrides or Patches
+
+Update the MariaDB image for 25.10.4 compatibility, enable autoUpdateDataPlane: true, and apply:
+
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+Run the Maintenance
+
+kubectl scale deployment mariadb-operator -n mariadb-system --replicas=0
+kubectl scale deployment mariadb-operator-webhook -n mariadb-system --replicas=0
+kubectl delete validatingwebhookconfiguration mariadb-operator-webhook
+kubectl delete mutatingwebhookconfiguration mariadb-operator-webhook 2>/dev/null || true
+helm uninstall mariadb-operator -n mariadb-system
+/opt/genestack/bin/install-mariadb-operator.sh
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+Post-Maint
+
+Verify the release, CRs, and Galera health:
+
+helm list -A | grep mariadb
+kubectl get mariadb -n openstack -o yaml | grep -B1 autoFailover
+kubectl get pods -n mariadb-system -o wide
+kubectl get pods -n openstack | grep mariadb
+kubectl exec -it "$PRIMARY_POD" -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW STATUS LIKE 'wsrep_cluster_size';
+SHOW STATUS LIKE 'wsrep_cluster_status';
+SHOW STATUS LIKE 'wsrep_ready';"
+
+Expected:
+- The operator version is 25.10.4.
+- autoFailover is present in the MariaDB CR output.
+- wsrep_cluster_status is Primary.
+
+Troubleshooting
+
+Rollback
+
+Restore the previous chart version in /etc/genestack/helm-chart-versions.yaml and rerun:
+
+/opt/genestack/bin/install-mariadb-operator.sh
+
+Sources
+
+https://github.com/mariadb-operator/mariadb-operator/releases/tag/25.8.1

--- a/maintenances/maintenance-mariadb-operator-replication-0.36.0-to-0.37.1.txt
+++ b/maintenances/maintenance-mariadb-operator-replication-0.36.0-to-0.37.1.txt
@@ -1,0 +1,172 @@
+MariaDB Operator Replication Maintenance: 0.36.0 to 0.37.1
+
+Validation
+
+This maintenance upgrades the MariaDB Operator for a primary/replica MariaDB cluster from 0.36.0 to 0.37.1.
+Skip 0.37.0 and upgrade directly to 0.37.1.
+Never delete MariaDB CRDs during this maintenance.
+
+Major operational risks:
+- Deleting MariaDB CRDs will remove the MariaDB pods.
+- Replication must be revalidated after the operator hop.
+- This pre-25.10 replication hop is operational guidance inferred from the staged upgrade path and local release history, not from upstream GA replication runbooks. Validate it in a non-production environment first.
+
+Goal
+
+Upgrade the MariaDB Operator from 0.36.0 to 0.37.1 for a primary/replica cluster and restore healthy replication.
+
+Prep
+
+Deployment Node
+
+Verify current versions and target availability:
+
+helm list -A | grep mariadb
+helm status mariadb-operator -n mariadb-system
+helm repo update mariadb-operator
+helm search repo mariadb-operator/mariadb-operator --versions | head -20
+
+Expected:
+- The current version is 0.36.0.
+- The target version is 0.37.1.
+
+Retrieve the MariaDB root password and current primary:
+
+export MARIADB_ROOT_PASSWORD=$(kubectl get secret mariadb -n openstack \
+  -o jsonpath='{.data.root-password}' | base64 -d)
+export PRIMARY_POD=$(kubectl get mariadb mariadb-cluster -n openstack -o jsonpath="{.status.currentPrimary}")
+
+Confirm this is not a Galera cluster:
+
+kubectl get mariadb mariadb-cluster -n openstack -o jsonpath="{.spec.galera.enabled}"
+
+Expected:
+- The command returns empty or false.
+
+Verify replication health and create a backup:
+
+kubectl exec -it mariadb-cluster-1 -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW REPLICA STATUS\G"
+kubectl exec -i "$PRIMARY_POD" -n openstack -- mariadb-dump \
+  -u root -p"$MARIADB_ROOT_PASSWORD" --all-databases --single-transaction \
+  --routines --triggers > mariadb-cluster-full-backup-$(date +%Y%m%d-%H%M).sql
+ls -lh mariadb-cluster-full-backup-*.sql | tail -1
+
+Expected:
+- Slave_IO_Running: Yes
+- Slave_SQL_Running: Yes
+
+Execute
+
+Update the Target Version
+
+Edit /etc/genestack/helm-chart-versions.yaml:
+
+mariadb-operator: 0.37.1
+
+Apply Required Overrides or Patches
+
+Update the MariaDB image for 0.37.1 compatibility, enable autoUpdateDataPlane: true, and apply:
+
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+Run the Maintenance
+
+kubectl scale deployment mariadb-operator -n mariadb-system --replicas=0
+kubectl scale deployment mariadb-operator-webhook -n mariadb-system --replicas=0
+kubectl delete validatingwebhookconfiguration mariadb-operator-webhook
+kubectl delete mutatingwebhookconfiguration mariadb-operator-webhook 2>/dev/null || true
+helm uninstall mariadb-operator -n mariadb-system
+/opt/genestack/bin/install-mariadb-operator.sh
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+Run the replication migration after the hop:
+
+export MARIADB_NAME=mariadb-cluster
+export MARIADB_NAMESPACE=openstack
+cat >/tmp/migrate-replication.sh <<'EOF'
+#!/bin/bash
+
+set -eo pipefail
+
+if [[ -z "$MARIADB_NAME" || -z "$MARIADB_NAMESPACE" || -z "$MARIADB_ROOT_PASSWORD" ]]; then
+  echo "Error: MARIADB_NAME, MARIADB_NAMESPACE and MARIADB_ROOT_PASSWORD env vars must be set."
+  exit 1
+fi
+
+function exec_sql {
+  local pod=$1
+  local sql=$2
+  kubectl exec -n "$MARIADB_NAMESPACE" "$pod" -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "$sql"
+}
+
+function wait_for_ready_replication {
+  local pod=$1
+  local timeout=300
+  local interval=10
+  local elapsed=0
+
+  while [[ $elapsed -lt $timeout ]]; do
+    exec_sql "$pod" "SHOW REPLICA STATUS\\G" | tee /tmp/replication_status_$pod_$MARIADB_NAMESPACE.txt
+
+    if grep -q "Slave_IO_Running: Yes" /tmp/replication_status_$pod_$MARIADB_NAMESPACE.txt && \
+       grep -q "Slave_SQL_Running: Yes" /tmp/replication_status_$pod_$MARIADB_NAMESPACE.txt; then
+      return 0
+    fi
+
+    sleep $interval
+    ((elapsed+=interval))
+  done
+
+  echo "Error: Replication did not become ready on $pod within 5 minutes."
+  exit 1
+}
+
+PODS=$(kubectl get pods -n "$MARIADB_NAMESPACE" \
+  -l app.kubernetes.io/instance=$MARIADB_NAME \
+  -o jsonpath="{.items[*].metadata.name}")
+PRIMARY_POD=$(kubectl get mariadb "$MARIADB_NAME" -n "$MARIADB_NAMESPACE" \
+  -o jsonpath="{.status.currentPrimary}")
+
+for POD in $PODS; do
+  if [[ "$POD" == "$PRIMARY_POD" ]]; then
+    continue
+  fi
+
+  exec_sql "$POD" "STOP SLAVE 'mariadb-operator';"
+  exec_sql "$POD" "RESET SLAVE 'mariadb-operator' ALL;"
+  kubectl delete pod "$POD" -n "$MARIADB_NAMESPACE"
+  kubectl wait --for=condition=Ready pod/"$POD" -n "$MARIADB_NAMESPACE" --timeout=5m
+  wait_for_ready_replication "$POD"
+done
+EOF
+chmod +x /tmp/migrate-replication.sh
+/tmp/migrate-replication.sh
+
+Post-Maint
+
+Verify the release and replication health:
+
+helm list -A | grep mariadb
+kubectl get pods -n mariadb-system -o wide
+kubectl get pods -n openstack | grep mariadb
+kubectl exec -it mariadb-cluster-1 -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW REPLICA STATUS\G"
+
+Expected:
+- The operator version is 0.37.1.
+- Slave_IO_Running: Yes
+- Slave_SQL_Running: Yes
+
+Troubleshooting
+
+Rollback
+
+Restore the previous chart version in /etc/genestack/helm-chart-versions.yaml and rerun:
+
+/opt/genestack/bin/install-mariadb-operator.sh
+
+Sources
+
+https://github.com/mariadb-operator/mariadb-operator/releases/tag/0.37.1
+https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_0.37.1.md

--- a/maintenances/maintenance-mariadb-operator-replication-0.36.0-to-26.3.0.txt
+++ b/maintenances/maintenance-mariadb-operator-replication-0.36.0-to-26.3.0.txt
@@ -1,0 +1,284 @@
+MariaDB Operator Replication Maintenance: 0.36.0 to 26.3.0
+
+Validation
+
+This maintenance upgrades the MariaDB Operator for a primary/replica MariaDB cluster from 0.36.0 to 26.3.0 using the required staged path:
+0.36.0 -> 0.37.1 -> 0.38.1 -> 25.8.4 -> 25.10.4 -> 26.3.0.
+Do not skip outside this path. Complete the prep, execute, and post-maint validation for each hop before moving to the next hop.
+
+Never delete MariaDB CRDs during this maintenance. Deleting the CRDs will delete the MariaDB pods. Uninstalling only the Helm release does not by itself cause database downtime.
+
+Validated intermediate version rules:
+- Skip 0.37.0 and upgrade directly to 0.37.1.
+- Skip 0.38.0 and upgrade directly to 0.38.1.
+- Do not step through every 25.8.x patch. Upgrade directly from 0.38.1 to 25.8.4.
+- Do not step through every 25.10.x patch. Upgrade directly to 25.10.4.
+
+Validated platform dependency:
+- Confirm Kubernetes version compatibility against the upstream chart metadata before the 0.38.1 -> 25.8.4 hop.
+
+Major operational risks for this maintenance:
+- Deleting MariaDB CRDs will remove the MariaDB pods.
+- Replication clusters require a post-upgrade replication migration after each operator hop.
+- The 25.x replication line changed syncBinlog from boolean to integer, and the 26.3.0 webhook can reject legacy syncBinlog: true values until the MariaDB CR is patched to syncBinlog: 1.
+- The 26.3.0 Helm overrides require the 26.3.0 image schema for maxscaleImage, exporterImage, and exporterMaxscaleImage.
+- A webhook certificate validation loop can block reconciliation after the 25.8.4 hop.
+
+Goal
+
+Upgrade the MariaDB Operator for a primary/replica cluster from 0.36.0 to 26.3.0 without deleting CRDs, without breaking replication, and with the cluster healthy after every required hop.
+
+For replication clusters before the 25.10.x line, treat this runbook as operational guidance inferred from the staged upgrade path and local release history rather than as an upstream GA replication runbook. Validate each early hop in a non-production environment first.
+
+Prep
+
+Deployment Node
+
+Run this maintenance from the Genestack deployment host with access to:
+- /etc/genestack/helm-chart-versions.yaml
+- /etc/genestack/helm-configs/mariadb-operator/mariadb-operator-helm-overrides.yaml
+- /etc/genestack/kustomize/mariadb-cluster/...
+- /opt/genestack/bin/install-mariadb-operator.sh
+
+Verify current installed versions:
+
+helm list -A | grep mariadb
+helm status mariadb-operator -n mariadb-system
+helm status mariadb-operator-crds -n mariadb-system
+
+Verify the Helm repo metadata and visible versions:
+
+helm repo update mariadb-operator
+helm search repo mariadb-operator/mariadb-operator --versions | head -20
+
+Repeat the following checks before every hop.
+
+Retrieve the MariaDB root password and current primary:
+
+export MARIADB_ROOT_PASSWORD=$(kubectl get secret mariadb -n openstack \
+  -o jsonpath='{.data.root-password}' | base64 -d)
+export PRIMARY_POD=$(kubectl get mariadb mariadb-cluster -n openstack -o jsonpath="{.status.currentPrimary}")
+echo "Primary pod: $PRIMARY_POD"
+
+Create a full database backup from the current primary:
+
+kubectl exec -i "$PRIMARY_POD" -n openstack -- mariadb-dump \
+  -u root -p"$MARIADB_ROOT_PASSWORD" \
+  --all-databases \
+  --single-transaction \
+  --routines \
+  --triggers > mariadb-cluster-full-backup-$(date +%Y%m%d-%H%M).sql
+
+Verify the backup:
+
+ls -lh mariadb-cluster-full-backup-*.sql | tail -1
+
+Confirm this cluster is using primary/replica replication:
+
+kubectl get mariadb mariadb-cluster -n openstack -o jsonpath="{.spec.galera.enabled}"
+
+Expected:
+- The command returns empty or false.
+
+Verify current primary and replica status:
+
+kubectl get mariadb mariadb-cluster -n openstack -o jsonpath="{.status.currentPrimary}"
+kubectl exec -it mariadb-cluster-1 -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW REPLICA STATUS\G"
+
+Verify current cluster and pod status:
+
+kubectl get mariadb -n openstack
+kubectl get pods -l app.kubernetes.io/name=mariadb -n openstack
+kubectl get mariadb -n openstack -o yaml | grep -B1 autoFailover
+kubectl get crd | grep mariadb
+
+Execute
+
+Perform every version hop separately in this order:
+- 0.36.0 -> 0.37.1
+- 0.37.1 -> 0.38.1
+- 0.38.1 -> 25.8.4
+- 25.8.4 -> 25.10.4
+- 25.10.4 -> 26.3.0
+
+Repeat the prep and post-maint validation for each hop before moving to the next hop.
+
+Update the Target Version
+
+Edit /etc/genestack/helm-chart-versions.yaml and set the next target hop:
+
+mariadb-operator: <TARGET_VERSION>
+
+Apply Required Overrides or Patches
+
+For every hop, update the MariaDB image in /etc/genestack/kustomize/mariadb-cluster/base/mariadb-replication.yaml to the image compatible with the target operator chart version.
+
+Enable autoUpdateDataPlane: true before upgrading the operator and apply the cluster config:
+
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+For the 26.3.0 hop, patch syncBinlog before reinstalling the operator if the MariaDB CR still uses the old boolean value:
+
+kubectl delete validatingwebhookconfiguration mariadb-operator-webhook
+kubectl -n openstack patch mariadb mariadb-cluster --type merge \
+  -p '{"spec":{"replication":{"syncBinlog":1}}}'
+
+Run the Maintenance
+
+Scale down the operator and remove webhooks:
+
+kubectl scale deployment mariadb-operator -n mariadb-system --replicas=0
+kubectl scale deployment mariadb-operator-webhook -n mariadb-system --replicas=0
+kubectl delete validatingwebhookconfiguration mariadb-operator-webhook
+kubectl delete mutatingwebhookconfiguration mariadb-operator-webhook 2>/dev/null || true
+
+Uninstall and reinstall the operator:
+
+helm uninstall mariadb-operator -n mariadb-system
+/opt/genestack/bin/install-mariadb-operator.sh
+
+Disable autoUpdateDataPlane after the hop finishes and the cluster is healthy by restoring the intended value in the overlay or base manifest and reapplying:
+
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+Run the replication migration after each operator hop:
+
+export MARIADB_NAME=mariadb-cluster
+export MARIADB_NAMESPACE=openstack
+cat >/tmp/migrate-replication.sh <<'EOF'
+#!/bin/bash
+
+set -eo pipefail
+
+if [[ -z "$MARIADB_NAME" || -z "$MARIADB_NAMESPACE" || -z "$MARIADB_ROOT_PASSWORD" ]]; then
+  echo "Error: MARIADB_NAME, MARIADB_NAMESPACE and MARIADB_ROOT_PASSWORD env vars must be set."
+  exit 1
+fi
+
+function exec_sql {
+  local pod=$1
+  local sql=$2
+  kubectl exec -n "$MARIADB_NAMESPACE" "$pod" -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "$sql"
+}
+
+function wait_for_ready_replication {
+  local pod=$1
+  local timeout=300
+  local interval=10
+  local elapsed=0
+
+  while [[ $elapsed -lt $timeout ]]; do
+    exec_sql "$pod" "SHOW REPLICA STATUS\\G" | tee /tmp/replication_status_$pod_$MARIADB_NAMESPACE.txt
+
+    if grep -q "Slave_IO_Running: Yes" /tmp/replication_status_$pod_$MARIADB_NAMESPACE.txt && \
+       grep -q "Slave_SQL_Running: Yes" /tmp/replication_status_$pod_$MARIADB_NAMESPACE.txt; then
+      return 0
+    fi
+
+    sleep $interval
+    ((elapsed+=interval))
+  done
+
+  echo "Error: Replication did not become ready on $pod within 5 minutes."
+  exit 1
+}
+
+PODS=$(kubectl get pods -n "$MARIADB_NAMESPACE" \
+  -l app.kubernetes.io/instance=$MARIADB_NAME \
+  -o jsonpath="{.items[*].metadata.name}")
+PRIMARY_POD=$(kubectl get mariadb "$MARIADB_NAME" -n "$MARIADB_NAMESPACE" \
+  -o jsonpath="{.status.currentPrimary}")
+
+for POD in $PODS; do
+  if [[ "$POD" == "$PRIMARY_POD" ]]; then
+    continue
+  fi
+
+  exec_sql "$POD" "STOP SLAVE 'mariadb-operator';"
+  exec_sql "$POD" "RESET SLAVE 'mariadb-operator' ALL;"
+  kubectl delete pod "$POD" -n "$MARIADB_NAMESPACE"
+  kubectl wait --for=condition=Ready pod/"$POD" -n "$MARIADB_NAMESPACE" --timeout=5m
+  wait_for_ready_replication "$POD"
+done
+EOF
+chmod +x /tmp/migrate-replication.sh
+/tmp/migrate-replication.sh
+
+Version-specific execution notes:
+- 0.37.1: skip 0.37.0 and follow the standard hop flow.
+- 0.38.1: skip 0.38.0 and follow the standard hop flow.
+- 25.8.4: skip 25.08.0 and verify Kubernetes version compatibility against the upstream chart metadata before proceeding.
+- 25.10.4: no extra hop-specific procedure beyond the standard flow.
+- 26.3.0: complete the syncBinlog and image-format changes before reinstalling the operator.
+
+Post-Maint
+
+Verify the deployed version and release state:
+
+helm list -A | grep mariadb
+helm status mariadb-operator -n mariadb-system
+helm status mariadb-operator-crds -n mariadb-system
+
+Verify operator, webhook, and MariaDB pod health:
+
+kubectl get pods -n mariadb-system -o wide
+kubectl get pods -n openstack | grep mariadb
+kubectl get mariadb -n openstack
+kubectl get crd | grep mariadb
+
+For the 26.3.0 hop, verify the new CRD exists:
+
+kubectl get crd pointintimerecoveries.k8s.mariadb.com
+
+Re-run replication health checks:
+
+kubectl get mariadb mariadb-cluster -n openstack -o jsonpath="{.status.currentPrimary}"
+kubectl exec -it mariadb-cluster-1 -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW REPLICA STATUS\G"
+
+Verify logs and recent events for reconciliation or rollout failures:
+
+kubectl logs -n mariadb-system deploy/mariadb-operator --tail=200
+kubectl logs -n mariadb-system deploy/mariadb-operator-webhook --tail=200
+kubectl get events -A --sort-by=.lastTimestamp | tail -n 50
+
+Troubleshooting
+
+Common Failure Signal
+
+If the upgrade stalls with webhook validation errors, cert validation loops, or replication threads failing to rejoin after a hop, stop and do not continue to the next version until the current hop is healthy.
+
+Rollback
+
+Stop at the current hop, keep the CRDs in place, restore the previous known-good chart version in /etc/genestack/helm-chart-versions.yaml, and rerun:
+
+/opt/genestack/bin/install-mariadb-operator.sh
+
+Additional Recovery Actions
+
+If the webhook blocks patches because the stored MariaDB CR still contains old values such as syncBinlog: true:
+
+kubectl scale deployment mariadb-operator -n mariadb-system --replicas=0
+kubectl scale deployment mariadb-operator-webhook -n mariadb-system --replicas=0
+kubectl delete validatingwebhookconfiguration mariadb-operator-webhook
+kubectl delete mutatingwebhookconfiguration mariadb-operator-webhook 2>/dev/null || true
+
+If operator pods are stuck in a Validating certs loop:
+
+kubectl get certificate -n mariadb-system
+kubectl delete secret mariadb-operator-webhook-cert -n mariadb-system
+kubectl delete deployment mariadb-operator-webhook -n mariadb-system
+/opt/genestack/bin/install-mariadb-operator.sh
+
+Sources
+
+https://github.com/mariadb-operator/mariadb-operator/releases/tag/0.37.1
+https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_0.37.1.md
+https://github.com/mariadb-operator/mariadb-operator/releases/tag/0.38.1
+https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_0.38.0.md
+https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_0.38.1.md
+https://github.com/mariadb-operator/mariadb-operator/releases/tag/25.8.1
+https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_25.08.0.md
+https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_25.8.1.md
+https://github.com/mariadb-operator/mariadb-operator/releases/tag/26.3.0

--- a/maintenances/maintenance-mariadb-operator-replication-0.37.1-to-0.38.1.txt
+++ b/maintenances/maintenance-mariadb-operator-replication-0.37.1-to-0.38.1.txt
@@ -1,0 +1,156 @@
+MariaDB Operator Replication Maintenance: 0.37.1 to 0.38.1
+
+Validation
+
+This maintenance upgrades the MariaDB Operator for a primary/replica MariaDB cluster from 0.37.1 to 0.38.1.
+Skip 0.38.0 and upgrade directly to 0.38.1.
+Never delete MariaDB CRDs during this maintenance.
+
+Major operational risks:
+- Deleting MariaDB CRDs will remove the MariaDB pods.
+- Replication must be revalidated after the operator hop.
+- This pre-25.10 replication hop is operational guidance inferred from the staged upgrade path and local release history, not from upstream GA replication runbooks. Validate it in a non-production environment first.
+
+Goal
+
+Upgrade the MariaDB Operator from 0.37.1 to 0.38.1 for a primary/replica cluster and restore healthy replication.
+
+Prep
+
+Deployment Node
+
+Verify current versions and target availability:
+
+helm list -A | grep mariadb
+helm status mariadb-operator -n mariadb-system
+helm repo update mariadb-operator
+helm search repo mariadb-operator/mariadb-operator --versions | head -20
+
+Expected:
+- The current version is 0.37.1.
+- The target version is 0.38.1.
+
+Retrieve the MariaDB root password and current primary, verify replication health, and create a backup:
+
+export MARIADB_ROOT_PASSWORD=$(kubectl get secret mariadb -n openstack \
+  -o jsonpath='{.data.root-password}' | base64 -d)
+export PRIMARY_POD=$(kubectl get mariadb mariadb-cluster -n openstack -o jsonpath="{.status.currentPrimary}")
+kubectl exec -it mariadb-cluster-1 -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW REPLICA STATUS\G"
+kubectl exec -i "$PRIMARY_POD" -n openstack -- mariadb-dump \
+  -u root -p"$MARIADB_ROOT_PASSWORD" --all-databases --single-transaction \
+  --routines --triggers > mariadb-cluster-full-backup-$(date +%Y%m%d-%H%M).sql
+ls -lh mariadb-cluster-full-backup-*.sql | tail -1
+
+Execute
+
+Update the Target Version
+
+Edit /etc/genestack/helm-chart-versions.yaml:
+
+mariadb-operator: 0.38.1
+
+Apply Required Overrides or Patches
+
+Update the MariaDB image for 0.38.1 compatibility, enable autoUpdateDataPlane: true, and apply:
+
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+Run the Maintenance
+
+kubectl scale deployment mariadb-operator -n mariadb-system --replicas=0
+kubectl scale deployment mariadb-operator-webhook -n mariadb-system --replicas=0
+kubectl delete validatingwebhookconfiguration mariadb-operator-webhook
+kubectl delete mutatingwebhookconfiguration mariadb-operator-webhook 2>/dev/null || true
+helm uninstall mariadb-operator -n mariadb-system
+/opt/genestack/bin/install-mariadb-operator.sh
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+export MARIADB_NAME=mariadb-cluster
+export MARIADB_NAMESPACE=openstack
+cat >/tmp/migrate-replication.sh <<'EOF'
+#!/bin/bash
+
+set -eo pipefail
+
+if [[ -z "$MARIADB_NAME" || -z "$MARIADB_NAMESPACE" || -z "$MARIADB_ROOT_PASSWORD" ]]; then
+  echo "Error: MARIADB_NAME, MARIADB_NAMESPACE and MARIADB_ROOT_PASSWORD env vars must be set."
+  exit 1
+fi
+
+function exec_sql {
+  local pod=$1
+  local sql=$2
+  kubectl exec -n "$MARIADB_NAMESPACE" "$pod" -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "$sql"
+}
+
+function wait_for_ready_replication {
+  local pod=$1
+  local timeout=300
+  local interval=10
+  local elapsed=0
+
+  while [[ $elapsed -lt $timeout ]]; do
+    exec_sql "$pod" "SHOW REPLICA STATUS\\G" | tee /tmp/replication_status_$pod_$MARIADB_NAMESPACE.txt
+
+    if grep -q "Slave_IO_Running: Yes" /tmp/replication_status_$pod_$MARIADB_NAMESPACE.txt && \
+       grep -q "Slave_SQL_Running: Yes" /tmp/replication_status_$pod_$MARIADB_NAMESPACE.txt; then
+      return 0
+    fi
+
+    sleep $interval
+    ((elapsed+=interval))
+  done
+
+  echo "Error: Replication did not become ready on $pod within 5 minutes."
+  exit 1
+}
+
+PODS=$(kubectl get pods -n "$MARIADB_NAMESPACE" \
+  -l app.kubernetes.io/instance=$MARIADB_NAME \
+  -o jsonpath="{.items[*].metadata.name}")
+PRIMARY_POD=$(kubectl get mariadb "$MARIADB_NAME" -n "$MARIADB_NAMESPACE" \
+  -o jsonpath="{.status.currentPrimary}")
+
+for POD in $PODS; do
+  if [[ "$POD" == "$PRIMARY_POD" ]]; then
+    continue
+  fi
+
+  exec_sql "$POD" "STOP SLAVE 'mariadb-operator';"
+  exec_sql "$POD" "RESET SLAVE 'mariadb-operator' ALL;"
+  kubectl delete pod "$POD" -n "$MARIADB_NAMESPACE"
+  kubectl wait --for=condition=Ready pod/"$POD" -n "$MARIADB_NAMESPACE" --timeout=5m
+  wait_for_ready_replication "$POD"
+done
+EOF
+chmod +x /tmp/migrate-replication.sh
+/tmp/migrate-replication.sh
+
+Post-Maint
+
+Verify the release and replication health:
+
+helm list -A | grep mariadb
+kubectl get pods -n mariadb-system -o wide
+kubectl get pods -n openstack | grep mariadb
+kubectl exec -it mariadb-cluster-1 -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW REPLICA STATUS\G"
+
+Expected:
+- The operator version is 0.38.1.
+- Slave_IO_Running: Yes
+- Slave_SQL_Running: Yes
+
+Troubleshooting
+
+Rollback
+
+Restore the previous chart version in /etc/genestack/helm-chart-versions.yaml and rerun:
+
+/opt/genestack/bin/install-mariadb-operator.sh
+
+Sources
+
+https://github.com/mariadb-operator/mariadb-operator/releases/tag/0.38.1
+https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_0.38.0.md
+https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_0.38.1.md

--- a/maintenances/maintenance-mariadb-operator-replication-0.38.1-to-25.8.4.txt
+++ b/maintenances/maintenance-mariadb-operator-replication-0.38.1-to-25.8.4.txt
@@ -1,0 +1,174 @@
+MariaDB Operator Replication Maintenance: 0.38.1 to 25.8.4
+
+Validation
+
+This maintenance upgrades the MariaDB Operator for a primary/replica MariaDB cluster from 0.38.1 to 25.8.4.
+Do not step through every 25.8.x patch. Upgrade directly to 25.8.4.
+Confirm Kubernetes version compatibility against the upstream chart metadata before this hop.
+Never delete MariaDB CRDs during this maintenance.
+
+Major operational risks:
+- Deleting MariaDB CRDs will remove the MariaDB pods.
+- Replication must be revalidated after the operator hop.
+- A webhook certificate validation loop can block reconciliation after the hop.
+- This pre-25.10 replication hop is operational guidance inferred from the staged upgrade path and local release history, not from upstream GA replication runbooks. Validate it in a non-production environment first.
+
+Goal
+
+Upgrade the MariaDB Operator from 0.38.1 to 25.8.4 for a primary/replica cluster and restore healthy replication.
+
+Prep
+
+Deployment Node
+
+Verify current versions, target availability, and Kubernetes level:
+
+helm list -A | grep mariadb
+helm status mariadb-operator -n mariadb-system
+helm repo update mariadb-operator
+helm search repo mariadb-operator/mariadb-operator --versions | head -20
+kubectl version
+
+Expected:
+- The current version is 0.38.1.
+- The target version is 25.8.4.
+- Kubernetes version compatibility has been confirmed against the upstream chart metadata.
+
+Retrieve the MariaDB root password and current primary, verify replication health, and create a backup:
+
+export MARIADB_ROOT_PASSWORD=$(kubectl get secret mariadb -n openstack \
+  -o jsonpath='{.data.root-password}' | base64 -d)
+export PRIMARY_POD=$(kubectl get mariadb mariadb-cluster -n openstack -o jsonpath="{.status.currentPrimary}")
+kubectl exec -it mariadb-cluster-1 -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW REPLICA STATUS\G"
+kubectl exec -i "$PRIMARY_POD" -n openstack -- mariadb-dump \
+  -u root -p"$MARIADB_ROOT_PASSWORD" --all-databases --single-transaction \
+  --routines --triggers > mariadb-cluster-full-backup-$(date +%Y%m%d-%H%M).sql
+ls -lh mariadb-cluster-full-backup-*.sql | tail -1
+
+Execute
+
+Update the Target Version
+
+Edit /etc/genestack/helm-chart-versions.yaml:
+
+mariadb-operator: 25.8.4
+
+Apply Required Overrides or Patches
+
+Update the MariaDB image for 25.8.4 compatibility, enable autoUpdateDataPlane: true, and apply:
+
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+Run the Maintenance
+
+kubectl scale deployment mariadb-operator -n mariadb-system --replicas=0
+kubectl scale deployment mariadb-operator-webhook -n mariadb-system --replicas=0
+kubectl delete validatingwebhookconfiguration mariadb-operator-webhook
+kubectl delete mutatingwebhookconfiguration mariadb-operator-webhook 2>/dev/null || true
+helm uninstall mariadb-operator -n mariadb-system
+/opt/genestack/bin/install-mariadb-operator.sh
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+If operator pods are stuck in a Validating certs loop, recover before continuing:
+
+kubectl get certificate -n mariadb-system
+kubectl delete secret mariadb-operator-webhook-cert -n mariadb-system
+kubectl delete deployment mariadb-operator-webhook -n mariadb-system
+/opt/genestack/bin/install-mariadb-operator.sh
+
+Run the replication migration after the hop:
+
+export MARIADB_NAME=mariadb-cluster
+export MARIADB_NAMESPACE=openstack
+cat >/tmp/migrate-replication.sh <<'EOF'
+#!/bin/bash
+
+set -eo pipefail
+
+if [[ -z "$MARIADB_NAME" || -z "$MARIADB_NAMESPACE" || -z "$MARIADB_ROOT_PASSWORD" ]]; then
+  echo "Error: MARIADB_NAME, MARIADB_NAMESPACE and MARIADB_ROOT_PASSWORD env vars must be set."
+  exit 1
+fi
+
+function exec_sql {
+  local pod=$1
+  local sql=$2
+  kubectl exec -n "$MARIADB_NAMESPACE" "$pod" -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "$sql"
+}
+
+function wait_for_ready_replication {
+  local pod=$1
+  local timeout=300
+  local interval=10
+  local elapsed=0
+
+  while [[ $elapsed -lt $timeout ]]; do
+    exec_sql "$pod" "SHOW REPLICA STATUS\\G" | tee /tmp/replication_status_$pod_$MARIADB_NAMESPACE.txt
+
+    if grep -q "Slave_IO_Running: Yes" /tmp/replication_status_$pod_$MARIADB_NAMESPACE.txt && \
+       grep -q "Slave_SQL_Running: Yes" /tmp/replication_status_$pod_$MARIADB_NAMESPACE.txt; then
+      return 0
+    fi
+
+    sleep $interval
+    ((elapsed+=interval))
+  done
+
+  echo "Error: Replication did not become ready on $pod within 5 minutes."
+  exit 1
+}
+
+PODS=$(kubectl get pods -n "$MARIADB_NAMESPACE" \
+  -l app.kubernetes.io/instance=$MARIADB_NAME \
+  -o jsonpath="{.items[*].metadata.name}")
+PRIMARY_POD=$(kubectl get mariadb "$MARIADB_NAME" -n "$MARIADB_NAMESPACE" \
+  -o jsonpath="{.status.currentPrimary}")
+
+for POD in $PODS; do
+  if [[ "$POD" == "$PRIMARY_POD" ]]; then
+    continue
+  fi
+
+  exec_sql "$POD" "STOP SLAVE 'mariadb-operator';"
+  exec_sql "$POD" "RESET SLAVE 'mariadb-operator' ALL;"
+  kubectl delete pod "$POD" -n "$MARIADB_NAMESPACE"
+  kubectl wait --for=condition=Ready pod/"$POD" -n "$MARIADB_NAMESPACE" --timeout=5m
+  wait_for_ready_replication "$POD"
+done
+EOF
+chmod +x /tmp/migrate-replication.sh
+/tmp/migrate-replication.sh
+
+Post-Maint
+
+Verify the release and replication health:
+
+helm list -A | grep mariadb
+kubectl get pods -n mariadb-system -o wide
+kubectl get pods -n openstack | grep mariadb
+kubectl exec -it mariadb-cluster-1 -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW REPLICA STATUS\G"
+
+Expected:
+- The operator version is 25.8.4.
+- Slave_IO_Running: Yes
+- Slave_SQL_Running: Yes
+
+Troubleshooting
+
+Common Failure Signal
+
+If the operator logs are stuck on Validating certs, stop and repair the webhook cert before continuing.
+
+Rollback
+
+Restore the previous chart version in /etc/genestack/helm-chart-versions.yaml and rerun:
+
+/opt/genestack/bin/install-mariadb-operator.sh
+
+Sources
+
+https://github.com/mariadb-operator/mariadb-operator/releases/tag/25.8.1
+https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_25.08.0.md
+https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_25.8.1.md

--- a/maintenances/maintenance-mariadb-operator-replication-25.10.4-to-26.3.0.txt
+++ b/maintenances/maintenance-mariadb-operator-replication-25.10.4-to-26.3.0.txt
@@ -1,0 +1,175 @@
+MariaDB Operator Replication Maintenance: 25.10.4 to 26.3.0
+
+Validation
+
+This maintenance upgrades the MariaDB Operator for a primary/replica MariaDB cluster from 25.10.4 to 26.3.0.
+Never delete MariaDB CRDs during this maintenance.
+
+Major operational risks:
+- Deleting MariaDB CRDs will remove the MariaDB pods.
+- The 25.x replication line changed syncBinlog from boolean to integer, and the 26.3.0 webhook can reject legacy syncBinlog: true values until the MariaDB CR is patched to syncBinlog: 1.
+- The 26.3.0 Helm overrides require the 26.3.0 image schema for maxscaleImage, exporterImage, and exporterMaxscaleImage.
+- Replication must be revalidated after the operator hop.
+
+Goal
+
+Upgrade the MariaDB Operator from 25.10.4 to 26.3.0 for a primary/replica cluster and restore healthy replication.
+
+Prep
+
+Deployment Node
+
+Verify current versions, target availability, and override format:
+
+helm list -A | grep mariadb
+helm status mariadb-operator -n mariadb-system
+helm repo update mariadb-operator
+helm search repo mariadb-operator/mariadb-operator --versions | head -20
+grep -n "mariadbImageName\\|mariadbImage:\\|maxscaleImage\\|exporterImage\\|exporterMaxscaleImage" \
+  /etc/genestack/helm-configs/mariadb-operator/mariadb-operator-helm-overrides.yaml
+
+Expected:
+- The current version is 25.10.4.
+- The target version is 26.3.0.
+- The override file has been reviewed against the 26.3.0 image schema where required.
+
+Retrieve the MariaDB root password and current primary, verify replication health, and create a backup:
+
+export MARIADB_ROOT_PASSWORD=$(kubectl get secret mariadb -n openstack \
+  -o jsonpath='{.data.root-password}' | base64 -d)
+export PRIMARY_POD=$(kubectl get mariadb mariadb-cluster -n openstack -o jsonpath="{.status.currentPrimary}")
+kubectl exec -it mariadb-cluster-1 -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW REPLICA STATUS\G"
+kubectl exec -i "$PRIMARY_POD" -n openstack -- mariadb-dump \
+  -u root -p"$MARIADB_ROOT_PASSWORD" --all-databases --single-transaction \
+  --routines --triggers > mariadb-cluster-full-backup-$(date +%Y%m%d-%H%M).sql
+ls -lh mariadb-cluster-full-backup-*.sql | tail -1
+
+Execute
+
+Update the Target Version
+
+Edit /etc/genestack/helm-chart-versions.yaml:
+
+mariadb-operator: 26.3.0
+
+Apply Required Overrides or Patches
+
+Update the MariaDB image for 26.3.0 compatibility, verify the 26.3.0 image schema in /etc/genestack/helm-configs/mariadb-operator/mariadb-operator-helm-overrides.yaml, patch syncBinlog if the CR still stores the old boolean value, enable autoUpdateDataPlane: true, and apply:
+
+kubectl delete validatingwebhookconfiguration mariadb-operator-webhook
+kubectl -n openstack patch mariadb mariadb-cluster --type merge \
+  -p '{"spec":{"replication":{"syncBinlog":1}}}'
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+Run the Maintenance
+
+kubectl scale deployment mariadb-operator -n mariadb-system --replicas=0
+kubectl scale deployment mariadb-operator-webhook -n mariadb-system --replicas=0
+kubectl delete validatingwebhookconfiguration mariadb-operator-webhook
+kubectl delete mutatingwebhookconfiguration mariadb-operator-webhook 2>/dev/null || true
+helm uninstall mariadb-operator -n mariadb-system
+/opt/genestack/bin/install-mariadb-operator.sh
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+export MARIADB_NAME=mariadb-cluster
+export MARIADB_NAMESPACE=openstack
+cat >/tmp/migrate-replication.sh <<'EOF'
+#!/bin/bash
+
+set -eo pipefail
+
+if [[ -z "$MARIADB_NAME" || -z "$MARIADB_NAMESPACE" || -z "$MARIADB_ROOT_PASSWORD" ]]; then
+  echo "Error: MARIADB_NAME, MARIADB_NAMESPACE and MARIADB_ROOT_PASSWORD env vars must be set."
+  exit 1
+fi
+
+function exec_sql {
+  local pod=$1
+  local sql=$2
+  kubectl exec -n "$MARIADB_NAMESPACE" "$pod" -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "$sql"
+}
+
+function wait_for_ready_replication {
+  local pod=$1
+  local timeout=300
+  local interval=10
+  local elapsed=0
+
+  while [[ $elapsed -lt $timeout ]]; do
+    exec_sql "$pod" "SHOW REPLICA STATUS\\G" | tee /tmp/replication_status_$pod_$MARIADB_NAMESPACE.txt
+
+    if grep -q "Slave_IO_Running: Yes" /tmp/replication_status_$pod_$MARIADB_NAMESPACE.txt && \
+       grep -q "Slave_SQL_Running: Yes" /tmp/replication_status_$pod_$MARIADB_NAMESPACE.txt; then
+      return 0
+    fi
+
+    sleep $interval
+    ((elapsed+=interval))
+  done
+
+  echo "Error: Replication did not become ready on $pod within 5 minutes."
+  exit 1
+}
+
+PODS=$(kubectl get pods -n "$MARIADB_NAMESPACE" \
+  -l app.kubernetes.io/instance=$MARIADB_NAME \
+  -o jsonpath="{.items[*].metadata.name}")
+PRIMARY_POD=$(kubectl get mariadb "$MARIADB_NAME" -n "$MARIADB_NAMESPACE" \
+  -o jsonpath="{.status.currentPrimary}")
+
+for POD in $PODS; do
+  if [[ "$POD" == "$PRIMARY_POD" ]]; then
+    continue
+  fi
+
+  exec_sql "$POD" "STOP SLAVE 'mariadb-operator';"
+  exec_sql "$POD" "RESET SLAVE 'mariadb-operator' ALL;"
+  kubectl delete pod "$POD" -n "$MARIADB_NAMESPACE"
+  kubectl wait --for=condition=Ready pod/"$POD" -n "$MARIADB_NAMESPACE" --timeout=5m
+  wait_for_ready_replication "$POD"
+done
+EOF
+chmod +x /tmp/migrate-replication.sh
+/tmp/migrate-replication.sh
+
+Post-Maint
+
+Verify the release, new CRD, and replication health:
+
+helm list -A | grep mariadb
+kubectl get crd pointintimerecoveries.k8s.mariadb.com
+kubectl get pods -n mariadb-system -o wide
+kubectl get pods -n openstack | grep mariadb
+kubectl exec -it mariadb-cluster-1 -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW REPLICA STATUS\G"
+
+Expected:
+- The operator version is 26.3.0.
+- pointintimerecoveries.k8s.mariadb.com exists.
+- Slave_IO_Running: Yes
+- Slave_SQL_Running: Yes
+
+Troubleshooting
+
+Common Failure Signal
+
+If the webhook rejects MariaDB CR updates after the hop, stop and confirm syncBinlog has been converted from the older boolean form to the newer integer form.
+
+Rollback
+
+Restore the previous chart version in /etc/genestack/helm-chart-versions.yaml and rerun:
+
+/opt/genestack/bin/install-mariadb-operator.sh
+
+Additional Recovery Actions
+
+If replication threads remain stuck after the migration:
+
+kubectl exec -it mariadb-cluster-1 -n openstack -- mariadb \
+  -u root -p"$MARIADB_ROOT_PASSWORD" -e "SHOW PROCESSLIST;"
+kubectl exec -it mariadb-cluster-1 -n openstack -- mariadb \
+  -u root -p"$MARIADB_ROOT_PASSWORD" -e "KILL <thread_id>;"
+
+Sources
+
+https://github.com/mariadb-operator/mariadb-operator/releases/tag/26.3.0

--- a/maintenances/maintenance-mariadb-operator-replication-25.8.4-to-25.10.4.txt
+++ b/maintenances/maintenance-mariadb-operator-replication-25.8.4-to-25.10.4.txt
@@ -1,0 +1,155 @@
+MariaDB Operator Replication Maintenance: 25.8.4 to 25.10.4
+
+Validation
+
+This maintenance upgrades the MariaDB Operator for a primary/replica MariaDB cluster from 25.8.4 to 25.10.4.
+Do not step through every 25.10.x patch. Upgrade directly to 25.10.4.
+Never delete MariaDB CRDs during this maintenance.
+
+Major operational risks:
+- Deleting MariaDB CRDs will remove the MariaDB pods.
+- Replication must be revalidated after the operator hop.
+
+Goal
+
+Upgrade the MariaDB Operator from 25.8.4 to 25.10.4 for a primary/replica cluster and restore healthy replication.
+
+Prep
+
+Deployment Node
+
+Verify current versions and target availability:
+
+helm list -A | grep mariadb
+helm status mariadb-operator -n mariadb-system
+helm repo update mariadb-operator
+helm search repo mariadb-operator/mariadb-operator --versions | head -20
+
+Expected:
+- The current version is 25.8.4.
+- The target version is 25.10.4.
+
+Retrieve the MariaDB root password and current primary, verify replication health, and create a backup:
+
+export MARIADB_ROOT_PASSWORD=$(kubectl get secret mariadb -n openstack \
+  -o jsonpath='{.data.root-password}' | base64 -d)
+export PRIMARY_POD=$(kubectl get mariadb mariadb-cluster -n openstack -o jsonpath="{.status.currentPrimary}")
+kubectl exec -it mariadb-cluster-1 -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW REPLICA STATUS\G"
+kubectl exec -i "$PRIMARY_POD" -n openstack -- mariadb-dump \
+  -u root -p"$MARIADB_ROOT_PASSWORD" --all-databases --single-transaction \
+  --routines --triggers > mariadb-cluster-full-backup-$(date +%Y%m%d-%H%M).sql
+ls -lh mariadb-cluster-full-backup-*.sql | tail -1
+
+Execute
+
+Update the Target Version
+
+Edit /etc/genestack/helm-chart-versions.yaml:
+
+mariadb-operator: 25.10.4
+
+Apply Required Overrides or Patches
+
+Update the MariaDB image for 25.10.4 compatibility, enable autoUpdateDataPlane: true, and apply:
+
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+
+Run the Maintenance
+
+kubectl scale deployment mariadb-operator -n mariadb-system --replicas=0
+kubectl scale deployment mariadb-operator-webhook -n mariadb-system --replicas=0
+kubectl delete validatingwebhookconfiguration mariadb-operator-webhook
+kubectl delete mutatingwebhookconfiguration mariadb-operator-webhook 2>/dev/null || true
+helm uninstall mariadb-operator -n mariadb-system
+/opt/genestack/bin/install-mariadb-operator.sh
+kubectl --namespace openstack apply -k /etc/genestack/kustomize/mariadb-cluster/overlay
+export MARIADB_NAME=mariadb-cluster
+export MARIADB_NAMESPACE=openstack
+cat >/tmp/migrate-replication.sh <<'EOF'
+#!/bin/bash
+
+set -eo pipefail
+
+if [[ -z "$MARIADB_NAME" || -z "$MARIADB_NAMESPACE" || -z "$MARIADB_ROOT_PASSWORD" ]]; then
+  echo "Error: MARIADB_NAME, MARIADB_NAMESPACE and MARIADB_ROOT_PASSWORD env vars must be set."
+  exit 1
+fi
+
+function exec_sql {
+  local pod=$1
+  local sql=$2
+  kubectl exec -n "$MARIADB_NAMESPACE" "$pod" -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "$sql"
+}
+
+function wait_for_ready_replication {
+  local pod=$1
+  local timeout=300
+  local interval=10
+  local elapsed=0
+
+  while [[ $elapsed -lt $timeout ]]; do
+    exec_sql "$pod" "SHOW REPLICA STATUS\\G" | tee /tmp/replication_status_$pod_$MARIADB_NAMESPACE.txt
+
+    if grep -q "Slave_IO_Running: Yes" /tmp/replication_status_$pod_$MARIADB_NAMESPACE.txt && \
+       grep -q "Slave_SQL_Running: Yes" /tmp/replication_status_$pod_$MARIADB_NAMESPACE.txt; then
+      return 0
+    fi
+
+    sleep $interval
+    ((elapsed+=interval))
+  done
+
+  echo "Error: Replication did not become ready on $pod within 5 minutes."
+  exit 1
+}
+
+PODS=$(kubectl get pods -n "$MARIADB_NAMESPACE" \
+  -l app.kubernetes.io/instance=$MARIADB_NAME \
+  -o jsonpath="{.items[*].metadata.name}")
+PRIMARY_POD=$(kubectl get mariadb "$MARIADB_NAME" -n "$MARIADB_NAMESPACE" \
+  -o jsonpath="{.status.currentPrimary}")
+
+for POD in $PODS; do
+  if [[ "$POD" == "$PRIMARY_POD" ]]; then
+    continue
+  fi
+
+  exec_sql "$POD" "STOP SLAVE 'mariadb-operator';"
+  exec_sql "$POD" "RESET SLAVE 'mariadb-operator' ALL;"
+  kubectl delete pod "$POD" -n "$MARIADB_NAMESPACE"
+  kubectl wait --for=condition=Ready pod/"$POD" -n "$MARIADB_NAMESPACE" --timeout=5m
+  wait_for_ready_replication "$POD"
+done
+EOF
+chmod +x /tmp/migrate-replication.sh
+/tmp/migrate-replication.sh
+
+Post-Maint
+
+Verify the release, CRs, and replication health:
+
+helm list -A | grep mariadb
+kubectl get mariadb -n openstack -o yaml | grep -B1 autoFailover
+kubectl get pods -n mariadb-system -o wide
+kubectl get pods -n openstack | grep mariadb
+kubectl exec -it mariadb-cluster-1 -n openstack -- mariadb -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+SHOW REPLICA STATUS\G"
+
+Expected:
+- The operator version is 25.10.4.
+- autoFailover is present in the MariaDB CR output.
+- Slave_IO_Running: Yes
+- Slave_SQL_Running: Yes
+
+Troubleshooting
+
+Rollback
+
+Restore the previous chart version in /etc/genestack/helm-chart-versions.yaml and rerun:
+
+/opt/genestack/bin/install-mariadb-operator.sh
+
+Sources
+
+https://github.com/mariadb-operator/mariadb-operator/releases/tag/25.8.1


### PR DESCRIPTION
Convert the MariaDB operator upgrade guidance into maintenance runbooks, split by topology and by required version hop. 