### PR TITLE
chore: disable innodb_snapshot_isolation

### DIFF
--- a/base-kustomize/mariadb-cluster/base/mariadb-replication.yaml
+++ b/base-kustomize/mariadb-cluster/base/mariadb-replication.yaml
@@ -48,12 +48,13 @@ spec:
     # Keep binlogs long enough for replica recovery and PITR workflows.
     binlog_expire_logs_seconds=604800
     innodb_autoinc_lock_mode=2
+    innodb_snapshot_isolation=OFF
     max_allowed_packet=256M
     max_connections=10240
     open_files_limit=10240
     max-connect-errors=1000000
     innodb_rollback_on_timeout=1
-    performance_schema=ON
+    performance_schema=OFF
     innodb_log_buffer_size=33554432
     innodb_flush_log_at_trx_commit=1
     ignore_db_dirs=lost+found


### PR DESCRIPTION
This change sets innodb_snapshot_isolation=OFF in the MariaDB cluster configuration.

MariaDB 11.6.2 and newer default innodb_snapshot_isolation to ON. With OpenStack services using the default REPEATABLE-READ isolation level, this can cause transient write/write conflict detection errors to surface as MariaDB error 

1020:

Record has changed since last read in table 'services'.

This was causing nova-conductor to stackstrace on service updates.
reported bug: https://bugs.launchpad.net/nova/+bug/2116186