### PR TITLE
feat: Enable Nova rootwrap daemon by default

### DIFF
--- a/base-helm-configs/nova/nova-helm-overrides.yaml
+++ b/base-helm-configs/nova/nova-helm-overrides.yaml
@@ -96,6 +96,7 @@ conf:
       osapi_compute_workers: 2
       preallocate_images: space
       service_down_time: 120
+      use_rootwrap_daemon: true
       vif_plugging_is_fatal: true
       vif_plugging_timeout: 300
       cross_az_attach: true

--- a/releasenotes/notes/release-2025.1-nova-f36775ca46965f66.yaml
+++ b/releasenotes/notes/release-2025.1-nova-f36775ca46965f66.yaml
@@ -17,6 +17,11 @@ features:
   - |
     Added runtime class and priority class hooks in pod templates for improved
     scheduling and workload isolation customization.
+  - |
+    Genestack now enables ``use_rootwrap_daemon = true`` in the base Nova Helm
+    overrides under ``conf.nova.DEFAULT``. This aligns Nova compute
+    configuration with the recommended OpenStack 2025.1 guidance for compute
+    nodes and reduces rootwrap overhead for privileged operations.
 
 issues:
   - |
@@ -53,3 +58,8 @@ upgrade:
     The new Nova helm chart iterates through endpoints.identity.auth
     for user configuration. endpoints.identity.auth may require
     modification/removal.
+  - |
+    Environments overriding ``conf.nova.DEFAULT.use_rootwrap_daemon`` should
+    reconcile those settings with the new base default. Validate that
+    ``nova-rootwrap-daemon`` and the related sudoers/rootwrap configuration are
+    present in the deployed Nova compute image before rollout.


### PR DESCRIPTION
This updates the Genestack Nova Helm overrides to set conf.nova.DEFAULT.use_rootwrap_daemon: true in the existing DEFAULT section. The change aligns Nova compute configuration with OpenStack 2025.1 guidance, where rootwrap daemon mode is typically enabled on compute nodes to reduce rootwrap overhead for privileged operations.