### PR TITLE
feat: add mariadb-backup-secrets to create-secrets.sh and update docs

### DIFF
--- a/bin/create-secrets.sh
+++ b/bin/create-secrets.sh
@@ -921,6 +921,19 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
+  name: mariadb-backup-secrets
+  namespace: openstack
+type: Opaque
+data:
+  access-key-id: $(echo -n "" | base64)
+  secret-access-key: $(echo -n "" | base64)
+  S3_ENDPOINT: $(echo -n "" | base64)
+  S3_REGION: $(echo -n "$region" | base64)
+  S3_BUCKET: $(echo -n "mariadb-backups" | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
   name: blazar-rabbitmq-password
   namespace: openstack
 type: Opaque

--- a/docs/mariadb-backuprestore-from-tempauth.md
+++ b/docs/mariadb-backuprestore-from-tempauth.md
@@ -20,6 +20,25 @@ This document provides procedures to restore MariaDB backups stored in Swift obj
 
 ### :material-key: Credentials
 
+!!! note "Information about the secrets used"
+
+    The `mariadb-backup-secrets` secret is automatically created with placeholder values when you run the `create-secrets.sh` script located in `/opt/genestack/bin`. However, you still need to populate the empty keys (`access-key-id`, `secret-access-key`, `S3_ENDPOINT`) with your region-specific values. You can use `/etc/genestack/secrets.yaml` to store these per-region values.
+
+    ??? example "Example secret generation"
+
+        If you haven't run `create-secrets.sh`, you can create the secret manually:
+
+        ``` shell
+        kubectl --namespace openstack \
+            create secret generic mariadb-backup-secrets \
+            --type Opaque \
+            --from-literal=access-key-id="<YOUR_ACCESS_KEY>" \
+            --from-literal=secret-access-key="<YOUR_SECRET_KEY>" \
+            --from-literal=S3_ENDPOINT="<SWIFT_S3_ENDPOINT_URL>" \
+            --from-literal=S3_REGION="<S3_REGION>" \
+            --from-literal=S3_BUCKET="mariadb-backups"
+        ```
+
 - Kubernetes secret (e.g., `region-1-credentials`, `region-2-credentials`, `region-3-credentials`) from cluster with `access-key-id` and `secret-access-key` keys, generated via:
 
     ```bash


### PR DESCRIPTION
[OSPC-1036](https://rackspace.atlassian.net/browse/OSPC-1036): Put mariadb-backup into the installation mainline documentation and handle secret generation