### PR TITLE
fix(cinder): Disable send_actions in volume usage audit job

### DIFF
--- a/base-kustomize/cinder/base/cinder-volume-usage-audit-no-send-actions.yaml
+++ b/base-kustomize/cinder/base/cinder-volume-usage-audit-no-send-actions.yaml
@@ -1,0 +1,8 @@
+- op: replace
+  path: /data/volume-usage-audit.sh
+  value: |
+    #!/bin/bash
+
+    set -ex
+
+    exec cinder-volume-usage-audit

--- a/base-kustomize/cinder/base/kustomization.yaml
+++ b/base-kustomize/cinder/base/kustomization.yaml
@@ -8,3 +8,9 @@ resources:
   - hpa-cinder-scheduler.yaml
   - hpa-cinder-api.yaml
   - policies.yaml
+patches:
+  - path: cinder-volume-usage-audit-no-send-actions.yaml
+    target:
+      version: v1
+      kind: ConfigMap
+      name: cinder-bin


### PR DESCRIPTION
Remove --send_actions from cinder-volume-usage-audit to prevent replayed Cinder lifecycle notifications from recreating/resurrecting deleted resources in Gnocchi during periodic audit runs.