### PR TITLE
fix(cache): Add statefulset to oslo_cache (#1595)

### DIFF
--- a/base-helm-configs/cloudkitty/cloudkitty-helm-overrides.yaml
+++ b/base-helm-configs/cloudkitty/cloudkitty-helm-overrides.yaml
@@ -42,6 +42,9 @@ endpoints:
       default: memcached
     host_fqdn_override:
       default: memcached.openstack.svc.cluster.local
+    statefulset:
+      name: memcached-memcached
+      replicas: 3
 
 dependencies:
   static:

--- a/base-helm-configs/gnocchi/gnocchi-helm-overrides.yaml
+++ b/base-helm-configs/gnocchi/gnocchi-helm-overrides.yaml
@@ -160,6 +160,9 @@ endpoints:
       default: memcached.openstack.svc.cluster.local
     hosts:
       default: memcached
+    statefulset:
+      name: memcached-memcached
+      replicas: 3
 
 manifests:
   ingress_api: false

--- a/base-helm-configs/horizon/horizon-helm-overrides.yaml
+++ b/base-helm-configs/horizon/horizon-helm-overrides.yaml
@@ -6783,6 +6783,9 @@ endpoints:
   oslo_cache:
     host_fqdn_override:
       default: memcached.openstack.svc.cluster.local
+    statefulset:
+      name: memcached-memcached
+      replicas: 3
     hosts:
       default: memcached
   oslo_messaging:

--- a/base-helm-configs/magnum/magnum-helm-overrides.yaml
+++ b/base-helm-configs/magnum/magnum-helm-overrides.yaml
@@ -179,6 +179,9 @@ endpoints:
       default: memcached.openstack.svc.cluster.local
     hosts:
       default: memcached
+    statefulset:
+      name: memcached-memcached
+      replicas: 3
   oslo_messaging:
     host_fqdn_override:
       default: rabbitmq.openstack.svc.cluster.local

--- a/base-helm-configs/opentelemetry-kube-stack/opentelemetry-kube-stack-helm-overrides.yaml
+++ b/base-helm-configs/opentelemetry-kube-stack/opentelemetry-kube-stack-helm-overrides.yaml
@@ -907,8 +907,36 @@ collectors:
             rabbitmq.node.sockets_used_details.rate:
               enabled: true
 
-        memcached:
-          endpoint: memcached.openstack.svc.cluster.local:11211
+        memcached/memcached-0:
+          endpoint: memcached-memcached-0.memcached.openstack.svc.cluster.local:11211
+          collection_interval: 30s
+          transport: tcp
+          metrics:
+            memcached.operation_hit_ratio:
+              enabled: true
+            memcached.current_items:
+              enabled: true
+            memcached.evictions:
+              enabled: true
+            memcached.bytes:
+              enabled: true
+
+        memcached/memcached-1:
+          endpoint: memcached-memcached-1.memcached.openstack.svc.cluster.local:11211
+          collection_interval: 30s
+          transport: tcp
+          metrics:
+            memcached.operation_hit_ratio:
+              enabled: true
+            memcached.current_items:
+              enabled: true
+            memcached.evictions:
+              enabled: true
+            memcached.bytes:
+              enabled: true
+
+        memcached/memcached-2:
+          endpoint: memcached-memcached-2.memcached.openstack.svc.cluster.local:11211
           collection_interval: 30s
           transport: tcp
           metrics:
@@ -1150,7 +1178,9 @@ collectors:
               - otlp
               - mysql
               - rabbitmq
-              - memcached
+              - memcached/memcached-0
+              - memcached/memcached-1
+              - memcached/memcached-2
               - prometheus/infra
 #              - httpcheck # uncomment to add endpoint checking metrics with above endpoint config...
             processors:

--- a/base-helm-configs/skyline/skyline-helm-overrides.yaml
+++ b/base-helm-configs/skyline/skyline-helm-overrides.yaml
@@ -40,6 +40,9 @@ endpoints:
       default: memcached.openstack.svc.cluster.local
     hosts:
       default: memcached
+    statefulset:
+      name: memcached-memcached
+      replicas: 3
 
 pod:
   replicas:


### PR DESCRIPTION
Add missing statefulset name under oslo_cache sections in several services.

OTel does not use the helm kit macro to expand statefulset replicas so we define the endpoints manually.