### PR TITLE
fix(gnocchi): Set coordination URL with query params

### DIFF
--- a/base-helm-configs/gnocchi/gnocchi-helm-overrides.yaml
+++ b/base-helm-configs/gnocchi/gnocchi-helm-overrides.yaml
@@ -50,6 +50,8 @@ conf:
         </Directory>
     </VirtualHost>
   gnocchi:
+    DEFAULT:
+      coordination_url: memcached://memcached-memcached-0.memcached.openstack.svc.cluster.local:11211?hosts=memcached-memcached-1.memcached.openstack.svc.cluster.local:11211&hosts=memcached-memcached-2.memcached.openstack.svc.cluster.local:11211
     metricd:
       workers: 2
   gnocchi_api_wsgi:


### PR DESCRIPTION
The Gnocchi helm chart tries to provide the coordination URL as a comma separated list of host:port but the underlying lib(s) used by Gnocchi do not like that and instead need the query parameter syntax manually added here to work as expected.