### PR TITLE
Epoxy rc cherry picks

### DIFF
--- a/base-helm-configs/nova/nova-helm-overrides.yaml
+++ b/base-helm-configs/nova/nova-helm-overrides.yaml
@@ -96,6 +96,7 @@ conf:
       osapi_compute_workers: 2
       preallocate_images: space
       service_down_time: 120
+      use_rootwrap_daemon: true
       vif_plugging_is_fatal: true
       vif_plugging_timeout: 300
       cross_az_attach: true

--- a/base-helm-configs/skyline/skyline-helm-overrides.yaml
+++ b/base-helm-configs/skyline/skyline-helm-overrides.yaml
@@ -1,4 +1,12 @@
 ---
+labels:
+  skyline:
+    node_selector_key: openstack-control-plane
+    node_selector_value: enabled
+  job:
+    node_selector_key: openstack-control-plane
+    node_selector_value: enabled
+
 images:
   pull_policy: IfNotPresent
   tags:

--- a/base-kustomize/mariadb-cluster/base/mariadb-replication.yaml
+++ b/base-kustomize/mariadb-cluster/base/mariadb-replication.yaml
@@ -39,10 +39,14 @@ spec:
     enabled: false
   myCnf: |
     [mariadb]
+    # Preserve legacy OpenStack table compatibility during Alembic FK migrations.
+    character-set-server=utf8mb3
+    collation-server=utf8mb3_general_ci
     bind-address=0.0.0.0
     default_storage_engine=InnoDB
     binlog_format=ROW
-    binlog_expire_logs_seconds=172800
+    # Keep binlogs long enough for replica recovery and PITR workflows.
+    binlog_expire_logs_seconds=604800
     innodb_autoinc_lock_mode=2
     max_allowed_packet=256M
     max_connections=10240

--- a/docs/infrastructure-mariadb-ops.md
+++ b/docs/infrastructure-mariadb-ops.md
@@ -73,7 +73,9 @@ This command will create a job that runs the backup process immediately, creatin
     backups. If it does not already exist, it's important to create the
     database with the correct charset and collate values. Failing to do so can
     result in errors such as `Foreign Key Constraint is Incorrectly Formed`
-    during DB upgrades.
+    during DB upgrades. This matches the replication cluster baseline, which
+    intentionally keeps `utf8mb3` / `utf8mb3_general_ci` as the server default
+    so Alembic migrations can add foreign keys to older pre-`11.8.5` tables.
 
     ```
     CREATE DATABASE ${DATABASE_NAME} DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;

--- a/docs/infrastructure-mariadb.md
+++ b/docs/infrastructure-mariadb.md
@@ -68,6 +68,15 @@ kubectl --namespace mariadb-system get pods -w
 
     Replication in MariaDB involves synchronizing data between a primary database and one or more replicas, enabling continuous data availability even in the event of hardware failures or outages. By using MariaDB replication, OpenStack deployments can achieve improved fault tolerance and load balancing, ensuring that critical cloud services remain operational and performant at all times.
 
+    Genestack's supported replication baseline for MariaDB `11.8.5` on mariadb-operator
+    `26.3.0` is intentionally both crash-safe and backward compatible with older
+    OpenStack tables. The active replication manifest is the canonical source of truth
+    and keeps `binlog_format=ROW`, `innodb_flush_log_at_trx_commit=1`, and
+    `sync_binlog=1` for durable primary/replica operation while also pinning
+    `character-set-server=utf8mb3` and `collation-server=utf8mb3_general_ci`.
+    This charset/collation pairing is required so Alembic migrations can create new
+    foreign keys against pre-`11.8.5` tables without collation mismatch failures.
+
     !!! note "Replication setup"
 
         Updating the `replication` configuration to include the `replication` resource will deploy a primary MariaDB instance along with one or more replicas, providing a simple yet effective way to enhance database availability and performance in OpenStack environments.

--- a/docs/openstack-mariadb-operator-upgrade.md
+++ b/docs/openstack-mariadb-operator-upgrade.md
@@ -201,6 +201,13 @@ to match the version compatible with the operator chart version being deployed.
 With every release update you must update this image **before** upgrading the
 mariadb-cluster (Galera or Replication).
 
+For replication clusters, treat this file as the canonical MariaDB baseline. In
+addition to the image tag, preserve the crash-safe replication settings
+(`binlog_format=ROW`, `innodb_flush_log_at_trx_commit=1`, `sync_binlog=1`) and
+the compatibility defaults (`character-set-server=utf8mb3`,
+`collation-server=utf8mb3_general_ci`) required for Alembic migrations against
+older OpenStack tables.
+
 ??? info "Finding the compatible MariaDB image"
     Check the `config.mariadbImage` value in the upstream chart's `values.yaml` at the
     corresponding tag:

--- a/maintenances/maintenance-skyline-2024.1-to-2025.1-helm-migration.txt
+++ b/maintenances/maintenance-skyline-2024.1-to-2025.1-helm-migration.txt
@@ -60,8 +60,11 @@ kubectl --namespace openstack get secret skyline-apiserver-secrets -o jsonpath='
 # If the secret does not exist or is missing keys, create it before continuing:
 # See the "Creating the Skyline Database Password Secret" section below
 
-# Verify node or workload placement, if relevant:
-kubectl --namespace openstack get nodes -L longhorn.io/storage-node
+# Verify the target control-plane nodes are labeled for Skyline placement:
+kubectl get nodes -L openstack-control-plane
+
+# Expected:
+# - At least one target node shows openstack-control-plane=enabled
 
 # Verify backups, snapshots, or restore points are available:
 # This is a Helm migration, so no database backup is required beyond the existing MariaDB backups
@@ -94,9 +97,19 @@ charts:
 # The skyline-helm-overrides.yaml file will need to be craeted /etc/genestack/base-helm-configs/skyline/skyline-helm-overrides.yaml
 mkdir -p /etc/genestack/helm-configs/skyline
 
-# At a minimum there will need to be a single override that sets the region name.
+# At a minimum there will need to be overrides for the region name and Skyline's
+# chart-supported node placement labels. The upstream openstack-helm/skyline
+# chart uses labels.skyline and labels.job node selector keys rather than a
+# generic nodeSelector block.
 cat >/etc/genestack/helm-configs/skyline/skyline-helm-overrides.yaml<<EOF
 ---
+labels:
+  skyline:
+    node_selector_key: openstack-control-plane
+    node_selector_value: enabled
+  job:
+    node_selector_key: openstack-control-plane
+    node_selector_value: enabled
 conf:
   skyline:
     openstack:
@@ -107,6 +120,7 @@ EOF
 # - images: Set the correct Genestack image tag
 # - endpoints: Configure database and identity endpoints
 # - conf.skyline: Configure Skyline application settings
+# - labels.skyline / labels.job: Keep placement on nodes labeled openstack-control-plane=enabled
 
 # Craete the skyline kustomize setup
 mkdir -p /etc/genestack/kustomize/skyline

--- a/releasenotes/notes/release-2025.1-nova-f36775ca46965f66.yaml
+++ b/releasenotes/notes/release-2025.1-nova-f36775ca46965f66.yaml
@@ -17,6 +17,11 @@ features:
   - |
     Added runtime class and priority class hooks in pod templates for improved
     scheduling and workload isolation customization.
+  - |
+    Genestack now enables ``use_rootwrap_daemon = true`` in the base Nova Helm
+    overrides under ``conf.nova.DEFAULT``. This aligns Nova compute
+    configuration with the recommended OpenStack 2025.1 guidance for compute
+    nodes and reduces rootwrap overhead for privileged operations.
 
 issues:
   - |
@@ -53,3 +58,8 @@ upgrade:
     The new Nova helm chart iterates through endpoints.identity.auth
     for user configuration. endpoints.identity.auth may require
     modification/removal.
+  - |
+    Environments overriding ``conf.nova.DEFAULT.use_rootwrap_daemon`` should
+    reconcile those settings with the new base default. Validate that
+    ``nova-rootwrap-daemon`` and the related sudoers/rootwrap configuration are
+    present in the deployed Nova compute image before rollout.

--- a/releasenotes/notes/release-2026.1-libvirt-exporter-metrics-9d2a6c4b1e7f5a3c.yaml
+++ b/releasenotes/notes/release-2026.1-libvirt-exporter-metrics-9d2a6c4b1e7f5a3c.yaml
@@ -1,0 +1,28 @@
+---
+prelude: |
+  Genestack now documents and supports enabling libvirt exporter metrics as a
+  per-cluster override instead of changing the base libvirt Helm defaults. This
+  keeps the base deployment minimal while allowing environments with
+  Prometheus Operator to opt into libvirt metrics collection.
+
+features:
+  - |
+    Operators can enable the libvirt exporter sidecar and PodMonitor through a
+    cluster-specific libvirt Helm override by setting
+    ``pod.sidecars.libvirt_exporter.enabled: true`` and
+    ``manifests.podmonitor: true``.
+  - |
+    The recommended per-cluster override can also retain
+    ``conf.init_modules.enabled: true`` where nested virtualization support is
+    required on compute hosts.
+
+issues:
+  - |
+    ``manifests.podmonitor`` only has effect in environments with Prometheus
+    Operator CRDs installed, and useful metrics require the
+    ``libvirt_exporter`` sidecar to be enabled at the same time.
+
+other:
+  - |
+    Genestack base libvirt Helm overrides remain unchanged; this metrics
+    enablement is intended to be applied in cluster-specific override files.


### PR DESCRIPTION
libvirt exporter sidecar
mariadb-replication so it sucks less
skyline node-selectors
enable node rootwrap daemon