### PR TITLE
chore: set private key rotation policy for public-endpoint-ca-cert to…

### DIFF
--- a/base-kustomize/envoyproxy-gateway/base/envoy-internal-gateway-issuer.yaml
+++ b/base-kustomize/envoyproxy-gateway/base/envoy-internal-gateway-issuer.yaml
@@ -18,6 +18,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
+    rotationPolicy: Never
   issuerRef:
     name: flex-gateway-issuer
     kind: ClusterIssuer


### PR DESCRIPTION
… Never

For cert-manager 1.18+, private key rotation policy changed to default to Always. helm-chart-versions already has cert-manager on v1.19.2.

None of our certificates in our environments have explicitly set a policy, so these now all default to generating a new key when the certificate rotates.

I think we would want to rotate that manually and carefully for a CA certificate

JIRA:OSPC-2083