### PR TITLE
feat: OSPC-2093: Exposing etcd metrics and updating the monitoring stack to collect those metrics

### DIFF
--- a/ansible/inventory/genestack/group_vars/etcd.yml
+++ b/ansible/inventory/genestack/group_vars/etcd.yml
@@ -3,7 +3,12 @@
 # etcd_compaction_retention: 0
 
 ## Set level of detail for etcd exported metrics, specify 'extensive' to include histogram metrics.
-# etcd_metrics: basic
+etcd_metrics: basic
+
+## Expose etcd metrics on a dedicated HTTP port (no TLS required).
+## This generates ETCD_LISTEN_METRICS_URLS in etcd.env and is required
+## for the monitoring stack to scrape etcd without mTLS certificates.
+etcd_metrics_port: 2381
 
 ## Etcd is restricted by default to 512M on systems under 4GB RAM, 512MB is not enough for much more than testing.
 ## Set this if your etcd nodes have less than 4GB but you want more RAM for etcd. Set to 0 for unrestricted RAM.

--- a/base-helm-configs/opentelemetry-kube-stack/opentelemetry-kube-stack-helm-overrides.yaml
+++ b/base-helm-configs/opentelemetry-kube-stack/opentelemetry-kube-stack-helm-overrides.yaml
@@ -362,6 +362,15 @@ collectors:
                 static_configs:
                   - targets: ["localhost:9474"]
 
+        prometheus/etcd:
+          config:
+            scrape_configs:
+              - job_name: etcd
+                scrape_interval: 30s
+                metrics_path: /metrics
+                static_configs:
+                  - targets: ["localhost:2381"]
+
         filelog/k8s_containers:
           max_concurrent_files: 1024
           fingerprint_size: 1024
@@ -717,6 +726,7 @@ collectors:
             receivers:
               - hostmetrics
               - prometheus/libvirt
+              - prometheus/etcd
             processors:
               - attributes/add-node-labels
               - resourcedetection/env
@@ -1222,7 +1232,7 @@ kubeDns:
   enabled: false
 
 kubeEtcd:
-  enabled: true
+  enabled: false
   service:
     enabled: true
     port: 2381


### PR DESCRIPTION
Exposing etcd metrics on a dedicated plain HTTP port (2381) so the monitoring stack can scrape them without requiring mTLS certificates.

etcd is deployed via Kubespray as a host (systemd) service with `ETCD_METRICS=basic` set by default. However, metrics are only accessible on the main client port (2379) which requires mTLS — making it impractical for the monitoring stack to scrape.

The Kubespray `etcd.env.j2` template only generates `ETCD_LISTEN_METRICS_URLS` when `etcd_metrics_port` is defined.

The OTel daemon collector already runs as a DaemonSet with hostNetwork: true on every node. It would scrape `localhost:2381` for etcd metrics using a simple static config:
```
prometheus/etcd:
  config:
    scrape_configs:
      - job_name: etcd
        scrape_interval: 30s
        static_configs:
          - targets: ["localhost:2381"]
```
Added `prometheus/etcd` to the daemon's metrics pipeline.
And, set `kubeEtcd.enabled: false` as it is no longer needed, because OTel daemon collector already runs as a DaemonSet with `hostNetwork: true` on every node. It would scrape `localhost:2381` for etcd metrics using a simple static config (mentioned above).