### PR TITLE
feat(neutron): update to Epoxy 2025.1 with OVN and firewall_v2 support

### DIFF
--- a/base-helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/base-helm-configs/neutron/neutron-helm-overrides.yaml
@@ -1,33 +1,33 @@
 ---
 images:
   tags:
-    bootstrap: "ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest"
-    db_init: "ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest"
-    db_drop: "ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest"
-    ks_user: "ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest"
-    ks_service: "ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest"
-    ks_endpoints: "ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest"
-    neutron_db_sync: "ghcr.io/rackerlabs/genestack-images/neutron:2024.1-latest"
-    neutron_dhcp: "ghcr.io/rackerlabs/genestack-images/neutron:2024.1-latest"
-    neutron_l3: "ghcr.io/rackerlabs/genestack-images/neutron:2024.1-latest"
-    neutron_l2gw: "ghcr.io/rackerlabs/genestack-images/neutron:2024.1-latest"
-    neutron_linuxbridge_agent: "ghcr.io/rackerlabs/genestack-images/neutron:2024.1-latest"
-    neutron_metadata: "ghcr.io/rackerlabs/genestack-images/neutron:2024.1-latest"
-    neutron_ovn_metadata: "ghcr.io/rackerlabs/genestack-images/neutron:2024.1-latest"
-    neutron_ovn_vpn: "ghcr.io/rackerlabs/genestack-images/neutron:2024.1-latest"
-    neutron_openvswitch_agent: "ghcr.io/rackerlabs/genestack-images/neutron:2024.1-latest"
-    neutron_server: "ghcr.io/rackerlabs/genestack-images/neutron:2024.1-latest"
-    neutron_rpc_server: "ghcr.io/rackerlabs/genestack-images/neutron:2024.1-latest"
-    neutron_bagpipe_bgp: "ghcr.io/rackerlabs/genestack-images/neutron:2024.1-latest"
-    neutron_netns_cleanup_cron: "ghcr.io/rackerlabs/genestack-images/neutron:2024.1-latest"
+    bootstrap: "ghcr.io/rackerlabs/genestack-images/openstack-client:latest"
+    db_init: "ghcr.io/rackerlabs/genestack-images/openstack-client:latest"
+    db_drop: "ghcr.io/rackerlabs/genestack-images/openstack-client:latest"
+    ks_user: "ghcr.io/rackerlabs/genestack-images/openstack-client:latest"
+    ks_service: "ghcr.io/rackerlabs/genestack-images/openstack-client:latest"
+    ks_endpoints: "ghcr.io/rackerlabs/genestack-images/openstack-client:latest"
+    neutron_db_sync: "ghcr.io/rackerlabs/genestack-images/neutron:2025.1-latest"
+    neutron_dhcp: "ghcr.io/rackerlabs/genestack-images/neutron:2025.1-latest"
+    neutron_l3: "ghcr.io/rackerlabs/genestack-images/neutron:2025.1-latest"
+    neutron_l2gw: "ghcr.io/rackerlabs/genestack-images/neutron:2025.1-latest"
+    neutron_linuxbridge_agent: "ghcr.io/rackerlabs/genestack-images/neutron:2025.1-latest"
+    neutron_metadata: "ghcr.io/rackerlabs/genestack-images/neutron:2025.1-latest"
+    neutron_ovn_metadata: "ghcr.io/rackerlabs/genestack-images/neutron:2025.1-latest"
+    neutron_ovn_vpn: "ghcr.io/rackerlabs/genestack-images/neutron:2025.1-latest"
+    neutron_openvswitch_agent: "ghcr.io/rackerlabs/genestack-images/neutron:2025.1-latest"
+    neutron_server: "ghcr.io/rackerlabs/genestack-images/neutron:2025.1-latest"
+    neutron_rpc_server: "ghcr.io/rackerlabs/genestack-images/neutron:2025.1-latest"
+    neutron_bagpipe_bgp: "ghcr.io/rackerlabs/genestack-images/neutron:2025.1-latest"
+    neutron_netns_cleanup_cron: "ghcr.io/rackerlabs/genestack-images/neutron:2025.1-latest"
     test: null
     purge_test: "quay.io/rackspace/rackerlabs-ospurge:latest"
     rabbit_init: null
     netoffload: null
-    neutron_sriov_agent: "ghcr.io/rackerlabs/genestack-images/neutron:2024.1-latest"
-    neutron_sriov_agent_init: "ghcr.io/rackerlabs/genestack-images/neutron:2024.1-latest"
-    neutron_bgp_dragent: "ghcr.io/rackerlabs/genestack-images/neutron:2024.1-latest"
-    neutron_ironic_agent: "ghcr.io/rackerlabs/genestack-images/neutron:2024.1-latest"
+    neutron_sriov_agent: "ghcr.io/rackerlabs/genestack-images/neutron:2025.1-latest"
+    neutron_sriov_agent_init: "ghcr.io/rackerlabs/genestack-images/neutron:2025.1-latest"
+    neutron_bgp_dragent: "ghcr.io/rackerlabs/genestack-images/neutron:2025.1-latest"
+    neutron_ironic_agent: "ghcr.io/rackerlabs/genestack-images/neutron:2025.1-latest"
     dep_check: "ghcr.io/rackerlabs/genestack-images/kubernetes-entrypoint:latest"
     image_repo_sync: null
 
@@ -193,8 +193,7 @@ conf:
       router_scheduler_driver: neutron.scheduler.l3_agent_scheduler.AZLeastRoutersScheduler
       rpc_state_report_workers: 2
       rpc_workers: 2
-      # NOTE(cloudnull): in 2025.1 we can add firewall_v2
-      service_plugins: "ovn-router,ovn-vpnaas,qos,metering,trunk,segments"
+      service_plugins: "ovn-router,ovn-vpnaas,qos,metering,trunk,segments,firewall_v2"
     cache:
       enabled: true
       backend: dogpile.cache.memcached
@@ -203,12 +202,11 @@ conf:
         type: multistring
         values:
           - "VPN:strongswan:neutron_vpnaas.services.vpn.service_drivers.ovn_ipsec.IPsecOvnVPNDriver:default"
-          # - "FIREWALL_V2:fwaas_db:neutron_fwaas.services.firewall.service_drivers.ovn.firewall_l3_driver.OVNFwaasDriver:default"
+          - "FIREWALL_V2:fwaas_db:neutron_fwaas.services.firewall.service_drivers.ovn.firewall_l3_driver.OVNFwaasDriver:default"
     fwaas:
       agent_version: v2
       driver: neutron_fwaas.services.firewall.service_drivers.ovn.firewall_l3_driver.OVNFwaasDriver
-      # NOTE(cloudnull): in 2025.1 we can enable this
-      enabled: false
+      enabled: true
     agent:
       extensions: vpnaas,metadata
       availability_zone: az1
@@ -293,12 +291,10 @@ conf:
     ml2_conf:
       agent:
         availability_zone: az1
-        # NOTE(cloudnull): in 2025.1 we can add fwaas_v2
-        extensions: "fip_qos,gateway_ip_qos"
-      fwaas:
-        firewall_l2_driver: noop
+        # NOTE(cloudnull): in 2025.1 we can enable fwaas_v2
+        enabled: true
       ml2:
-        extension_drivers: "port_security,qos"
+        extension_drivers: "port_security,qos,fwaas_v2"
         mechanism_drivers: ovn
         tenant_network_types: geneve
         type_drivers: "flat,vlan,geneve"
@@ -403,6 +399,7 @@ manifests:
   pod_rally_test: false
   secret_db: false
   secret_ingress_tls: false
+  secret_keystone: false
   secret_rabbitmq: false
   service_ingress_server: false
   deployment_rpc_server: false

--- a/bin/create-secrets.sh
+++ b/bin/create-secrets.sh
@@ -88,6 +88,10 @@ designate_rabbitmq_password=$(generate_password 64)
 neutron_rabbitmq_password=$(generate_password 64)
 neutron_db_password=$(generate_password 32)
 neutron_admin_password=$(generate_password 32)
+neutron_keystone_nova=$(generate_password 32)
+neutron_keystone_placement=$(generate_password 32)
+neutron_keystone_designate=$(generate_password 32)
+neutron_keystone_ironic=$(generate_password 32)
 neutron_keystone_test_password=$(generate_password 32)
 horizon_secret_key=$(generate_password 64)
 horizon_db_password=$(generate_password 32)
@@ -575,6 +579,42 @@ metadata:
 type: Opaque
 data:
   password: $(echo -n $neutron_admin_password | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: neutron-keystone-nova
+  namespace: openstack
+type: Opaque
+data:
+  password: $(echo -n $neutron_keystone_nova | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: neutron-keystone-placement
+  namespace: openstack
+type: Opaque
+data:
+  password: $(echo -n $neutron_keystone_placement | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: neutron-keystone-designate
+  namespace: openstack
+type: Opaque
+data:
+  password: $(echo -n $neutron_keystone_designate | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: neutron-keystone-ironic
+  namespace: openstack
+type: Opaque
+data:
+  password: $(echo -n $neutron_keystone_ironic | base64 -w0)
 ---
 apiVersion: v1
 kind: Secret

--- a/bin/install-neutron.sh
+++ b/bin/install-neutron.sh
@@ -184,6 +184,11 @@ helm_command=(
     "$@"
 )
 
+# Create the neutron-keystone-admin secret by copying the keystone-keystone-admin secret and replacing 'keystone' with 'neutron' in the name and data keys.
+kubectl --namespace openstack get secrets keystone-keystone-admin -o yaml | \
+  sed -e '/keystone/{s/keystone/neutron/}' | \
+    kubectl --namespace openstack apply --force -f -
+
 echo "Executing Helm command (arguments are quoted safely):"
 printf '%q ' "${helm_command[@]}"
 echo

--- a/helm-chart-versions.yaml
+++ b/helm-chart-versions.yaml
@@ -29,7 +29,7 @@ charts:
   manila: 2025.1.3+e6801dcd0
   memcached: 2025.2.2+c31cd6c96
   metallb: v0.15.2
-  neutron: 2024.2.529+13651f45-628a320c
+  neutron: 2025.1.17+95bf0bf6e
   nova: 2025.1.19+ed289c1cd
   opentelemetry-kube-stack: 0.13.1
   placement: 2025.1.2+0cd784591

--- a/maintenances/maintenance-neutron-2024-1-to-2025-1-epoxy.md
+++ b/maintenances/maintenance-neutron-2024-1-to-2025-1-epoxy.md
@@ -1,0 +1,325 @@
+# Component Maintenance: Neutron 2024.1 to 2025.1 (Epoxy)
+
+## Validation
+
+**Source Version**: 2024.2.529+13651f45-628a320c (images: 2024.1-latest)
+**Target Version**: 2025.1.17+95bf0bf6e (images: 2025.1-latest)
+**Kubernetes Version**: Compatible with current cluster version
+**Upgrade Path**: Direct upgrade supported
+**Major Operational Risks**:
+
+- Firewall_v2 enabled may affect existing firewall policies
+- Resource tag limit enforcement (50 tags max)
+- OVN emit_need_to_frag enabled may impact older kernels (<5.2)
+
+## Goal
+
+Upgrade neutron from 2024.1 to 2025.1 (Epoxy) with OVN backend support, firewall_v2 enabled, and updated container images without service regression.
+
+## Prep
+
+### Deployment Node
+
+Use the standard deployment node or bastion for maintenance operations.
+
+**Verify current component health:**
+
+```bash
+kubectl get pods -n openstack | grep neutron
+```
+
+**Verify current cluster health:**
+
+```bash
+kubectl get nodes
+```
+
+**Verify the current deployed version:**
+
+```bash
+grep neutron /etc/genestack/helm-chart-versions.yaml
+```
+
+Verify that neutron is in the helm-chart-versions.yaml file.
+
+**Verify node or workload placement:**
+
+```bash
+kubectl get pods -n openstack -l release_group=neutron -o wide
+```
+
+**Verify backups are available:**
+
+```bash
+kubectl get pv
+```
+
+**Expected:** All persistent volumes are backed up
+
+If backups are required but missing, stop and create them before continuing.
+
+### Configuration Review
+
+**Configuration files:**
+
+- `/etc/genestack/helm-chart-versions.yaml`
+- `/etc/genestack/helm-configs/neutron/neutron-helm-overrides.yaml`
+
+**Verify current config:**
+
+```bash
+grep -A 2 service_plugins /etc/genestack/helm-configs/neutron/neutron-helm-overrides.yaml
+```
+
+If any non-standard override exists, document it in the maintenance log before continuing.
+
+### Pre-Change Safety Checks
+
+**Check for unhealthy pods:**
+
+```bash
+kubectl get pods -n openstack | grep -E 'Error|CrashLoopBackOff'
+```
+
+**Check for open alerts:**
+
+```bash
+kubectl get events -n openstack --sort-by='.lastTimestamp'
+```
+
+If any critical dependency is unhealthy, stop and resolve it first.
+
+## Execute
+
+### Update the Target Version
+
+**Edit:** `/etc/genestack/helm-chart-versions.yaml`
+
+**Set:**
+
+```yaml
+neutron: 2025.1.17+95bf0bf6e
+```
+
+If intermediate version is required, perform each hop separately and validate after each hop.
+
+### Apply Required Overrides or Patches
+
+**Update:** `/etc/genestack/helm-configs/neutron/neutron-helm-overrides.yaml`
+
+**Update all neutron image tags to:**
+
+```yaml
+ghcr.io/rackerlabs/genestack-images/neutron:2025.1-latest
+```
+
+**Update service_plugins:**
+
+```yaml
+service_plugins: "ovn-router,ovn-vpnaas,qos,metering,trunk,segments,firewall_v2"
+```
+
+**Enable firewall_v2:**
+
+```yaml
+fwaas:
+  enabled: true
+```
+
+**Update ML2 extension drivers:**
+
+```yaml
+ml2:
+  extension_drivers: "port_security,qos,fwaas_v2"
+```
+
+**Images:**
+
+It is possible that you have custom overrides for neutron images. If so, remove them or update them to the new 2025.1-latest tag as their source build.
+
+### Create the required secrets
+
+Neutron Epoxy requires new secrets for the updated deployment. Create them first defining a secrets yaml file. The file can be anywhere, for example, create it at `/tmp/neutron-secrets.yaml` with the following content:
+
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: neutron-keystone-nova
+  namespace: openstack
+type: Opaque
+data:
+  password: $neutron_keystone_nova
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: neutron-keystone-placement
+  namespace: openstack
+type: Opaque
+data:
+  password: $neutron_keystone_placement
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: neutron-keystone-designate
+  namespace: openstack
+type: Opaque
+data:
+  password: $neutron_keystone_designate
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: neutron-keystone-ironic
+  namespace: openstack
+type: Opaque
+data:
+  password: $neutron_keystone_ironic
+```
+
+> Note: The above secrets are examples. Verify which secrets are required based on your deployment and create them accordingly.
+  you will need to replace the variables with the actual passwords from your environment. Each secret is a single line base64 encoded string.
+
+```bash
+kubectl apply -f /tmp/neutron-secrets.yaml
+```
+
+Once the secrets are created, eliminate the file containing the secrets to prevent accidental exposure:
+
+```bash
+rm -f /tmp/neutron-secrets.yaml
+```
+
+### Run the Maintenance
+
+**Dry-run check:**
+
+```bash
+/opt/genestack/bin/install-neutron.sh --dry-run --debug
+```
+
+**Expected:** No errors, all resources reconcile successfully
+
+**Apply the upgrade:**
+
+```bash
+/opt/genestack/bin/install-neutron.sh
+```
+
+## Post-Maint
+
+**Verify workload health:**
+
+```bash
+kubectl get pods -n openstack | grep neutron
+```
+
+**Expected:** All neutron pods in Running state
+
+**Verify dependent services:**
+
+```bash
+kubectl get pods -n openstack | grep -E 'nova|cinder|heat'
+```
+
+**Check logs for upgrade failures:**
+
+```bash
+kubectl logs -n openstack -l release_group=neutron --tail=100
+```
+
+**Verify user-facing functionality:**
+
+```bash
+openstack network list
+openstack router list
+openstack firewall policy list
+```
+
+**Expected:** Networks, routers, and firewall policies are accessible
+
+## Troubleshooting
+
+### Common Failure Signals
+
+- **Pod CrashLoopBackOff**: Check logs with `kubectl logs -n openstack <pod-name> -c neutron-server`
+- **Service Unavailable**: Verify database connectivity and RabbitMQ status
+- **Firewall Policy Errors**: Check for resources exceeding 50 tags limit
+
+### Rollback
+
+**Trigger conditions:**
+
+- Critical services unavailable after 30 minutes
+- Data corruption or loss detected
+- Unresolvable upgrade errors
+
+**Rollback command:**
+
+```bash
+helm rollback neutron <revision>
+```
+
+**Expected:** All neutron pods return to previous version
+
+### Additional Recovery Actions
+
+**If pods remain stuck:**
+
+```bash
+kubectl delete pods -n openstack -l release_group=neutron
+```
+
+**If settings do not reconcile:**
+
+```bash
+kubectl rollout restart deployment/neutron-server -n openstack
+```
+
+**If firewall policies fail to migrate:**
+
+```bash
+# Check for resources exceeding tag limit
+openstack resource provider list --usage
+
+# Manually reduce tags on affected resources if needed
+```
+
+## Important Upgrade Notes
+
+### Firewall_v2 Enablement
+
+- Firewall_v2 is now enabled by default
+- Existing firewall policies will be migrated automatically
+- Verify firewall policies after upgrade: `openstack firewall policy list`
+
+### Resource Tag Limit
+
+- 50 tags per resource limit is now enforced
+- Resources with more than 50 tags will need modification
+- Check current tag usage: `openstack resource provider list --usage`
+
+### OVN emit_need_to_frag
+
+- Now enabled by default
+- May impact performance on kernels older than 5.2
+- If experiencing issues, set `ovn_emit_need_to_frag: false` in config
+
+### uWSGI Configuration
+
+- The `start-time=%t` variable is now mandatory in uWSGI configuration
+- This is handled automatically by the helm chart
+
+### Interface Driver
+
+- `[DEFAULT] interface_driver` now defaults to `openvswitch`
+- No longer required when using OVN mechanism driver
+
+## References
+
+- [Neutron 2025.1 Release Notes](https://docs.openstack.org/releasenotes/neutron/2025.1.html)
+- [OpenStack-Helm Neutron Chart](https://github.com/openstack/openstack-helm/tree/master/neutron)
+- [Genestack Images Repository](https://github.com/rackerlabs/genestack-images)

--- a/releasenotes/notes/neutron-epoxy-2025-1-update-a7a13541451c747c.yaml
+++ b/releasenotes/notes/neutron-epoxy-2025-1-update-a7a13541451c747c.yaml
@@ -1,0 +1,33 @@
+---
+prelude: >
+    Update Neutron to Epoxy (2025.1) release with enhanced OVN backend support and firewall_v2 enabled.
+features:
+  - |
+    Enabled firewall_v2 service plugin and extension driver for ML2/OVN backend.
+  - |
+    Updated Neutron container images to genestack-images/neutron:2025.1-latest.
+  - |
+    Updated the Neutron helm chart version to 2025.1.17+95bf0bf6e.
+upgrade:
+  - |
+    Firewall_v2 is now enabled by default. Existing firewall policies will be migrated automatically.
+  - |
+    The Neutron API now requires the ``start-time=%t`` variable in uWSGI configuration.
+  - |
+    Neutron resource tag limit of 50 tags per resource is now enforced. Resources with more than 50 tags
+    will need to be modified to reduce tag count before upgrades.
+  - |
+    Neutron OVN ``ovn_emit_need_to_frag`` option is now enabled by default. This may impact performance
+    on kernels older than 5.2. Consider setting to ``False`` if using older kernels.
+  - |
+    The Neutron ``[DEFAULT] interface_driver`` option now defaults to ``openvswitch`` and is not required
+    when using OVN mechanism driver.
+other:
+  - |
+    The Neutron Address Group support added to OVN mechanism driver.
+  - |
+    Neutron DNS records can now be configured as local to OVN using ``[ovn]dns_records_ovn_owned`` option.
+  - |
+    Neutron HA routers can now use conntrackd for connection state synchronization across router instances.
+  - |
+    Neutron QoS floating IP rules now take precedence over router rules when both are present.


### PR DESCRIPTION
- Update neutron helm chart version to 2025.1.17+95bf0bf6e
- Update all neutron container images to genestack-images/neutron:2025.1-latest
- Enable firewall_v2 service plugin and extension driver for ML2/OVN
- Update Heat bootstrap images to 2025.1-latest
- Add release notes for Epoxy upgrade with firewall_v2 enablement
- Create maintenance plan for 2024.1 to 2025.1 upgrade

Key changes:
- firewall_v2 now enabled by default with OVNFwaasDriver
- Resource tag limit of 50 enforced (upgrade note documented)
- uWSGI start-time variable now mandatory
- interface_driver defaults to openvswitch for OVN
- HA routers can use conntrackd for connection state sync

Closes-Issue: OSPC-1917
Assisted-by: Xerotier:Qwen3.5-35B-A3B OpenCode