### PR TITLE
feat(docs/config): add Ironic OVN annotation document and config update

### DIFF
--- a/base-helm-configs/ironic/ironic-helm-overrides.yaml
+++ b/base-helm-configs/ironic/ironic-helm-overrides.yaml
@@ -205,8 +205,7 @@ dependencies:
         - endpoint: internal
           service: oslo_messaging
     db_sync:
-      jobs:
-        - ironic-db-init
+      jobs: []
 
 endpoints:
   baremetal:

--- a/docs/infrastructure-ovn-ironic-setup.md
+++ b/docs/infrastructure-ovn-ironic-setup.md
@@ -1,0 +1,131 @@
+## OVN Annotations for Ironic-Enabled Deployment
+
+This guide configures OVN annotations for deploying Ironic bare metal provisioning alongside OpenStack standard deployment (non-ironic). Ironic requires additional bridge, VLAN, and network mappings beyond standard OVN deployments.
+
+### Overview of OVN Annotations
+
+| <div style="width:220px">key</div> | type | <div style="width:128px">value</div>  | notes |
+| :--- | -- | :--: | :--- |
+| **ovn.openstack.org/int_bridge** | str | `br-int` | The name of the integration bridge that will be used. |
+| **ovn.openstack.org/bridges** | str | `br-ex,br-pxe` | **Required for Ironic:** Include `br-pxe` bridge for PXE provisioning network. |
+| **ovn.openstack.org/ports** | str | `br-ex:bond0,br-pxe:vlan126` | **Required for Ironic:** Map each bridge to physical interface or VLAN (format: `bridge:interface`). |
+| **ovn.openstack.org/vlans** | str | `vlan126:bond0:126:1500` | **Required for Ironic:** Create VLAN interface for PXE (format: `name:parent:vlan_id:mtu`). |
+| **ovn.openstack.org/mappings** | str | `physnet1:br-ex,physnet2:br-pxe` | **Required for Ironic:** Map Neutron provider networks to bridges. |
+| **ovn.openstack.org/availability_zones** | str | `az1` | Colon-separated list of Availability Zones. |
+| **ovn.openstack.org/gateway** | str | `enabled` | Mark node as an OVN gateway for external traffic. |
+
+## Applying Ironic Annotations
+
+When deploying Ironic for bare metal provisioning, apply the key annotations (bridges, ports, vlans, mappings) shown in the overview table above to required controller and network nodes if not already exists.
+
+### Set `ovn.openstack.org/int_bridge`
+
+Set the name of the OVS integration bridge we'll use. In general, this should be **br-int**, and while this setting is implicitly configured we're explicitly defining what the bridge will be on these nodes. This step mirrors standard deployments and can be skipped if already configured."
+
+``` shell
+kubectl annotate \
+        nodes \
+        -l openstack-control-plane=enabled -l openstack-network-node=enabled \
+        ovn.openstack.org/int_bridge='br-int'
+```
+
+### Set `ovn.openstack.org/bridges`
+
+Set the name of the OVS bridges we'll use. These are the bridges you will use on your hosts within OVS. The option is a string and comma separated. You can define as many OVS type bridges you need or want for your environment.
+
+!!! note
+
+    The Ironic functional example here annotates all nodes; however, not all nodes have to have the same setup. If the `ovn.openstack.org/bridges` is already configured, use `--overwrite` when annotating the nodes.
+
+``` shell
+# First, set the required bridges including br-pxe
+kubectl annotate \
+        nodes \
+        -l openstack-control-plane=enabled -l openstack-network-node=enabled \
+        ovn.openstack.org/bridges='br-ex,br-pxe'
+```
+ 
+### Set `ovn.openstack.org/ports`
+
+Set the port mapping for OVS interfaces to a local physical interface on a given machine. This option uses a colon between the OVS bridge and the physical interface, `OVS_BRIDGE:PHYSICAL_INTERFACE_NAME`. Multiple bridge mappings can be defined by separating values with a comma.
+
+!!! note
+
+    For setting up Ironic, the port mapping should reference the provisioning vlan interface (e.g., `br-ex:bond0,br-pxe:vlanXYZ`) rather than to a physical interface. If the `ovn.openstack.org/ports` is already configured, use `--overwrite` when annotating the nodes.
+
+```shell
+# Update vlanXYZ with your interface name for provisioning network
+kubectl annotate \
+        nodes \
+        -l openstack-control-plane=enabled -l openstack-network-node=enabled \
+        ovn.openstack.org/ports='br-ex:bond0,br-pxe:vlanXYZ'
+```
+
+### Set `ovn.openstack.org/vlans` (Optional)
+
+Create Linux VLAN subinterfaces on the host before OVN attaches them to an OVS bridge. This is useful when the host must keep the parent interface while OVN consumes a tagged child interface such as `bond0.XYZ`.
+
+```shell
+# Create the provisioning VLAN interface
+kubectl annotate \ 
+        nodes \
+        -l openstack-control-plane=enabled -l openstack-network-node=enabled \
+        ovn.openstack.org/vlans='vlanXYZ:bond0:XYZ:1500'
+```
+
+
+### Set `ovn.openstack.org/mappings`
+
+Set the Neutron bridge mapping. This maps the Neutron interfaces to the ovs bridge names. These are colon delimitated between `NEUTRON_INTERFACE:OVS_BRIDGE`. Multiple bridge mappings can be defined here and are separated by commas.
+
+!!! note
+
+    Set the Neutron bridge mapping for Ironic provisioning network. Neutron interfaces are string value and can be anything you want. The `NEUTRON_INTERFACE` value defined will be used when you create provider type networks after the cloud is online. If the `ovn.openstack.org/mappings` is already configured, use `--overwrite` when annotating the nodes.
+
+``` shell
+# Map to Neutron provider networks
+kubectl annotate \
+        nodes \
+        -l openstack-control-plane=enabled -l openstack-network-node=enabled \
+        ovn.openstack.org/mappings='physnet1:br-ex,physnet2:br-pxe'
+```
+
+### Set `ovn.openstack.org/availability_zones`
+
+Set the OVN availability zones which inturn creates neutron availability zones. Multiple network availability zones can be defined and are colon separated which allows us to define all of the availability zones a node will be able to provide for, `nova:az1:az2:az3`.
+
+``` shell
+kubectl annotate \
+        nodes \
+        -l openstack-control-plane=enabled -l openstack-network-node=enabled \
+        ovn.openstack.org/availability_zones='az1'
+```
+
+### Set `ovn.openstack.org/gateway`
+
+Define where the gateways nodes will reside. There are many ways to run this, some like every compute node to be a gateway, some like dedicated gateway hardware. Either way you will need at least one gateway node within your environment.
+NOTE: In the following example, we will apply the 'ovn.openstack.org/gateway' to dedicated network nodes.  You will want to change the node filter to the specific nodes you wish to use as ovn gateway nodes.
+
+``` shell
+kubectl annotate \
+        nodes \
+        $(kubectl get nodes | awk '/network/ {print $1}') \
+        ovn.openstack.org/gateway='enabled'
+```
+
+## Run the OVN integration
+
+With all of the annotations defined, we can now apply the network policy with the following command.
+
+``` shell
+kubectl apply -k /etc/genestack/kustomize/ovn/overlay
+```
+
+After running the setup, nodes will have the label `ovn.openstack.org/configured` with a date stamp when it was configured.
+If there's ever a need to reconfigure a node, simply remove the label and the DaemonSet will take care of it automatically.
+
+### Key Differences from Standard OVN
+
+- **Provisioning Bridge (`br-pxe`):** Ironic requires a dedicated bridge for PXE boot traffic
+- **Provisioning VLAN:** The provisioning network must be isolated on a specific VLAN interface
+- **Provider Network Mapping:** The provisioning network must be explicitly mapped to Neutron

--- a/docs/infrastructure-ovn-setup.md
+++ b/docs/infrastructure-ovn-setup.md
@@ -216,7 +216,7 @@ kubectl annotate \
 With all of the annotations defined, we can now apply the network policy with the following command.
 
 ``` shell
-kubectl apply -k /etc/genestack/kustomize/ovn/base
+kubectl apply -k /etc/genestack/kustomize/ovn/overlay
 ```
 
 After running the setup, nodes will have the label `ovn.openstack.org/configured` with a date stamp when it was configured.

--- a/docs/openstack-compute-kit-nova.md
+++ b/docs/openstack-compute-kit-nova.md
@@ -25,3 +25,8 @@ If running in an environment that doesn't have hardware virtualization extension
 
     You may need to provide custom values to configure your openstack services, for a simple single region or lab deployment you can supply an additional overrides flag using the example found at `base-helm-configs/aio-example-openstack-overrides.yaml`.
     In other cases such as a multi-region deployment you may want to view the [Multi-Region Support](multi-region-support.md) guide to for a workflow solution.
+
+!!! note
+
+    When deploying Ironic, set `manifests.statefulset_compute_ironic: true` in `nova-helm-overrides.yaml` to enable the Nova Ironic compute service.
+

--- a/docs/openstack-ironic-operational-guide.md
+++ b/docs/openstack-ironic-operational-guide.md
@@ -26,6 +26,8 @@ Nova may not see a newly available node immediately after enrollment because the
 The provisioning flow typically follows this sequence:
 
 ```text
+Create provisioning network
+   ->
 Create flavor
    ->
 Set bare metal resource class mapping
@@ -49,21 +51,22 @@ Create server with matching flavor and required image
 
 This guide walks through the following workflow:
 
-1. Create a flavor for bare metal server
-2. Set a resource class mapping so Nova can match the flavor to the correct Ironic node
-3. Enroll the physical node into Ironic with the correct driver and interfaces
-4. Set properties and driver details such as hardware specs, BMC credentials, and boot method
-5. Create ports so the node can participate in provisioning and tenant networking
-6. Validate step verifies that required fields are present and the interfaces such as power, management, deploy, boot, and others report valid/usable for the baremetal node
-7. Manage step moves the bare metal node from enroll to manageable by starting verification and confirming that Ironic can control the node using the configured interfaces and credentials.
-8. Provide the node to transition it into the available state, making it ready for scheduling.
-9. Create a server with the matching flavor and image using either PXE/iPXE or virtual media boot.
+1. Create The Ironic Provisioning Network
+2. Create a flavor for bare metal server
+3. Set a resource class mapping so Nova can match the flavor to the correct Ironic node
+4. Enroll the physical node into Ironic with the correct driver and interfaces
+5. Set properties and driver details such as hardware specs, BMC credentials, and boot method
+6. Create ports so the node can participate in provisioning and tenant networking
+7. Validate step verifies that required fields are present and the interfaces such as power, management, deploy, boot, and others report valid/usable for the baremetal node
+8. Manage step moves the bare metal node from enroll to manageable by starting verification and confirming that Ironic can control the node using the configured interfaces and credentials.
+9. Provide the node to transition it into the available state, making it ready for scheduling.
+10. Create a server with the matching flavor and image using either PXE/iPXE or virtual media boot.
 
 Ironic supports multiple boot interfaces. PXE is the standard network boot mechanism, while virtual media typically relies on the BMC to mount boot media remotely instead of using traditional PXE infrastructure.
 
 ## Prerequisites
 
-Before enrolling a node, ensure that the OpenStack environment and all required services are properly configured and available. Also create the dedicated provisioning network, if it does not already exist.
+Before enrolling a node, ensure that the OpenStack environment and all required services are properly configured and available. 
 
 ### Source Administrative Credentials
 
@@ -83,15 +86,15 @@ openstack network create \
   --provider-physical-network physnet2 \
   --provider-network-type flat \
   --disable-port-security \
-  ironic
+  baremetal-provisioning-network
 
 openstack subnet create \
   --allocation-pool start=172.23.209.11,end=172.23.211.254 \
   --gateway 172.23.208.1 \
   --dns-nameserver 1.1.1.1 \
   --subnet-range 172.23.208.0/22 \
-  --network ironic \
-  ironic-subnet1
+  --network baremetal-provisioning-network \
+  baremetal-provisioning-subnet
 ```
 
 ### Create Bare Metal Flavor
@@ -339,7 +342,7 @@ openstack server create \
   --flavor GP2.XL \
   --image ubuntu-jammy-metal-simple \
   --key-name <nova key name> \
-  --network ironic $node
+  --network baremetal-provisioning-network $node
 
 --hint query='["=", "$hypervisor_hostname", "<baremetal_node_UUID>"]'
 

--- a/helm-chart-versions.yaml
+++ b/helm-chart-versions.yaml
@@ -16,7 +16,7 @@ charts:
   grafana: 10.1.0
   heat: 2025.2.12+3bc47c1e9
   horizon: 2024.2.264+13651f45-628a320c
-  ironic: 2024.2.121+13651f45-628a320c
+  ironic: 2025.1.4+ed289c1cd
   keystone: 2025.1.5+ed289c1cd
   kube-ovn: v1.15.4
   kube-prometheus-stack: 78.3.0


### PR DESCRIPTION
- Add Ironic-specific OVN setup documentation covering the provisioning bridge, VLAN, port, and provider network mappings.
- Bump the Ironic chart version to 2025.1.4+ed289c1cd.
- Remove the explicit ironic-db-init job dependency from the db_sync configuration.
- Update the Ironic operational guide to consistently create and use baremetal-provisioning-network for subnet creation and server deployment.
- Point the OVN setup instructions to the overlay kustomization.