### PR TITLE
chore: enable neutron keystone_secret manifest

### DIFF
--- a/base-helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/base-helm-configs/neutron/neutron-helm-overrides.yaml
@@ -399,7 +399,6 @@ manifests:
   pod_rally_test: false
   secret_db: false
   secret_ingress_tls: false
-  secret_keystone: false
   secret_rabbitmq: false
   service_ingress_server: false
   deployment_rpc_server: false


### PR DESCRIPTION
re-enable allowing the helm chart to create the necessary neutron per-service secrets. 