### PR TITLE
fix(ceilometer): Use socket for libvirt connection

### DIFF
--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -37,6 +37,7 @@ images:
 conf:
   ceilometer:
     DEFAULT:
+      libvirt_uri: qemu+unix:///system?socket=/var/run/libvirt/libvirt-sock
       debug: "false"
       # NOTE: If you need to enable debug, it is highly recommended to uncomment the below lines
       # to ensure logs are ceilometer does not spam the logs


### PR DESCRIPTION
Configure libvirt_uri to connect via unix socket directly, bypassing DBus/polkit authentication. The default connection method attempts polkit authorization which fails in containerized environments where polkitd runs on the host.

This works without any other modifications as the ceilometer-compute pods already have access to the socket. Fixes "Action org.libvirt.unix.monitor is not registered" traceback in 2025.1 container images.