### PR TITLE
chore: make replication baseline crash-safe on 11.8.5 and document utf8mb3 compatibility

### DIFF
--- a/base-kustomize/mariadb-cluster/base/mariadb-replication.yaml
+++ b/base-kustomize/mariadb-cluster/base/mariadb-replication.yaml
@@ -39,10 +39,14 @@ spec:
     enabled: false
   myCnf: |
     [mariadb]
+    # Preserve legacy OpenStack table compatibility during Alembic FK migrations.
+    character-set-server=utf8mb3
+    collation-server=utf8mb3_general_ci
     bind-address=0.0.0.0
     default_storage_engine=InnoDB
     binlog_format=ROW
-    binlog_expire_logs_seconds=172800
+    # Keep binlogs long enough for replica recovery and PITR workflows.
+    binlog_expire_logs_seconds=604800
     innodb_autoinc_lock_mode=2
     max_allowed_packet=256M
     max_connections=10240

--- a/docs/infrastructure-mariadb-ops.md
+++ b/docs/infrastructure-mariadb-ops.md
@@ -73,7 +73,9 @@ This command will create a job that runs the backup process immediately, creatin
     backups. If it does not already exist, it's important to create the
     database with the correct charset and collate values. Failing to do so can
     result in errors such as `Foreign Key Constraint is Incorrectly Formed`
-    during DB upgrades.
+    during DB upgrades. This matches the replication cluster baseline, which
+    intentionally keeps `utf8mb3` / `utf8mb3_general_ci` as the server default
+    so Alembic migrations can add foreign keys to older pre-`11.8.5` tables.
 
     ```
     CREATE DATABASE ${DATABASE_NAME} DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;

--- a/docs/infrastructure-mariadb.md
+++ b/docs/infrastructure-mariadb.md
@@ -68,6 +68,15 @@ kubectl --namespace mariadb-system get pods -w
 
     Replication in MariaDB involves synchronizing data between a primary database and one or more replicas, enabling continuous data availability even in the event of hardware failures or outages. By using MariaDB replication, OpenStack deployments can achieve improved fault tolerance and load balancing, ensuring that critical cloud services remain operational and performant at all times.
 
+    Genestack's supported replication baseline for MariaDB `11.8.5` on mariadb-operator
+    `26.3.0` is intentionally both crash-safe and backward compatible with older
+    OpenStack tables. The active replication manifest is the canonical source of truth
+    and keeps `binlog_format=ROW`, `innodb_flush_log_at_trx_commit=1`, and
+    `sync_binlog=1` for durable primary/replica operation while also pinning
+    `character-set-server=utf8mb3` and `collation-server=utf8mb3_general_ci`.
+    This charset/collation pairing is required so Alembic migrations can create new
+    foreign keys against pre-`11.8.5` tables without collation mismatch failures.
+
     !!! note "Replication setup"
 
         Updating the `replication` configuration to include the `replication` resource will deploy a primary MariaDB instance along with one or more replicas, providing a simple yet effective way to enhance database availability and performance in OpenStack environments.

--- a/docs/openstack-mariadb-operator-upgrade.md
+++ b/docs/openstack-mariadb-operator-upgrade.md
@@ -201,6 +201,13 @@ to match the version compatible with the operator chart version being deployed.
 With every release update you must update this image **before** upgrading the
 mariadb-cluster (Galera or Replication).
 
+For replication clusters, treat this file as the canonical MariaDB baseline. In
+addition to the image tag, preserve the crash-safe replication settings
+(`binlog_format=ROW`, `innodb_flush_log_at_trx_commit=1`, `sync_binlog=1`) and
+the compatibility defaults (`character-set-server=utf8mb3`,
+`collation-server=utf8mb3_general_ci`) required for Alembic migrations against
+older OpenStack tables.
+
 ??? info "Finding the compatible MariaDB image"
     Check the `config.mariadbImage` value in the upstream chart's `values.yaml` at the
     corresponding tag:


### PR DESCRIPTION
This updates the Genestack MariaDB replication baseline for MariaDB 11.8.5 and mariadb-operator 26.3.0.

The replication manifest is now the single source of truth for the cluster baseline, with crash-safe replication defaults and explicit compatibility settings for older OpenStack tables.

- keep the active MariaDB CR in `base-kustomize/mariadb-cluster/base/mariadb-replication.yaml` as the canonical replication config
- preserve `character-set-server=utf8mb3` and `collation-server=utf8mb3_general_ci` for compatibility with pre-11.8.5 tables
- keep crash-safe replication settings:
  - `binlog_format=ROW`
  - `innodb_flush_log_at_trx_commit=1`
  - `sync_binlog=1`
- set explicit binlog retention with `binlog_expire_logs_seconds=604800`
- remove the stale unused `mariadb-config-patch.yaml`
- update MariaDB docs to explain the supported replication baseline and the Alembic foreign key compatibility requirement