### PR TITLE
fix hyperconverged lab Gateway listener setup

### DIFF
--- a/base-kustomize/envoyproxy-gateway/base/envoy-gateway.yaml
+++ b/base-kustomize/envoyproxy-gateway/base/envoy-gateway.yaml
@@ -13,22 +13,10 @@ spec:
     annotations:
       metallb.io/address-pool: gateway-api-external
   listeners:
-    - name: cluster-http
+    - name: http-wildcard-listener
       port: 80
       protocol: HTTP
       hostname: "*.cluster.local"
       allowedRoutes:
         namespaces:
           from: All
-    - name: cluster-tls
-      port: 443
-      protocol: HTTPS
-      hostname: "*.cluster.local"
-      allowedRoutes:
-        namespaces:
-          from: All
-      tls:
-        mode: Terminate
-        certificateRefs:
-          - kind: Secret
-            name: wildcard-cluster-tls-secret

--- a/base-kustomize/envoyproxy-gateway/base/envoy-gateway.yaml
+++ b/base-kustomize/envoyproxy-gateway/base/envoy-gateway.yaml
@@ -13,10 +13,22 @@ spec:
     annotations:
       metallb.io/address-pool: gateway-api-external
   listeners:
-    - name: http-wildcard-listener
+    - name: cluster-http
       port: 80
       protocol: HTTP
       hostname: "*.cluster.local"
       allowedRoutes:
         namespaces:
           from: All
+    - name: cluster-tls
+      port: 443
+      protocol: HTTPS
+      hostname: "*.cluster.local"
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: wildcard-cluster-tls-secret

--- a/bin/setup-envoy-gateway.sh
+++ b/bin/setup-envoy-gateway.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # shellcheck disable=SC2045,SC2124,SC2145,SC2164,SC2236,SC2294
+set -euo pipefail
 
 # Function to display general usage
 usage() {
@@ -1375,22 +1376,52 @@ else
     echo "Skipping ACME configuration (no email provided)"
 fi
 
-# Process routes
-sudo mkdir -p /etc/genestack/gateway-api/routes
-for route in $(ls -1 /opt/genestack/etc/gateway-api/routes); do
-    sed "s/your.domain.tld/${GATEWAY_DOMAIN}/g" "/opt/genestack/etc/gateway-api/routes/${route}" > "/tmp/${route}"
-    sudo mv -v "/tmp/${route}" "/etc/genestack/gateway-api/routes/${route}"
-done
-kubectl apply -f /etc/genestack/gateway-api/routes
-
 # Process listeners
 sudo mkdir -p /etc/genestack/gateway-api/listeners
 for listener in $(ls -1 /opt/genestack/etc/gateway-api/listeners); do
     sed "s/your.domain.tld/${GATEWAY_DOMAIN}/g" "/opt/genestack/etc/gateway-api/listeners/${listener}" > "/tmp/${listener}"
     sudo mv -v "/tmp/${listener}" "/etc/genestack/gateway-api/listeners/${listener}"
 done
-kubectl patch -n envoy-gateway gateway flex-gateway \
-              --type='json' \
-              --patch="$(jq -s 'flatten | .' /etc/genestack/gateway-api/listeners/*)"
+
+function ensure_gateway_listener() {
+    local listener_file="$1"
+    local listener_name desired_listener existing_listener
+
+    listener_name=$(jq -r '.[0].value.name' "${listener_file}")
+    desired_listener=$(jq -c '.[0].value | {name, port, protocol, hostname, tls, allowedRoutes}' "${listener_file}")
+    existing_listener=$(kubectl -n envoy-gateway get gateway flex-gateway -o json | \
+        jq -c --arg name "${listener_name}" '.spec.listeners[]? | select(.name == $name) | {name, port, protocol, hostname, tls, allowedRoutes}')
+
+    if [ -z "${existing_listener}" ]; then
+        echo "Patching flex-gateway with listener ${listener_name}"
+        kubectl patch -n envoy-gateway gateway flex-gateway \
+            --type='json' \
+            --patch-file "${listener_file}"
+    elif [ "${existing_listener}" != "${desired_listener}" ]; then
+        echo "ERROR: flex-gateway listener ${listener_name} exists but does not match ${listener_file}"
+        echo "Existing: ${existing_listener}"
+        echo "Desired:  ${desired_listener}"
+        exit 1
+    else
+        echo "Listener ${listener_name} already present on flex-gateway"
+    fi
+
+    if ! kubectl -n envoy-gateway get gateway flex-gateway -o jsonpath='{range .spec.listeners[*]}{.name}{"\n"}{end}' | grep -qx "${listener_name}"; then
+        echo "ERROR: listener ${listener_name} was not found on flex-gateway after patching"
+        exit 1
+    fi
+}
+
+for listener_file in /etc/genestack/gateway-api/listeners/*; do
+    ensure_gateway_listener "${listener_file}"
+done
+
+# Process routes after their parent listeners exist on the Gateway.
+sudo mkdir -p /etc/genestack/gateway-api/routes
+for route in $(ls -1 /opt/genestack/etc/gateway-api/routes); do
+    sed "s/your.domain.tld/${GATEWAY_DOMAIN}/g" "/opt/genestack/etc/gateway-api/routes/${route}" > "/tmp/${route}"
+    sudo mv -v "/tmp/${route}" "/etc/genestack/gateway-api/routes/${route}"
+done
+kubectl apply -f /etc/genestack/gateway-api/routes
 
 echo "Setup Complete"

--- a/bin/setup-envoy-gateway.sh
+++ b/bin/setup-envoy-gateway.sh
@@ -1376,6 +1376,13 @@ else
     echo "Skipping ACME configuration (no email provided)"
 fi
 
+# Process routes
+sudo mkdir -p /etc/genestack/gateway-api/routes
+for route in $(ls -1 /opt/genestack/etc/gateway-api/routes); do
+    sed "s/your.domain.tld/${GATEWAY_DOMAIN}/g" "/opt/genestack/etc/gateway-api/routes/${route}" > "/tmp/${route}"
+    sudo mv -v "/tmp/${route}" "/etc/genestack/gateway-api/routes/${route}"
+done
+
 # Process listeners
 sudo mkdir -p /etc/genestack/gateway-api/listeners
 for listener in $(ls -1 /opt/genestack/etc/gateway-api/listeners); do
@@ -1385,43 +1392,63 @@ done
 
 function ensure_gateway_listener() {
     local listener_file="$1"
-    local listener_name desired_listener existing_listener
+    local listener_name desired_listener existing_listener gateway_json existing_index patch_file
 
     listener_name=$(jq -r '.[0].value.name' "${listener_file}")
     desired_listener=$(jq -c '.[0].value | {name, port, protocol, hostname, tls, allowedRoutes}' "${listener_file}")
-    existing_listener=$(kubectl -n envoy-gateway get gateway flex-gateway -o json | \
-        jq -c --arg name "${listener_name}" '.spec.listeners[]? | select(.name == $name) | {name, port, protocol, hostname, tls, allowedRoutes}')
+    gateway_json=$(kubectl -n envoy-gateway get gateway flex-gateway -o json)
+    existing_listener=$(jq -c --arg name "${listener_name}" \
+        '.spec.listeners[]? | select(.name == $name) | {name, port, protocol, hostname, tls, allowedRoutes}' \
+        <<< "${gateway_json}")
 
-    if [ -z "${existing_listener}" ]; then
-        echo "Patching flex-gateway with listener ${listener_name}"
-        kubectl patch -n envoy-gateway gateway flex-gateway \
-            --type='json' \
-            --patch-file "${listener_file}"
-    elif [ "${existing_listener}" != "${desired_listener}" ]; then
-        echo "ERROR: flex-gateway listener ${listener_name} exists but does not match ${listener_file}"
-        echo "Existing: ${existing_listener}"
-        echo "Desired:  ${desired_listener}"
-        exit 1
-    else
+    if [ -n "${existing_listener}" ]; then
+        if [ "${existing_listener}" != "${desired_listener}" ]; then
+            echo "ERROR: flex-gateway listener ${listener_name} exists but does not match ${listener_file}"
+            echo "Existing: ${existing_listener}"
+            echo "Desired:  ${desired_listener}"
+            exit 1
+        fi
         echo "Listener ${listener_name} already present on flex-gateway"
+        return
     fi
 
-    if ! kubectl -n envoy-gateway get gateway flex-gateway -o jsonpath='{range .spec.listeners[*]}{.name}{"\n"}{end}' | grep -qx "${listener_name}"; then
-        echo "ERROR: listener ${listener_name} was not found on flex-gateway after patching"
-        exit 1
+    if [ "${listener_name}" = "http-wildcard-listener" ]; then
+        existing_index=$(jq -r '
+            .spec.listeners
+            | to_entries[]
+            | select(.value.name == "cluster-http")
+            | .key
+        ' <<< "${gateway_json}")
+        if [ -n "${existing_index}" ]; then
+            patch_file=$(mktemp)
+            jq -n --argjson index "${existing_index}" --argjson listener "${desired_listener}" \
+                '[{"op":"replace","path":("/spec/listeners/" + ($index|tostring)),"value":$listener}]' \
+                > "${patch_file}"
+            echo "Replacing cluster-http with ${listener_name} on flex-gateway"
+            kubectl patch -n envoy-gateway gateway flex-gateway \
+                --type='json' \
+                --patch-file "${patch_file}"
+            rm -f "${patch_file}"
+            return
+        fi
     fi
+
+    echo "Patching flex-gateway with listener ${listener_name}"
+    kubectl patch -n envoy-gateway gateway flex-gateway \
+        --type='json' \
+        --patch-file "${listener_file}"
 }
 
-for listener_file in /etc/genestack/gateway-api/listeners/*; do
-    ensure_gateway_listener "${listener_file}"
-done
-
-# Process routes after their parent listeners exist on the Gateway.
-sudo mkdir -p /etc/genestack/gateway-api/routes
-for route in $(ls -1 /opt/genestack/etc/gateway-api/routes); do
-    sed "s/your.domain.tld/${GATEWAY_DOMAIN}/g" "/opt/genestack/etc/gateway-api/routes/${route}" > "/tmp/${route}"
-    sudo mv -v "/tmp/${route}" "/etc/genestack/gateway-api/routes/${route}"
-done
-kubectl apply -f /etc/genestack/gateway-api/routes
+if [ "${HYPERCONVERGED:-false}" = "true" ]; then
+    for listener_file in /etc/genestack/gateway-api/listeners/*; do
+        ensure_gateway_listener "${listener_file}"
+    done
+    kubectl apply -f /etc/genestack/gateway-api/routes
+else
+    kubectl apply -f /etc/genestack/gateway-api/routes
+    kubectl patch -n envoy-gateway gateway flex-gateway \
+                  --type='json' \
+                  --patch="$(jq -s 'flatten | .' /etc/genestack/gateway-api/listeners/*)"
+fi
 
 echo "Setup Complete"


### PR DESCRIPTION
### Story
- https://rackspace.atlassian.net/browse/OSPC-2071

### Summary
This change fixes Envoy Gateway listener setup so Gateway API routes can reliably attach to the listener names the repo expects.

The Gateway updates preserve the existing listener-name contract such as keystone-https and http-wildcard-listener. The base Gateway no longer defines the conflicting wildcard HTTPS listener, the wildcard HTTP listener now uses the expected contract name, and setup-envoy-gateway.sh now runs with strict shell settings, patches listeners individually, verifies they exist on the live Gateway, and only applies routes after parent listeners are in place.