### PR TITLE
chore: fix install-neutron.sh to use charts secret-keystone template

### DIFF
--- a/base-helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/base-helm-configs/neutron/neutron-helm-overrides.yaml
@@ -399,7 +399,6 @@ manifests:
   pod_rally_test: false
   secret_db: false
   secret_ingress_tls: false
-  secret_keystone: false
   secret_rabbitmq: false
   service_ingress_server: false
   deployment_rpc_server: false

--- a/base-helm-configs/opentelemetry-kube-stack/opentelemetry-kube-stack-helm-overrides.yaml
+++ b/base-helm-configs/opentelemetry-kube-stack/opentelemetry-kube-stack-helm-overrides.yaml
@@ -143,14 +143,29 @@ defaultCRConfig:
           - key: service_namespace
             from_attribute: service.namespace
             action: upsert
-          - key: severity
-            from_attribute: severity
-            action: upsert
           - key: application
             from_attribute: service.name
             action: upsert
           - key: component
             from_attribute: component
+            action: upsert
+          - key: app
+            from_attribute: app
+            action: upsert
+          - key: app_kubernetes_io_name
+            from_attribute: app_kubernetes_io_name
+            action: upsert
+          - key: app_kubernetes_io_component
+            from_attribute: app_kubernetes_io_component
+            action: upsert
+          - key: app_kubernetes_io_instance
+            from_attribute: app_kubernetes_io_instance
+            action: upsert
+          - key: app_kubernetes_io_version
+            from_attribute: app_kubernetes_io_version
+            action: upsert
+          - key: type
+            from_attribute: type
             action: upsert
           - key: log_type
             from_attribute: log_type
@@ -168,36 +183,45 @@ defaultCRConfig:
         extract:
           metadata:
             - k8s.namespace.name
-            - k8s.pod.name
-            - k8s.pod.uid
             - k8s.deployment.name
             - k8s.statefulset.name
             - k8s.daemonset.name
-            - k8s.job.name
             - k8s.cronjob.name
+            - k8s.job.name
             - k8s.node.name
+            - k8s.pod.name
+            - k8s.pod.uid
             - k8s.pod.start_time
-            - k8s.container.name
           labels:
             - tag_name: app
               key: app
               from: pod
-            - tag_name: app_kubernetes_io_name
+            - tag_name: app.kubernetes.io/name
               key: app.kubernetes.io/name
               from: pod
-            - tag_name: app_kubernetes_io_component
-              key: app.kubernetes.io/component
-              from: pod
-            - tag_name: app_kubernetes_io_instance
+            - tag_name: app.kubernetes.io/instance
               key: app.kubernetes.io/instance
               from: pod
-            - tag_name: app_kubernetes_io_version
+            - tag_name: app.kubernetes.io/component
+              key: app.kubernetes.io/component
+              from: pod
+            - tag_name: app.kubernetes.io/part-of
+              key: app.kubernetes.io/part-of
+              from: pod
+            - tag_name: app.kubernetes.io/version
               key: app.kubernetes.io/version
               from: pod
-          annotations:
-            - tag_name: openstack_service
-              key: openstack.service
-              from: pod
+        pod_association:
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.uid
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+          - sources:
+              - from: connection
 
     receivers:
       otlp:
@@ -669,59 +693,6 @@ collectors:
             - key: version
               from_attribute: app.kubernetes.io/version
               action: upsert
-
-        k8sattributes:
-          auth_type: "serviceAccount"
-          passthrough: true
-          extract:
-            metadata:
-              - k8s.namespace.name
-              - k8s.deployment.name
-              - k8s.statefulset.name
-              - k8s.daemonset.name
-              - k8s.cronjob.name
-              - k8s.job.name
-              - k8s.node.name
-              - k8s.pod.name
-              - k8s.pod.uid
-              - k8s.pod.start_time
-            labels:
-              - tag_name: app
-                key: app
-                from: pod
-              - tag_name: app.kubernetes.io/name
-                key: app.kubernetes.io/name
-                from: pod
-              - tag_name: app.kubernetes.io/instance
-                key: app.kubernetes.io/instance
-                from: pod
-              - tag_name: app.kubernetes.io/component
-                key: app.kubernetes.io/component
-                from: pod
-              - tag_name: app.kubernetes.io/part-of
-                key: app.kubernetes.io/part-of
-                from: pod
-              - tag_name: app.kubernetes.io/version
-                key: app.kubernetes.io/version
-                from: pod
-              - tag_name: helm.sh/chart
-                key: helm.sh/chart
-                from: pod
-              - tag_name: job-name
-                key: job-name
-                from: pod
-              - tag_name: controller-uid
-                key: controller-uid
-                from: pod
-          pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: k8s.pod.ip
-            - sources:
-                - from: resource_attribute
-                  name: k8s.pod.uid
-            - sources:
-                - from: connection
 
       service:
         # Telemetry configuration for the collector's own logs

--- a/bin/install-neutron.sh
+++ b/bin/install-neutron.sh
@@ -146,7 +146,6 @@ set_args=(
     --set "conf.ovn_metadata_agent.DEFAULT.metadata_proxy_shared_secret=$(kubectl --namespace openstack get secret metadata-shared-secret -o jsonpath='{.data.password}' | base64 -d)"
     --set "endpoints.identity.auth.admin.password=$(kubectl --namespace openstack get secret keystone-admin -o jsonpath='{.data.password}' | base64 -d)"
     --set "endpoints.identity.auth.neutron.password=$(kubectl --namespace openstack get secret neutron-admin -o jsonpath='{.data.password}' | base64 -d)"
-    --set "endpoints.identity.auth.test.password=$(kubectl --namespace openstack get secret neutron-keystone-test-password -o jsonpath='{.data.password}' | base64 -d)"
     --set "endpoints.identity.auth.nova.password=$(kubectl --namespace openstack get secret nova-admin -o jsonpath='{.data.password}' | base64 -d)"
     --set "endpoints.identity.auth.placement.password=$(kubectl --namespace openstack get secret placement-admin -o jsonpath='{.data.password}' | base64 -d)"
     --set "endpoints.identity.auth.designate.password=$(kubectl --namespace openstack get secret designate-admin -o jsonpath='{.data.password}' | base64 -d)"
@@ -183,12 +182,6 @@ helm_command=(
 
     "$@"
 )
-
-# Create the neutron-keystone-admin secret by copying the keystone-keystone-admin secret and replacing 'keystone' with 'neutron' in the name and data keys.
-kubectl --namespace openstack get secrets keystone-keystone-admin -o yaml | \
-  sed -e '/keystone/{s/keystone/neutron/}' | \
-    kubectl --namespace openstack apply --force -f -
-
 echo "Executing Helm command (arguments are quoted safely):"
 printf '%q ' "${helm_command[@]}"
 echo

--- a/docs/monitoring-observability-overview.md
+++ b/docs/monitoring-observability-overview.md
@@ -14,6 +14,7 @@ Complete overview of the monitoring and observability stack for Rackspace Genest
 6. [What Gets Monitored](#what-gets-monitored)
 7. [Access Points](#access-points)
 8. [Key Features](#key-features)
+9. [Summary](#summary)
 
 ---
 
@@ -35,21 +36,23 @@ The documentation still groups the stack conceptually so you can navigate it as 
 - [OpenTelemetry](monitoring-opentelemetry.md) for collectors and infrastructure telemetry receivers
 - [OpenStack Exporter](openstack-exporter.md) for OpenStack API availability probes
 - [Pushgateway](prometheus-pushgateway.md) for short-lived job metrics
-- [Base OpenTelemetry Metrics Reference](monitoring-otel-base-metrics.md) for the default deployment-collector metrics
+- [OpenTelemetry Metrics Reference](monitoring-otel-base-metrics.md)
 
 ---
 
 ## Architecture Overview
 
 The observability stack is deployed in the `monitoring` namespace and provides comprehensive telemetry collection for:
+
 - **Kubernetes cluster** (nodes, pods, containers, resources)
-- **OpenStack services** (Nova, Neutron, Keystone, etc.)
+- **OpenStack services** (Nova, Neutron, Keystone, Cinder, Glance, and related APIs)
+- **OpenStack compute domains** via libvirt exporter metrics enriched with Nova/OpenStack metadata
 - **Infrastructure services** (MySQL, PostgreSQL, RabbitMQ, Memcached)
 - **Application traces** and **distributed tracing**
 
 ### High-Level Architecture
 
-```
+```text
 ┌────────────────────────────────────────────────────────────────────────────┐
 │                          Monitoring Namespace                              │
 ├────────────────────────────────────────────────────────────────────────────┤
@@ -66,6 +69,7 @@ The observability stack is deployed in the `monitoring` namespace and provides c
 │  │  │ • Logs (filelog)  │              │ • RabbitMQ Metrics   │       │    │
 │  │  │ • Host Metrics    │              │ • Memcached Metrics  │       │    │
 │  │  │ • K8s Events      │              │ • HTTP Checks        │       │    │
+│  │  │ • Libvirt Exporter│              │                      │       │    │
 │  │  └─────────┬─────────┘              └──────────┬───────────┘       │    │
 │  └────────────┼───────────────────────────────────┼───────────────────┘    │
 │               │                                   │                        │
@@ -88,7 +92,7 @@ The observability stack is deployed in the `monitoring` namespace and provides c
 │                            │                 │                             │
 │                            │ • Dashboards    │                             │
 │                            │ • Visualization │                             │
-│                            │  • Explore      │                             │
+│                            │ • Explore       │                             │
 │                            │                 │                             │
 │                            └─────────────────┘                             │
 │                                                                            │
@@ -103,12 +107,12 @@ The observability stack is deployed in the `monitoring` namespace and provides c
 
 | Component | Purpose | Technology | Storage |
 |-----------|---------|------------|---------|
-| **OpenTelemetry** | Telemetry collection & processing | OTel Collector Contrib | Stateless |
-| **Prometheus** | Metrics storage & querying | Prometheus 2.x | Local TSDB (15d retention) |
-| **Loki** | Log aggregation & querying | Grafana Loki 2.x | S3/Filesystem |
+| **OpenTelemetry** | Telemetry collection and processing | OTel Collector Contrib | Stateless |
+| **Prometheus** | Metrics storage and querying | Prometheus 2.x | Local TSDB (15d retention) |
+| **Loki** | Log aggregation and querying | Grafana Loki 2.x | S3/Filesystem |
 | **Tempo** | Distributed tracing | Grafana Tempo 2.x | S3/Filesystem |
-| **Grafana** | Visualization & dashboards | Grafana 10.x | MariaDB |
-| **Alertmanager** | Alert routing & notification | Prometheus Alertmanager | Stateless |
+| **Grafana** | Visualization and dashboards | Grafana 10.x | MariaDB |
+| **Alertmanager** | Alert routing and notification | Prometheus Alertmanager | Stateless |
 
 ### Supporting Components
 
@@ -116,6 +120,7 @@ The observability stack is deployed in the `monitoring` namespace and provides c
 |-----------|---------|---------|
 | **kube-state-metrics** | Kubernetes cluster state metrics | Exports cluster-level metrics (deployments, pods, nodes) |
 | **node-exporter** | Node-level system metrics | CPU, memory, disk, network per node |
+| **libvirt exporter** | Nova compute domain metrics | Exports VM state, CPU, memory, block, interface, vCPU, and job metrics with OpenStack metadata |
 | **MariaDB** | Grafana persistent storage | Stores dashboards, users, datasources |
 | **ServiceMonitors** | Prometheus target discovery | Auto-discovers scrape targets via CRDs |
 
@@ -125,85 +130,65 @@ The observability stack is deployed in the `monitoring` namespace and provides c
 
 ### Metrics Flow
 
-```
+```text
 ┌──────────────────────────────────────────────────────────────────────────┐
 │                          Metrics Collection                              │
 └──────────────────────────────────────────────────────────────────────────┘
 
-Sources                   Collectors              Storage         Visualization
-────────                  ──────────              ───────         ─────────────
+Sources                     Collectors                Storage   Visualization
+────────                    ──────────                ───────   ─────────────
+Kubernetes Pods ─────┐
+OpenStack Services ──┤
+Host Metrics ────────┤                         ┌──► Prometheus ──► Grafana
+K8s Events ──────────┤                         │    (TSDB)         (Dashboards)
+Libvirt Exporter ────┘ ───────► OTel Daemon ───┤
+                                 (DaemonSet)   │
+                                               └──► Alerting / Rules
 
-Kubernetes Pods  ─────┐
-                      │
-OpenStack Services ───┤
-                      ├──► OTel Daemon     ────┐
-Host Metrics  ────────┤    (DaemonSet)         │
-                      │                        │
-K8s Events  ──────────┘                        ├──► Prometheus ──► Grafana
-                                               │    (TSDB)         (Dashboards)
-MySQL  ───────────┐                            │                   (Alerts)
-                  │                            │
-PostgreSQL  ──────┤                            │
-                  ├──► OTel Deployment  ───────┘
-RabbitMQ  ────────┤    (Single Pod)
-                  │
-Memcached  ───────┘
+MySQL ───────────────┐
+PostgreSQL ──────────┤
+RabbitMQ ────────────┤ ───────► OTel Deployment ───────► Prometheus ──► Grafana
+Memcached ───────────┘           (Single Pod)             (TSDB)
 
-                                               
-ServiceMonitors  ─────► Prometheus  ────────────► Grafana
-(kube-state-metrics,    (Direct Scrape)           (Dashboards)
- node-exporter)
+ServiceMonitors ────────────────────────────────────────► Prometheus ──► Grafana
+(kube-state-metrics, node-exporter, other direct scrapes)
 ```
 
 ### Logs Flow
 
-```
+```text
 ┌──────────────────────────────────────────────────────────────────────────┐
-│                            Logs Collection                               │
+│                           Logs Collection                                │
 └──────────────────────────────────────────────────────────────────────────┘
 
-Log Sources              Collectors           Processing         Storage
-───────────              ──────────           ──────────         ───────
-
-/var/log/pods/  ──────┐
- (K8s containers)     │
-                      ├──► OTel Daemon  ──► Processors  ──► Loki  ──► Grafana
-/var/log/pods/  ──────┤    (filelog)         • Parse           (Storage)   (Explore)
- (OpenStack svcs)     │                      • Enrich          (Index)     (Search)
-                      │                      • Label
-K8s Events  ──────────┘                      • Filter
-
-                      Parse:                 Query:
-                      • CRI format           • LogQL
-                      • Multiline            • Label filters
-                      • Timestamps           • Regex search
-                      • Severity             • Aggregation
+Log Sources                 Collectors         Processing        Storage
+───────────                 ──────────         ──────────        ───────
+/var/log/pods/ ──────┐
+(K8s containers)     │
+                     ├──► OTel Daemon ──► Processors ──► Loki ──► Grafana
+/var/log/pods/ ──────┤    (filelog)         • Parse       (Store) (Explore)
+(OpenStack svcs)     │                      • Enrich              (Search)
+                     │                      • Label
+K8s Events ──────────┘                      • Filter
 ```
 
 ### Traces Flow
 
-```
+```text
 ┌──────────────────────────────────────────────────────────────────────────┐
-│                           Traces Collection                              │
+│                          Traces Collection                               │
 └──────────────────────────────────────────────────────────────────────────┘
 
 Application Code         Collectors            Storage          Visualization
 ────────────────         ──────────            ───────          ─────────────
-
 Python Apps  ────┐
- (OpenTelemetry) │
+(OpenTelemetry)  │
                  ├──► OTel Daemon  ──► Tempo  ──► Grafana
-Java Apps  ──────┤    (OTLP gRPC)      (S3)       (Trace View)
- (Jaeger SDK)    │                                (Service Graph)
+Java Apps ───────┤    (OTLP gRPC)      (S3)       (Trace View)
+(Jaeger SDK)     │                                (Service Graph)
                  │
-Go Apps  ────────┘
- (Zipkin)
-
-                 Protocols:              Query:
-                 • OTLP (gRPC/HTTP)      • TraceQL
-                 • Jaeger                • Trace ID
-                 • Zipkin                • Service
-                                         • Duration
+Go Apps ─────────┘
+(Zipkin)
 ```
 
 ---
@@ -212,9 +197,10 @@ Go Apps  ────────┘
 
 ### OpenTelemetry Collectors
 
-**Purpose**: Universal telemetry collection, processing, and export
+**Purpose**: Universal telemetry collection, processing, and export.
 
 #### Daemon Collector (DaemonSet)
+
 - **Deployment**: One pod per Kubernetes node
 - **Collects**:
   - OTLP metrics and traces from applications
@@ -222,6 +208,14 @@ Go Apps  ────────┘
   - Container logs via filelog (`/var/log/pods`)
   - Host metrics (CPU, memory, disk, network)
   - Kubernetes events via k8sobjects
+  - Libvirt exporter metrics from compute nodes, including:
+    - domain inventory and timeout status: `libvirt_domains`, `libvirt_domain_timed_out`
+    - domain metadata and state: `libvirt_domain_openstack_info`, `libvirt_domain_info`, `libvirt_domain_info_state`
+    - CPU and vCPU metrics: `libvirt_domain_info_cpu_time_seconds_total`, `libvirt_domain_vcpu_*`
+    - memory metrics: `libvirt_domain_memory_stats_*`
+    - block metrics: `libvirt_domain_block_stats_*`
+    - interface metrics: `libvirt_domain_interface_stats_*`
+    - migration and job progress metrics: `libvirt_domain_job_info_*`
 - **Processes**:
   - Kubernetes attributes enrichment (pod, namespace, labels)
   - Resource attribute manipulation
@@ -232,7 +226,8 @@ Go Apps  ────────┘
   - Traces → Tempo (OTLP/gRPC)
 
 #### Deployment Collector (Single Pod)
-- **Deployment**: One pod on control plane
+
+- **Deployment**: One pod on the control plane
 - **Collects**:
   - MySQL metrics (connections, queries, locks, buffer pool)
   - PostgreSQL metrics (backends, transactions, deadlocks, size)
@@ -243,65 +238,73 @@ Go Apps  ────────┘
   - Metrics → Prometheus (remote write)
 
 **Key Features**:
+
 - Vendor-agnostic telemetry format (OTLP)
 - Built-in processors for data manipulation
 - Multiple protocol support (OTLP, Jaeger, Zipkin)
 - Automatic Kubernetes metadata enrichment
-
----
+- Compute-local libvirt scraping from the daemon collector, which keeps VM metrics aligned with the node that runs the guest
 
 ### Prometheus
 
-**Purpose**: Time-series metrics storage and querying
+**Purpose**: Time-series metrics storage and querying.
 
 **Deployment**:
+
 - StatefulSet with persistent storage (15 days retention)
 - Alertmanager for alert routing
 
 **Collects Metrics From**:
+
 - OpenTelemetry collectors (remote write)
 - kube-state-metrics (Kubernetes cluster state)
 - node-exporter (node system metrics)
+- libvirt exporter metrics relayed through OpenTelemetry
 - ServiceMonitors (auto-discovered targets)
 
 **Data Model**:
+
 - Time-series: `metric_name{label="value"} value timestamp`
 - Query language: PromQL
 - Storage: Local TSDB (optimized for time-series data)
 
 **Retention**:
+
 - Default: 15 days
 - Configurable via `retention.time` and `retention.size`
 
 **Key Features**:
+
 - Powerful query language (PromQL)
 - Multi-dimensional data model
 - Built-in alerting rules
 - Service discovery and scraping
 - High performance for time-series queries
 
----
-
 ### Loki
 
-**Purpose**: Log aggregation and querying system (like Prometheus but for logs)
+**Purpose**: Log aggregation and querying system (like Prometheus but for logs).
 
 **Deployment**:
+
 - Distributed architecture:
   - **Write**: Ingests logs from OTel
   - **Read**: Serves log queries
   - **Backend**: Long-term storage
 
 **Data Model**:
+
 - Logs stored with labels (not indexed content)
 - Query language: LogQL (similar to PromQL)
-- Cost-effective: Only indexes labels, not log content
+- Cost-effective: only indexes labels, not log content
 
 **Storage**:
-- Short-term: Local filesystem
+
+- Short-term: local filesystem
 - Long-term: S3-compatible object storage
 
 **Key Features**:
+
 - Label-based indexing (efficient storage)
 - LogQL for querying (grep-like but better)
 - Integrates with Grafana (Explore interface)
@@ -309,6 +312,7 @@ Go Apps  ────────┘
 - Automatic log parsing and labeling
 
 **Query Examples**:
+
 ```logql
 # All logs from OpenStack namespace
 {namespace="openstack"}
@@ -320,17 +324,17 @@ Go Apps  ────────┘
 rate({namespace="openstack"} |= "ERROR" [5m])
 ```
 
----
-
 ### Tempo
 
-**Purpose**: Distributed tracing backend
+**Purpose**: Distributed tracing backend.
 
 **Deployment**:
+
 - Scalable architecture (ingester, querier, compactor)
 - S3-compatible storage for traces
 
 **Data Model**:
+
 - Traces composed of spans
 - Each span has:
   - Trace ID (unique per request)
@@ -339,68 +343,74 @@ rate({namespace="openstack"} |= "ERROR" [5m])
   - Timestamps, tags, logs
 
 **Key Features**:
+
 - Cost-effective trace storage
 - TraceQL for querying traces
 - Integrates with Grafana and Loki
-- Automatic trace to logs correlation
+- Automatic trace-to-logs correlation
 
 **Use Cases**:
+
 - Debug slow API requests
 - Find bottlenecks in microservices
 - Trace request flow across services
 - Identify error propagation
 
----
-
 ### Grafana
 
-**Purpose**: Visualization and dashboarding platform
+**Purpose**: Visualization and dashboarding platform.
 
 **Deployment**:
+
 - Deployment with MariaDB backend
 - Persistent storage for dashboards and configuration
 
 **Datasources**:
+
 - **Prometheus**: Metrics and alerting
 - **Loki**: Log searching and exploration
 - **Tempo**: Distributed tracing
 
 **Features**:
+
 - **Dashboards**: Pre-built and custom visualizations
 - **Explore**: Ad-hoc querying interface
 - **Alerting**: Visual alert rule builder
 - **Correlation**: Jump from metrics → logs → traces
 
-**Pre-configured Dashboards**:
+**Pre-configured Dashboard Themes**:
+
 - Kubernetes cluster monitoring
 - Node resource usage
 - OpenStack service health
+- Nova/libvirt compute domain health and capacity
 - Database performance
 - RabbitMQ queue monitoring
 
----
-
 ### Alertmanager
 
-**Purpose**: Alert routing and notification management
+**Purpose**: Alert routing and notification management.
 
 **Deployment**:
+
 - StatefulSet for HA (high availability)
 - Receives alerts from Prometheus
 
 **Features**:
+
 - **Grouping**: Combine similar alerts
 - **Inhibition**: Suppress dependent alerts
 - **Silencing**: Temporarily mute alerts
 - **Routing**: Send to different channels (Slack, PagerDuty, email)
 
 **Alert Flow**:
-```
-Prometheus Rules  ──► Alertmanager  ──► Notification Channels
+
+```text
+Prometheus Rules ──► Alertmanager ──► Notification Channels
  (PromQL)              (Routing)          • Slack
-                                          • PagerDuty
-                                          • Email
-                                          • Webhooks
+                                           • PagerDuty
+                                           • Email
+                                           • Webhooks
 ```
 
 ---
@@ -421,13 +431,39 @@ Prometheus Rules  ──► Alertmanager  ──► Notification Channels
 
 | Service | Metrics | Logs | Examples |
 |---------|---------|------|----------|
-| **Nova** | API requests, VM operations | nova-api, nova-compute logs | VM creation traces |
+| **Nova API** | API requests, scheduler activity, VM operations | nova-api, nova-scheduler logs | VM creation traces |
+| **Nova / Libvirt Compute** | Domain count, state, CPU, memory, vCPU, disk I/O, network I/O, migration/job progress | nova-compute, libvirtd logs | VM lifecycle and compute-node troubleshooting |
 | **Neutron** | Network operations, ports | neutron-server logs | Network provisioning |
 | **Keystone** | Auth requests, token operations | keystone logs | Auth flow traces |
 | **Cinder** | Volume operations | cinder-api logs | Volume attach traces |
 | **Glance** | Image operations | glance-api logs | Image upload traces |
-`All openstack services get logged the above is just an example`
 
+_All OpenStack services are logged; the above is representative, not exhaustive._
+
+### OpenStack Compute / Libvirt Metric Families
+
+The libvirt exporter provides detailed domain metrics that are best understood as Nova compute visibility rather than generic host metrics.
+
+| Family | Examples | Typical Use |
+|--------|----------|-------------|
+| **Domain inventory and metadata** | `libvirt_domains`, `libvirt_domain_timed_out`, `libvirt_domain_openstack_info`, `libvirt_domain_info`, `libvirt_domain_info_state` | Count VMs, track state, map domains to instance name, flavor, project, and compute host |
+| **CPU and vCPU** | `libvirt_domain_info_cpu_time_seconds_total`, `libvirt_domain_info_virtual_cpus`, `libvirt_domain_vcpu_current`, `libvirt_domain_vcpu_time_seconds_total`, `libvirt_domain_vcpu_wait_seconds_total`, `libvirt_domain_vcpu_delay_seconds_total`, `libvirt_domain_vcpu_state` | VM CPU usage, vCPU wait/delay analysis, scheduling pressure |
+| **Memory** | `libvirt_domain_info_memory_usage_bytes`, `libvirt_domain_info_maximum_memory_bytes`, `libvirt_domain_memory_stats_*` | Guest memory usage, RSS, ballooning, faults, swap, usable/unused memory |
+| **Block I/O** | `libvirt_domain_block_stats_*`, `libvirt_domain_block_stats_info` | Disk throughput, IOPS, read/write latency, flush latency, capacity |
+| **Interface I/O** | `libvirt_domain_interface_stats_*`, `libvirt_domain_interface_stats_info` | Guest network throughput, packet rates, drops, errors |
+| **Migration and job metrics** | `libvirt_domain_job_info_*` | Migration progress, elapsed time, remaining time, bytes processed |
+
+### Libvirt Metadata and Labeling Notes
+
+Use metadata from `libvirt_domain_openstack_info` for VM identity and OpenStack context:
+
+- `instance_name`: friendly VM name
+- `instance_id`: UUID for the Nova server
+- `project_name` and `project_id`: tenant/project context
+- `flavor_name`: Nova flavor context
+- `host_name`: compute host
+
+Be careful with the scrape label `instance`: in daemon-local libvirt scraping it may only identify the exporter endpoint, such as `localhost:9474`, rather than the Nova server identity.
 
 ### Infrastructure Services
 
@@ -441,6 +477,7 @@ Prometheus Rules  ──► Alertmanager  ──► Notification Channels
 ### Application Instrumentation
 
 Applications can send telemetry using:
+
 - **OpenTelemetry SDKs** (Python, Java, Go, Node.js)
 - **Jaeger client libraries** (legacy)
 - **Zipkin libraries** (legacy)
@@ -453,7 +490,7 @@ Send to: `opentelemetry-kube-stack-daemon-collector:4317` (OTLP gRPC)
 
 ### Grafana UI
 
-```
+```text
 URL: http://grafana.monitoring.svc.cluster.local
      or https://grafana.your-domain.com (if Ingress configured)
 
@@ -463,38 +500,54 @@ Default Credentials:
 ```
 
 **Access via kubectl port-forward**:
+
 ```bash
 kubectl -n monitoring port-forward svc/grafana 3000:80
 # Open: http://localhost:3000
 ```
 
+**Use Cases**:
+
+- View infrastructure dashboards
+- Explore Nova/libvirt compute dashboards
+- Correlate metrics with logs and traces
+
 ### Prometheus UI
 
-```
+```text
 URL: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+```
 
-Access via kubectl port-forward:
+**Access via kubectl port-forward**:
+
+```bash
 kubectl -n monitoring port-forward svc/kube-prometheus-stack-prometheus 9090:9090
 # Open: http://localhost:9090
 ```
 
 **Use Cases**:
+
 - Query metrics with PromQL
 - View active alerts
 - Check target health
 - Debug scraping issues
+- Validate libvirt exporter series and label joins
 
 ### Alertmanager UI
 
-```
+```text
 URL: http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093
+```
 
-Access via kubectl port-forward:
+**Access via kubectl port-forward**:
+
+```bash
 kubectl -n monitoring port-forward svc/kube-prometheus-stack-alertmanager 9093:9093
 # Open: http://localhost:9093
 ```
 
 **Use Cases**:
+
 - View active alerts
 - Silence alerts
 - Check alert routing
@@ -506,46 +559,51 @@ kubectl -n monitoring port-forward svc/kube-prometheus-stack-alertmanager 9093:9
 ### 1. Unified Observability
 
 **Three Pillars in One Stack**:
-- 📊 **Metrics**: Numerical time-series data (what's happening)
-- 📝 **Logs**: Event records (what happened)
-- 🔍 **Traces**: Request flows (how it happened)
+
+- **Metrics**: numerical time-series data (what is happening)
+- **Logs**: event records (what happened)
+- **Traces**: request flows (how it happened)
 
 **Correlation**:
+
 - Jump from metric spike → related logs → trace details
 - Unified view across all telemetry types
+- Follow Nova API activity into compute-node domain metrics and compute logs
 
 ### 2. Kubernetes-Native
 
-- **Service Discovery**: Automatic target discovery via ServiceMonitors
-- **Metadata Enrichment**: Automatic pod/namespace/label tagging
-- **Resource Awareness**: Monitors K8s resources (CPU, memory, limits)
-- **CRD-Based**: Uses Kubernetes Custom Resources for configuration
+- **Service Discovery**: automatic target discovery via ServiceMonitors
+- **Metadata Enrichment**: automatic pod/namespace/label tagging
+- **Resource Awareness**: monitors Kubernetes resources (CPU, memory, limits)
+- **CRD-Based**: uses Kubernetes custom resources for configuration
 
 ### 3. OpenStack Aware
 
-- **Service Logs**: Parses OpenStack log formats
-- **API Monitoring**: Tracks OpenStack API health
-- **Request Tracing**: Traces requests across OpenStack services
-- **Infrastructure Metrics**: Monitors databases and message queues
+- **Service Logs**: parses OpenStack log formats
+- **API Monitoring**: tracks OpenStack API health
+- **Request Tracing**: traces requests across OpenStack services
+- **Compute Metrics**: monitors libvirt/Nova domains with OpenStack metadata for instance, project, flavor, and compute host
+- **Infrastructure Metrics**: monitors databases and message queues
 
 ### 4. High Cardinality Support
 
-- **Prometheus**: Handles millions of time series
-- **Loki**: Efficient label-based log storage
-- **Tempo**: Cost-effective trace storage at scale
+- **Prometheus**: handles millions of time series
+- **Loki**: efficient label-based log storage
+- **Tempo**: cost-effective trace storage at scale
 
 ### 5. Alerting and Notification
 
-- **PrometheusRules**: Define alerts in YAML
-- **Alertmanager**: Route alerts to multiple channels
-- **Grafana Alerts**: Visual alert builder
-- **Alert Hierarchy**: Parent/child relationships and inhibition
+- **PrometheusRules**: define alerts in YAML
+- **Alertmanager**: route alerts to multiple channels
+- **Grafana Alerts**: visual alert builder
+- **Alert Hierarchy**: parent/child relationships and inhibition
 
 ### 6. Multi-Tenant Ready
 
-- **Namespace Isolation**: Clear separation of concerns
+- **Namespace Isolation**: clear separation of concerns
 - **RBAC Integration**: Kubernetes RBAC for access control
 - **Datasource Permissions**: Grafana team-based access
+- **Tenant Context**: OpenStack labels such as project, user, and flavor make per-tenant views possible without changing the scrape path
 
 ### 7. Long-Term Storage
 
@@ -555,9 +613,10 @@ kubectl -n monitoring port-forward svc/kube-prometheus-stack-alertmanager 9093:9
 
 ### 8. Cost-Effective
 
-- **Loki**: Only indexes labels (not log content) → lower storage costs
-- **Tempo**: Compressed trace storage in object storage
-- **Prometheus**: Efficient TSDB for time-series data
+- **Loki**: only indexes labels (not log content), lowering storage costs
+- **Tempo**: compressed trace storage in object storage
+- **Prometheus**: efficient TSDB for time-series data
+- **OpenTelemetry**: centralizes metric forwarding
 
 ---
 
@@ -565,46 +624,19 @@ kubectl -n monitoring port-forward svc/kube-prometheus-stack-alertmanager 9093:9
 
 ### What This Stack Provides
 
-✅ **Complete Observability**: Metrics, logs, and traces in one unified stack  
-✅ **Kubernetes-Native**: Built for cloud-native environments  
-✅ **OpenStack-Aware**: Tailored for OpenStack deployments  
-✅ **Scalable**: Handles large-scale infrastructure  
-✅ **Cost-Effective**: Efficient storage and indexing  
-✅ **Open Source**: No vendor lock-in, community-driven  
+- ✅ Complete observability: metrics, logs, and traces in one unified stack
+- ✅ Kubernetes-native: built for cloud-native environments
+- ✅ OpenStack-aware: tailored for OpenStack deployments
+- ✅ Compute-aware: includes libvirt/Nova domain metrics with OpenStack metadata
+- ✅ Scalable: handles large-scale infrastructure
+- ✅ Cost-effective: efficient storage and indexing
+- ✅ Open source: no vendor lock-in, community-driven
 
 ### Key Benefits
 
-- **Faster Debugging**: Correlated telemetry (metrics → logs → traces)
-- **Proactive Monitoring**: Alerts before users notice issues
-- **Performance Optimization**: Identify bottlenecks and optimize
-- **Compliance**: Audit trails and long-term retention
-- **Team Collaboration**: Shared dashboards and knowledge
-
-### Technology Choices
-
-| Technology | Why Chosen |
-|------------|-----------|
-| **OpenTelemetry** | Industry standard, vendor-neutral, future-proof |
-| **Prometheus** | De facto standard for metrics in Kubernetes |
-| **Loki** | Cost-effective logs, integrates with Prometheus/Grafana |
-| **Tempo** | Scalable tracing, S3-based storage |
-| **Grafana** | Best-in-class visualization, multi-datasource support |
-
----
-
-## Additional Resources
-
-### Documentation
-
-- [OpenTelemetry Documentation](https://opentelemetry.io/docs/)
-- [Prometheus Documentation](https://prometheus.io/docs/)
-- [Loki Documentation](https://grafana.com/docs/loki/)
-- [Tempo Documentation](https://grafana.com/docs/tempo/)
-- [Grafana Documentation](https://grafana.com/docs/grafana/)
-
-### Community
-
-- [CNCF Observability Landscape](https://landscape.cncf.io/card-mode?category=observability-and-analysis)
-- [Genestack Project](https://github.com/rackerlabs/genestack)
-
----
+- **Faster Debugging**: correlated telemetry (metrics → logs → traces)
+- **Proactive Monitoring**: alerts before users notice issues
+- **Performance Optimization**: identify bottlenecks and optimize
+- **Compute Visibility**: inspect per-VM CPU, memory, network, disk, and migration progress from the same monitoring stack
+- **Compliance**: audit trails and long-term retention
+- **Team Collaboration**: shared dashboards and knowledge

--- a/docs/monitoring-otel-base-metrics.md
+++ b/docs/monitoring-otel-base-metrics.md
@@ -85,6 +85,7 @@ This document describes the metrics collected by the current OpenTelemetry + Pro
 - `resource_to_telemetry_conversion` is enabled on the Prometheus remote write exporter, so OTel resource attributes become Prometheus labels.
 - `target_info` is disabled on the Prometheus remote write exporter.
 - The `httpcheck` receiver is configured with targets, but it is **currently commented out of the deployment metrics pipeline**. Its metric families are documented below so the reference stays complete for the configured receiver.
+- `libvirt` metrics are collected by a Prometheus receiver scrape in the daemon collector against a node-local `libvirt_exporter` endpoint and then remote-written to Prometheus.
 
 ---
 
@@ -169,7 +170,118 @@ That means this config does **not** collect hostmetrics process metrics such as:
 
 ---
 
-### 2. OTLP Application Metrics
+### 2. Libvirt Metrics (from libvirt_exporter via Prometheus receiver)
+
+**Source**: Prometheus receiver scrape job `libvirt` against the node-local `libvirt_exporter` endpoint  
+**Collector**: OTel DaemonSet  
+**Collection Interval**: `30s`  
+**Typical Scrape Target**: `localhost:9474/metrics` (or equivalent node-local endpoint)  
+**Labels**: `domain`, `host_name`, `instance_name`, `instance_id`, `project_name`, `project_id`, `user_name`, `user_id`, `flavor_name`, `job`, `instance`, plus converted resource attributes
+
+**Important label note**:
+- `instance` is the exporter scrape endpoint (for example `localhost:9474`), not the Nova instance UUID.
+- For VM identity and OpenStack metadata, use `libvirt_domain_openstack_info` labels such as `instance_name`, `instance_id`, `project_name`, `user_name`, and `flavor_name`.
+- For compute host selection, prefer `host_name`.
+
+#### Inventory and Metadata Metrics
+
+| Metric Name | Type | Description | Labels |
+|-------------|------|-------------|--------|
+| `libvirt_domains` | Gauge | Number of libvirt domains visible to the exporter | - |
+| `libvirt_domain_timed_out` | Gauge | Whether scraping metrics for a specific domain timed out | `domain` |
+| `libvirt_domain_openstack_info` | Gauge | OpenStack / Nova metadata exported as labels | `domain`, `host_name`, `instance_name`, `instance_id`, `project_name`, `project_id`, `user_name`, `user_id`, `flavor_name` |
+| `libvirt_domain_info` | Gauge | Static domain metadata such as OS type and architecture exported as labels | `domain`, `os_type`, `os_type_machine`, `os_type_arch` |
+| `libvirt_domain_info_state` | Gauge | Domain state code with descriptive state label | `domain`, `state_desc` |
+
+#### Domain Compute and Memory Overview Metrics
+
+| Metric Name | Type | Description | Labels |
+|-------------|------|-------------|--------|
+| `libvirt_domain_info_cpu_time_seconds_total` | Counter | Total CPU time consumed by the domain | `domain` |
+| `libvirt_domain_info_virtual_cpus` | Gauge | Configured virtual CPU count for the domain | `domain` |
+| `libvirt_domain_info_maximum_memory_bytes` | Gauge | Maximum configured memory for the domain | `domain` |
+| `libvirt_domain_info_memory_usage_bytes` | Gauge | Current memory usage reported for the domain | `domain` |
+
+#### Domain Memory Stats Metrics
+
+| Metric Name | Type | Description | Labels |
+|-------------|------|-------------|--------|
+| `libvirt_domain_memory_stats_available_bytes` | Gauge | Memory available to the guest | `domain` |
+| `libvirt_domain_memory_stats_current_balloon_bytes` | Gauge | Current balloon size | `domain` |
+| `libvirt_domain_memory_stats_disk_caches_bytes` | Gauge | Guest memory used for reclaimable disk cache | `domain` |
+| `libvirt_domain_memory_stats_hugetlb_pgalloc_total` | Counter | Successful guest hugepage allocations via balloon reporting | `domain` |
+| `libvirt_domain_memory_stats_hugetlb_pgfail_total` | Counter | Failed guest hugepage allocations via balloon reporting | `domain` |
+| `libvirt_domain_memory_stats_last_update_timestamp_seconds` | Gauge | Timestamp of the last memory stats update | `domain` |
+| `libvirt_domain_memory_stats_major_fault_total` | Counter | Major page faults reported for the domain | `domain` |
+| `libvirt_domain_memory_stats_maximum_bytes` | Gauge | Maximum guest memory available to the domain | `domain` |
+| `libvirt_domain_memory_stats_minor_fault_total` | Counter | Minor page faults reported for the domain | `domain` |
+| `libvirt_domain_memory_stats_rss_bytes` | Gauge | Resident set size of the process backing the domain | `domain` |
+| `libvirt_domain_memory_stats_swap_in_bytes` | Counter | Bytes swapped into guest memory | `domain` |
+| `libvirt_domain_memory_stats_swap_out_bytes` | Counter | Bytes swapped out from guest memory | `domain` |
+| `libvirt_domain_memory_stats_unused_bytes` | Gauge | Unused memory inside the guest | `domain` |
+| `libvirt_domain_memory_stats_usable_bytes` | Gauge | Usable guest memory, similar to Linux `MemAvailable` | `domain` |
+| `libvirt_domain_memory_stats_used_percent` | Gauge | Guest memory utilization percentage | `domain` |
+
+#### Block Device Metrics
+
+| Metric Name | Type | Description | Labels |
+|-------------|------|-------------|--------|
+| `libvirt_domain_block_stats_info` | Gauge | Block device metadata exported as labels | `domain`, `disk_type`, `driver_cache`, `driver_discard`, `driver_name`, `driver_type`, `serial`, `source_file`, `target_bus`, `target_device` |
+| `libvirt_domain_block_stats_capacity_bytes` | Gauge | Logical capacity of the block device backing image | `domain`, `target_device` |
+| `libvirt_domain_block_stats_flush_requests_total` | Counter | Flush requests issued to the block device | `domain`, `target_device` |
+| `libvirt_domain_block_stats_flush_time_seconds_total` | Counter | Time spent flushing the block device cache | `domain`, `target_device` |
+| `libvirt_domain_block_stats_read_bytes_total` | Counter | Bytes read from the block device | `domain`, `target_device` |
+| `libvirt_domain_block_stats_read_requests_total` | Counter | Read requests issued to the block device | `domain`, `target_device` |
+| `libvirt_domain_block_stats_read_time_seconds_total` | Counter | Time spent in block reads | `domain`, `target_device` |
+| `libvirt_domain_block_stats_write_bytes_total` | Counter | Bytes written to the block device | `domain`, `target_device` |
+| `libvirt_domain_block_stats_write_requests_total` | Counter | Write requests issued to the block device | `domain`, `target_device` |
+| `libvirt_domain_block_stats_write_time_seconds_total` | Counter | Time spent in block writes | `domain`, `target_device` |
+
+#### Network Interface Metrics
+
+| Metric Name | Type | Description | Labels |
+|-------------|------|-------------|--------|
+| `libvirt_domain_interface_stats_info` | Gauge | Interface metadata exported as labels | `domain`, `interface_type`, `mac_address`, `model_type`, `mtu_size`, `source_bridge`, `target_device` |
+| `libvirt_domain_interface_stats_receive_bytes_total` | Counter | Bytes received on the guest interface | `domain`, `target_device` |
+| `libvirt_domain_interface_stats_receive_drops_total` | Counter | Dropped received packets on the guest interface | `domain`, `target_device` |
+| `libvirt_domain_interface_stats_receive_errors_total` | Counter | Receive errors on the guest interface | `domain`, `target_device` |
+| `libvirt_domain_interface_stats_receive_packets_total` | Counter | Packets received on the guest interface | `domain`, `target_device` |
+| `libvirt_domain_interface_stats_transmit_bytes_total` | Counter | Bytes transmitted on the guest interface | `domain`, `target_device` |
+| `libvirt_domain_interface_stats_transmit_drops_total` | Counter | Dropped transmitted packets on the guest interface | `domain`, `target_device` |
+| `libvirt_domain_interface_stats_transmit_errors_total` | Counter | Transmit errors on the guest interface | `domain`, `target_device` |
+| `libvirt_domain_interface_stats_transmit_packets_total` | Counter | Packets transmitted on the guest interface | `domain`, `target_device` |
+
+#### Domain Job Metrics
+
+| Metric Name | Type | Description | Labels |
+|-------------|------|-------------|--------|
+| `libvirt_domain_job_info_data_processed_bytes` | Gauge | Data bytes already processed by the active domain job | `domain`, `host_name` |
+| `libvirt_domain_job_info_data_remaining_bytes` | Gauge | Data bytes remaining for the active domain job | `domain`, `host_name` |
+| `libvirt_domain_job_info_data_total_bytes` | Gauge | Total data bytes for the active domain job | `domain`, `host_name` |
+| `libvirt_domain_job_info_file_processed_bytes` | Gauge | File bytes already processed by the active domain job | `domain`, `host_name` |
+| `libvirt_domain_job_info_file_remaining_bytes` | Gauge | File bytes remaining for the active domain job | `domain`, `host_name` |
+| `libvirt_domain_job_info_file_total_bytes` | Gauge | Total file bytes for the active domain job | `domain`, `host_name` |
+| `libvirt_domain_job_info_memory_processed_bytes` | Gauge | Memory bytes already processed by the active domain job | `domain`, `host_name` |
+| `libvirt_domain_job_info_memory_remaining_bytes` | Gauge | Memory bytes remaining for the active domain job | `domain`, `host_name` |
+| `libvirt_domain_job_info_memory_total_bytes` | Gauge | Total memory bytes for the active domain job | `domain`, `host_name` |
+| `libvirt_domain_job_info_time_elapsed_seconds` | Gauge | Time elapsed for the active domain job | `domain`, `host_name` |
+| `libvirt_domain_job_info_time_remaining_seconds` | Gauge | Estimated time remaining for the active domain job | `domain`, `host_name` |
+| `libvirt_domain_job_info_type` | Gauge | Domain job type code | `domain`, `host_name` |
+
+**Note**: Domain job metrics are most useful during live migration, block copy, or other active libvirt jobs. It is normal for job-oriented panels to be sparse or empty when no domain jobs are running.
+
+#### vCPU Metrics
+
+| Metric Name | Type | Description | Labels |
+|-------------|------|-------------|--------|
+| `libvirt_domain_vcpu_current` | Gauge | Number of currently online vCPUs for the domain | `domain` |
+| `libvirt_domain_vcpu_delay_seconds_total` | Counter | Time a vCPU spent delayed in the run queue | `domain`, `vcpu` |
+| `libvirt_domain_vcpu_maximum` | Gauge | Maximum number of vCPUs allowed for the domain | `domain` |
+| `libvirt_domain_vcpu_state` | Gauge | Per-vCPU state code | `domain`, `vcpu`, `state_desc` |
+| `libvirt_domain_vcpu_time_seconds_total` | Counter | CPU time used by a specific vCPU | `domain`, `vcpu` |
+| `libvirt_domain_vcpu_wait_seconds_total` | Counter | Time a specific vCPU spent waiting | `domain`, `vcpu` |
+
+### 3. OTLP Application Metrics
 
 **Source**: Applications sending metrics to OTel collector via OTLP  
 **Collector**: OTel Deployment
@@ -192,7 +304,7 @@ Applications instrumented with OpenTelemetry SDKs can send custom metrics. These
 
 ---
 
-### 3. kubeletstats Metrics (DISABLED)
+### 4. kubeletstats Metrics (DISABLED)
 
 **Status**: ⚠️ **DISABLED**
 
@@ -200,7 +312,7 @@ The `kubeletMetrics` preset is disabled in both the daemon and deployment collec
 
 ---
 
-### 4. HTTP Endpoint Check Metrics
+### 5. HTTP Endpoint Check Metrics
 
 **Source**: `httpcheck` receiver  
 **Collector**: OTel Deployment  
@@ -910,6 +1022,17 @@ The config also defines synthetic HTTP endpoint checks for major OpenStack APIs.
 | `node` | Kube-OVN / Prometheus | Node associated with metric |
 | `target` | HTTP check receiver | Endpoint being checked |
 | `method` | HTTP check receiver | HTTP method used for the check |
+| `domain` | libvirt exporter | Libvirt domain identifier, often OpenStack `instance-...` |
+| `instance_name` | `libvirt_domain_openstack_info` | OpenStack / Nova server name |
+| `instance_id` | `libvirt_domain_openstack_info` | OpenStack / Nova server UUID |
+| `project_name` | `libvirt_domain_openstack_info` | OpenStack project / tenant identifier or name |
+| `project_id` | `libvirt_domain_openstack_info` | OpenStack project UUID |
+| `user_name` | `libvirt_domain_openstack_info` | OpenStack user name |
+| `user_id` | `libvirt_domain_openstack_info` | OpenStack user identifier |
+| `flavor_name` | `libvirt_domain_openstack_info` | OpenStack flavor associated with the domain |
+| `state_desc` | libvirt exporter | Human-readable libvirt state label for a domain or vCPU |
+| `target_device` | libvirt exporter | Guest block device or interface device name |
+| `vcpu` | libvirt exporter | Virtual CPU index within a domain |
 
 ### Labels from Prometheus ServiceMonitors
 
@@ -922,6 +1045,8 @@ The config also defines synthetic HTTP endpoint checks for major OpenStack APIs.
 | `namespace` | Namespace |
 | `pod` | Pod name, when available |
 | `node` | Node name, when added by relabeling |
+
+**Libvirt-specific note**: for the libvirt scrape job, `instance` is typically the exporter endpoint (for example `localhost:9474`) and should not be treated as the VM UUID. For dashboard filtering and joins, prefer `host_name` for compute selection and `instance_name` / `instance_id` from `libvirt_domain_openstack_info` for VM identity.
 
 ---
 
@@ -952,6 +1077,20 @@ kubectl logs -n monitoring deployment/opentelemetry-kube-stack-deployment-collec
 1. Verify the daemon collector is running on each node.
 2. Confirm the `hostmetrics` receiver is active in the daemon collector metrics pipeline.
 3. Check for permissions or host mount issues if hostmetrics suddenly drops out.
+
+---
+
+### Missing Libvirt Metrics
+
+1. Verify the libvirt exporter is running with the libvirt workload on each compute node.
+2. Confirm the daemon collector has an active Prometheus scrape job for `libvirt`.
+3. Verify the exporter endpoint is reachable from the collector pod, for example `curl http://localhost:9474/metrics` or the configured node-local address.
+4. If the exporter is running as a sidecar, confirm the libvirt socket path is correct inside the container.
+5. Check collector logs for Prometheus scrape failures:
+```bash
+kubectl logs -n monitoring daemonset/opentelemetry-kube-stack-daemon-collector -c otc-container | grep -i libvirt
+```
+6. Check exporter logs for libvirt connection failures or missing socket errors.
 
 ---
 
@@ -1036,6 +1175,7 @@ If Prometheus is struggling with too many series:
    - per-target pinger metrics
    - per-target HTTP check metrics
    - high-label OTLP application metrics
+   - libvirt per-domain / per-interface / per-block-device / per-vCPU metrics
    - kube-state-metrics object labels
 
 ---
@@ -1059,6 +1199,7 @@ Base configuration collects metrics from:
 
 1. **OTel Collectors (Remote Write to Prometheus)**:
    - Host metrics via `hostmetrics`
+   - Libvirt hypervisor and per-domain metrics via OTel Prometheus receiver scraping `libvirt_exporter`
    - Application OTLP metrics
    - MySQL metrics via OTel receiver
    - PostgreSQL metrics via OTel receiver
@@ -1094,6 +1235,7 @@ Base configuration collects metrics from:
 | Metric Prefix | Source | Collection Method | What It Measures |
 |--------------|--------|-------------------|------------------|
 | `system_*` | hostmetrics receiver | OTel DaemonSet → Remote Write | Node-level system metrics |
+| `libvirt_*` | `libvirt_exporter` | OTel DaemonSet Prometheus scrape → Remote Write | Hypervisor, VM, OpenStack metadata, disk, interface, job, and vCPU metrics |
 | `httpcheck.*` | HTTP check receiver | OTel Deployment → Remote Write when enabled | Endpoint availability and latency checks |
 | `mysql.*` | MySQL receiver | OTel Deployment → Remote Write | MariaDB/MySQL server health and usage |
 | `postgresql.*` | PostgreSQL receiver | OTel Deployment → Remote Write | PostgreSQL usage and transaction metrics |


### PR DESCRIPTION
- removed the manual creation of `secret/neutron-keystone-admin`
- removed the `neutron-keystone-test-password` secret lookup from the install script
- left Helm to render Neutron identity secrets from chart values
- kept the script focused on passing only the required runtime passwords and service settings
This change makes the install path consistent with the chart:
- `neutron-keystone-admin` should be created by Helm
- `neutron-keystone-test` should also be driven by Helm values rather than a separate Kubernetes secret dependency