### PR TITLE
fix(memcached): Align name with chart StatefulSet (#1593)

### DIFF
--- a/base-helm-configs/barbican/barbican-helm-overrides.yaml
+++ b/base-helm-configs/barbican/barbican-helm-overrides.yaml
@@ -119,7 +119,7 @@ endpoints:
     hosts:
       default: memcached
     statefulset:
-      name: memcached
+      name: memcached-memcached
       replicas: 3
   oslo_messaging:
     host_fqdn_override:

--- a/base-helm-configs/blazar/blazar-helm-overrides.yaml
+++ b/base-helm-configs/blazar/blazar-helm-overrides.yaml
@@ -32,7 +32,7 @@ endpoints:
     host_fqdn_override:
       default: memcached.openstack.svc.cluster.local
     statefulset:
-      name: memcached
+      name: memcached-memcached
       replicas: 3
   fluentd:
     namespace: fluentbit

--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -2307,7 +2307,7 @@ endpoints:
     hosts:
       default: memcached
     statefulset:
-      name: memcached
+      name: memcached-memcached
       replicas: 3
 
   fluentd:

--- a/base-helm-configs/cinder/cinder-helm-overrides.yaml
+++ b/base-helm-configs/cinder/cinder-helm-overrides.yaml
@@ -403,7 +403,7 @@ endpoints:
     hosts:
       default: memcached
     statefulset:
-      name: memcached
+      name: memcached-memcached
       replicas: 3
   oslo_messaging:
     host_fqdn_override:

--- a/base-helm-configs/designate/designate-helm-overrides.yaml
+++ b/base-helm-configs/designate/designate-helm-overrides.yaml
@@ -647,7 +647,7 @@ endpoints:
     host_fqdn_override:
       default: null
     statefulset:
-      name: memcached
+      name: memcached-memcached
       replicas: 3
     port:
       memcache:

--- a/base-helm-configs/freezer/freezer-helm-overrides.yaml
+++ b/base-helm-configs/freezer/freezer-helm-overrides.yaml
@@ -32,7 +32,7 @@ endpoints:
     host_fqdn_override:
       default: memcached.openstack.svc.cluster.local
     statefulset:
-      name: memcached
+      name: memcached-memcached
       replicas: 3
   fluentd:
     namespace: fluentbit

--- a/base-helm-configs/glance/glance-helm-overrides.yaml
+++ b/base-helm-configs/glance/glance-helm-overrides.yaml
@@ -213,7 +213,7 @@ endpoints:
     hosts:
       default: memcached
     statefulset:
-      name: memcached
+      name: memcached-memcached
       replicas: 3
   oslo_messaging:
     host_fqdn_override:

--- a/base-helm-configs/heat/heat-helm-overrides.yaml
+++ b/base-helm-configs/heat/heat-helm-overrides.yaml
@@ -188,7 +188,7 @@ endpoints:
     hosts:
       default: memcached
     statefulset:
-      name: memcached
+      name: memcached-memcached
       replicas: 3
   oslo_messaging:
     host_fqdn_override:

--- a/base-helm-configs/ironic/ironic-helm-overrides.yaml
+++ b/base-helm-configs/ironic/ironic-helm-overrides.yaml
@@ -297,7 +297,7 @@ endpoints:
     hosts:
       default: memcached
     statefulset:
-      name: memcached
+      name: memcached-memcached
       replicas: 3
     port:
       memcache:

--- a/base-helm-configs/keystone/keystone-helm-overrides.yaml
+++ b/base-helm-configs/keystone/keystone-helm-overrides.yaml
@@ -183,7 +183,7 @@ endpoints:
     hosts:
       default: memcached
     statefulset:
-      name: memcached
+      name: memcached-memcached
       replicas: 3
   oslo_messaging:
     host_fqdn_override:

--- a/base-helm-configs/manila/manila-helm-overrides.yaml
+++ b/base-helm-configs/manila/manila-helm-overrides.yaml
@@ -125,7 +125,7 @@ endpoints:
     host_fqdn_override:
       default: memcached.openstack.svc.cluster.local
     statefulset:
-      name: memcached
+      name: memcached-memcached
       replicas: 3
   oslo_messaging:
     hosts:

--- a/base-helm-configs/masakari/masakari-helm-overrides.yaml
+++ b/base-helm-configs/masakari/masakari-helm-overrides.yaml
@@ -105,7 +105,7 @@ endpoints:
     hosts:
       default: memcached
     statefulset:
-      name: memcached
+      name: memcached-memcached
       replicas: 3
   oslo_messaging:
     host_fqdn_override:

--- a/base-helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/base-helm-configs/neutron/neutron-helm-overrides.yaml
@@ -381,7 +381,7 @@ endpoints:
     hosts:
       default: memcached
     statefulset:
-      name: memcached
+      name: memcached-memcached
       replicas: 3
   oslo_messaging:
     host_fqdn_override:

--- a/base-helm-configs/nova/nova-helm-overrides.yaml
+++ b/base-helm-configs/nova/nova-helm-overrides.yaml
@@ -269,7 +269,7 @@ endpoints:
     hosts:
       default: memcached
     statefulset:
-      name: memcached
+      name: memcached-memcached
       replicas: 3
   oslo_messaging:
     host_fqdn_override:

--- a/base-helm-configs/octavia/octavia-helm-overrides.yaml
+++ b/base-helm-configs/octavia/octavia-helm-overrides.yaml
@@ -225,7 +225,7 @@ endpoints:
     hosts:
       default: memcached
     statefulset:
-      name: memcached
+      name: memcached-memcached
       replicas: 3
   oslo_messaging:
     host_fqdn_override:

--- a/base-helm-configs/placement/placement-helm-overrides.yaml
+++ b/base-helm-configs/placement/placement-helm-overrides.yaml
@@ -96,7 +96,7 @@ endpoints:
     hosts:
       default: memcached
     statefulset:
-      name: memcached
+      name: memcached-memcached
       replicas: 3
 
 dependencies:

--- a/base-helm-configs/trove/trove-helm-overrides.yaml
+++ b/base-helm-configs/trove/trove-helm-overrides.yaml
@@ -67,7 +67,7 @@ pod:
     hosts:
       default: memcached
     statefulset:
-      name: memcached
+      name: memcached-memcached
       replicas: 3
   oslo_messaging:
     host_fqdn_override:
@@ -199,7 +199,7 @@ endpoints:
     hosts:
       default: memcached
     statefulset:
-      name: memcached
+      name: memcached-memcached
       replicas: 3
   oslo_messaging:
     host_fqdn_override:

--- a/base-helm-configs/zaqar/zaqar-helm-overrides.yaml
+++ b/base-helm-configs/zaqar/zaqar-helm-overrides.yaml
@@ -54,7 +54,7 @@ endpoints:
     host_fqdn_override:
       default: memcached.openstack.svc.cluster.local
     statefulset:
-      name: memcached
+      name: memcached-memcached
       replicas: 3
 
 pod:

--- a/base-kustomize/memcached/aio/kustomization.yaml
+++ b/base-kustomize/memcached/aio/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 patches:
   - target:
       kind: StatefulSet
-      name: memcached
+      name: memcached-memcached
     patch: |-
       - op: replace
         path: /spec/replicas

--- a/base-kustomize/memcached/base/kustomization.yaml
+++ b/base-kustomize/memcached/base/kustomization.yaml
@@ -11,7 +11,7 @@ resources:
 patches:
   - target:
       kind: StatefulSet
-      name: memcached
+      name: memcached-memcached
     path: memcached-statefulset-extra-env-vars-patch.yaml
 
   - target:
@@ -22,4 +22,4 @@ patches:
   - path: memcached-statefulset-patch.yaml
     target:
       kind: StatefulSet
-      name: memcached
+      name: memcached-memcached

--- a/base-kustomize/memcached/base/memcached-statefulset-patch.yaml
+++ b/base-kustomize/memcached/base/memcached-statefulset-patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: memcached
+  name: memcached-memcached
 spec:
   template:
     spec:


### PR DESCRIPTION
Use memcached-memcached for the StatefulSet name in oslo_cache endpoints and kustomize patch targets, matching what the openstack-helm chart actually renders (release name + chart name). Per-pod memcache_servers entries now resolve correctly instead of pointing at hostnames that never existed.