### PR TITLE
provide options to create capi mgmt lb with floating ip

### DIFF
--- a/ansible/roles/capi_cluster/README.md
+++ b/ansible/roles/capi_cluster/README.md
@@ -42,6 +42,8 @@ These are the role variables:
   - capi_mgmt_cluster_volume_type: volume type for the capi mgmt cluster (defaults to lvmdriver-1)
   - capi_mgmt_cluster_volumes: can be used to define the size of the volumes for capi mgmt cluster vms
   - capi_mgmt_etcd_backup_volume: can be used to define the size of the etcd backup volume and volume type
+  - capi_mgmt_cluster_lb_enable_fip: can be used to create the capi mgmt cluster lb on the geneve network and assign a floating ip; useful for flex clouds
+  - create_tunnelled_network_infra: when true creates the capi mgmt cluster instances on geneve network or otherwise directly on the external network
 
 Refer to defaults/main.yml with the role directory for more details on the variables
 

--- a/ansible/roles/capi_cluster/defaults/main.yml
+++ b/ansible/roles/capi_cluster/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for capi_mgmt_cluster
-#create_tunnelled_network_infra: false
+create_tunnelled_network_infra: true
 os_endpoint_type: "public"
 capi_mgmt_net_name: "capi-mgmt-net"
 capi_mgmt_subnet_name: "capi-mgmt-subnet"
@@ -13,6 +13,7 @@ capi_mgmt_cluster_lb_vip_fqdn: "capi-mgmt-lb.cluster.local"
 capi_mgmt_cluster_lb_name: "capi-mgmt-cluster-lb"
 capi_mgmt_cluster_lb_listener_name: "capi-mgmt-cluster-listener"
 capi_mgmt_cluster_lb_pool_name: "capi-mgmt-cluster-pool"
+capi_mgmt_cluster_lb_enable_fip: false
 
 capi_mgmt_secgroup_name: "capi-mgmt-cluster-secgroup"
 

--- a/ansible/roles/capi_cluster/tasks/capi_mgmt_assert_tasks.yml
+++ b/ansible/roles/capi_cluster/tasks/capi_mgmt_assert_tasks.yml
@@ -62,3 +62,8 @@
       - volume_type_info.volume_type.name == capi_mgmt_cluster_volume_type
     fail_msg: "provided volume type {{ capi_mgmt_cluster_volume_type }} does not exist"
   when: capi_boot_from_volume
+
+- name: Check if network topology is valid
+  ansible.builtin.fail:
+    msg: "Invalid network topology: 'capi_mgmt_cluster_lb_enable_fip=true and create_tunnelled_network_infra=false'"
+  when: capi_mgmt_cluster_lb_enable_fip | bool and not create_tunnelled_network_infra | bool

--- a/ansible/roles/capi_cluster/tasks/capi_mgmt_bfv_instance_tasks.yml
+++ b/ansible/roles/capi_cluster/tasks/capi_mgmt_bfv_instance_tasks.yml
@@ -35,6 +35,7 @@
     server: "{{ capi_mgmt_cluster_instances[0].name }}"
     wait: true
   register: _capi_boostrap_fip
+  when: create_tunnelled_network_infra | bool
 
 - name: Attach the etcd backup volume to the capi mgmt cluster bootstrap vm
   openstack.cloud.server_volume:

--- a/ansible/roles/capi_cluster/tasks/capi_mgmt_cluster_bootstrap_tasks.yml
+++ b/ansible/roles/capi_cluster/tasks/capi_mgmt_cluster_bootstrap_tasks.yml
@@ -1,5 +1,5 @@
 ---
-- name: add the capi mgmt cluster bootstrap vm to the inventory
+- name: add the capi mgmt cluster bootstrap vm to the inventory (fip)
   ansible.builtin.add_host:
     name: "{{ _capi_boostrap_fip.floating_ip.floating_ip_address }}"
     groups: 'capi_mgmt_bootstrp_vm'
@@ -7,6 +7,17 @@
     ansible_ssh_user: 'ubuntu'
     ansible_ssh_private_key_file: "{{ ansible_env.HOME }}/capi_mgmt_private_key"
     ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
+  when: create_tunnelled_network_infra | bool
+
+- name: add the capi mgmt cluster bootstrap vm to the inventory
+  ansible.builtin.add_host:
+    name: "{{ _capi_cluster_port_ips[0] }}"
+    groups: 'capi_mgmt_bootstrp_vm'
+    ansible_ssh_host: "{{ _capi_cluster_port_ips[0] }}"
+    ansible_ssh_user: 'ubuntu'
+    ansible_ssh_private_key_file: "{{ ansible_env.HOME }}/capi_mgmt_private_key"
+    ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
+  when: not create_tunnelled_network_infra | bool
 
 - name: Obtain the details of the capi mgmt cluster vms
   openstack.cloud.server_info:

--- a/ansible/roles/capi_cluster/tasks/capi_mgmt_lb_tasks.yml
+++ b/ansible/roles/capi_cluster/tasks/capi_mgmt_lb_tasks.yml
@@ -17,7 +17,23 @@
     state: present
     name: "{{ capi_mgmt_cluster_lb_name }}"
     vip_network: "{{ ext_net_id }}"
-  register: _capi_lb
+  register: _capi_lb_no_fip
+  when: not capi_mgmt_cluster_lb_enable_fip | bool
+
+- name: Create the loadbalancer for the capi mgmt cluster (with fip)
+  openstack.cloud.loadbalancer:
+    interface: "{{ os_endpoint_type | default('public') }}"
+    state: present
+    name: "{{ capi_mgmt_cluster_lb_name }}"
+    vip_network: "{{ _capi_geneve_net.id }}"
+    assign_floating_ip: true
+    floating_ip_network: "{{ ext_net_id }}"
+  register: _capi_lb_with_fip
+  when: capi_mgmt_cluster_lb_enable_fip | bool
+
+- name: Set the unified LB fact
+  ansible.builtin.set_fact:
+    _capi_lb: "{{ _capi_lb_with_fip if capi_mgmt_cluster_lb_enable_fip else _capi_lb_no_fip }}"
 
 - name: Create the listener for the capi mgmt cluster lb
   openstack.cloud.lb_listener:

--- a/ansible/roles/capi_cluster/tasks/capi_mgmt_secgroup_port_tasks.yml
+++ b/ansible/roles/capi_cluster/tasks/capi_mgmt_secgroup_port_tasks.yml
@@ -20,7 +20,7 @@
     ethertype: "{{ item.ethertype }}"
   loop: "{{ capi_mgmt_secgroup_rules }}"
 
-- name: Create the ports for capi mgmt cluster
+- name: Create the ports for capi mgmt cluster (overlay network)
   openstack.cloud.port:
     interface: "{{ os_interface_name | default('public') }}"
     state: present
@@ -29,9 +29,28 @@
     description: "{{ item.description }}"
     security_groups: "{{ _capi_sec_group.security_group.id }}"
   loop: "{{ capi_mgmt_cluster_ports }}"
-  register: _capi_port_results
+  register: _capi_port_results_overlay_net
+  when: create_tunnelled_network_infra | bool
   notify:
     - Delete capi mgmt cluster lb pool
+
+- name: Create the ports for capi mgmt cluster (external network)
+  openstack.cloud.port:
+    interface: "{{ os_interface_name | default('public') }}"
+    state: present
+    name: "{{ item.name }}"
+    network: "{{ ext_net_id }}"
+    description: "{{ item.description }}"
+    security_groups: "{{ _capi_sec_group.security_group.id }}"
+  loop: "{{ capi_mgmt_cluster_ports }}"
+  register: _capi_port_results_ext_net
+  when: not create_tunnelled_network_infra | bool
+  notify:
+    - Delete capi mgmt cluster lb pool
+
+- name: Set the unified capi mgmt cluster ports fact
+  ansible.builtin.set_fact:
+    _capi_port_results: "{{ _capi_port_results_overlay_net if create_tunnelled_network_infra else _capi_port_results_ext_net }}"
 
 - name: Flush handlers to immediately delete the lb pool in case of port change
   ansible.builtin.meta: flush_handlers

--- a/ansible/roles/capi_cluster/templates/capi-cluster-install.sh.j2
+++ b/ansible/roles/capi_cluster/templates/capi-cluster-install.sh.j2
@@ -4,7 +4,11 @@ set -euo pipefail
 
 # obtain values for octavia lb fqdn and lb vip
 OCTAVIA_LB_FQDN={{ capi_mgmt_cluster_lb_vip_fqdn }}
+{% if capi_mgmt_cluster_lb_enable_fip %}
+OCTAVIA_LB_VIP={{ _capi_lb.floating_ip.floating_ip_address }}
+{% else %}
 OCTAVIA_LB_VIP={{ _capi_lb.load_balancer.vip_address }}
+{% endif %}
 HELM_VERSION={{ capi_mgmt_helm_version | default('3') }}
 DNS_VARS={{ (capi_mgmt_dns_forwarders is defined) | ternary(true, false) }}
 

--- a/ansible/roles/capi_cluster/templates/capi-cluster-vars.yml.j2
+++ b/ansible/roles/capi_cluster/templates/capi-cluster-vars.yml.j2
@@ -2,9 +2,17 @@
 kube_version: 1.35.1
 apiserver_loadbalancer_domain_name: {{ capi_mgmt_cluster_lb_vip_fqdn }}
 loadbalancer_apiserver:
+{% if capi_mgmt_cluster_lb_enable_fip %}
+    address: {{ _capi_lb.floating_ip.floating_ip_address }}
+{% else %}
     address: {{ _capi_lb.load_balancer.vip_address }}
+{% endif %}
     port: 6443
 loadbalancer_apiserver_localhost: false
 loadbalancer_apiserver_port: 6443
 supplementary_addresses_in_ssl_keys:
+{% if capi_mgmt_cluster_lb_enable_fip %}
+  - {{ _capi_lb.floating_ip.floating_ip_address }}
+{% else %}
   - {{ _capi_lb.load_balancer.vip_address }}
+{% endif %}


### PR DESCRIPTION
In our flex environments the external network is generally only designated to be used for:
1. creating router gateway ports
2. floating ip(s)

the current capi_cluster ansible role however creates the loadbalancer directly on the external network and doesn't have the option to create the loadbalancer on the geneve network and then attach a floating ip to the lb

this was done mainly to avoid adding another network hop and to have better performance

though while testing this ansible role in flex dev env it was noticed that the attributes were set on the neutron subnet which prevented the role from creating the lb directly on the external network

to address this issue in this PR there is another parameter has been introduced which is "capi_mgmt_cluster_lb_enable_fip" which when set to 'true' creates the lb on the geneve network and then attaches an fip to the lb; thus making the role more suitable for flex env

there is also another parameter which is introduced "create_tunnelled_network_infra" which when set to 'true' creates the ports for mgmt cluster vms on the geneve network and if set to 'false' creates the ports directly on the external network

this PR provides more choices to deploy the capi mgmt cluster with different network arch as required for each individual use-case

if the parameters aren't changed then the defaults will be create the lb on the external network and create the cluster vms on the geneve network