### PR TITLE
chore(release): backport gnocchi, cinder, and memcache fixes

### DIFF
--- a/base-helm-configs/gnocchi/gnocchi-helm-overrides.yaml
+++ b/base-helm-configs/gnocchi/gnocchi-helm-overrides.yaml
@@ -15,6 +15,16 @@ images:
     ks_service: "ghcr.io/rackerlabs/genestack-images/openstack-client:latest"
     ks_user: "ghcr.io/rackerlabs/genestack-images/openstack-client:latest"
 
+# Extend deleted resource retention from default 1day to 90 days.
+# The resources_cleaner cronjob runs `gnocchi resource batch delete "ended_at < '-TTL'"`,
+# permanently removing resources (and their metrics) marked as ended longer than the TTL.
+# A longer retention window provides buffer for:
+#   - Billing reconciliation and historical queries
+#   - Investigating resource revision anomalies
+jobs:
+  resources_cleaner:
+    deleted_resources_ttl: '90d'
+
 ceph_client:
   user_secret_name: gnocchi-temp-keyring
 

--- a/base-helm-configs/memcached/memcached-helm-overrides.yaml
+++ b/base-helm-configs/memcached/memcached-helm-overrides.yaml
@@ -1,14 +1,7 @@
 ---
 conf:
   memcached:
-    # Default value in openstack-helm memcached chart is 8192 for max_connections
-    # Setting 4096 to make identical with previously used bitnami memcached chart
-    max_connections: 4096
-    # NOTE(pordirect): this should match the value in
-    # `pod.resources.memcached.memory`
-    # Memory was set to 9216 Mi in previously used bitnami memcached chart https://github.com/rackerlabs/genestack/blob/065150e2efad717681f43afee527ada523af3356/base-helm-configs/memcached/memcached-helm-overrides.yaml#L131-L132
-    # Setting to 3072 Mi as the limit in resources is set to 3072 Mi
-    memory: 3072
+    memory: 4096  # NOTE(LukeRepko): Cache size MUST be lower than pod max memory
     # If we set stats_cachedump to false then we will have to add one additional argument "-X"
     # in https://github.com/rackerlabs/genestack/tree/main/base-kustomize/memcached/base/memcached-bin-configmap-patch.yaml
     # This is because openstack-helm memcached chart doesn't have some variables as compared to previously used bitnami memcached chart
@@ -126,7 +119,7 @@ pod:
     server:
       limits:
         cpu: "2"
-        memory: "3072Mi"
+        memory: "6144Mi"  # NOTE(LukeRepko): Should be 1.25 to 1.5 times the item cache memory
       requests:
         cpu: 200m
         memory: 2048Mi

--- a/base-kustomize/cinder/base/cinder-volume-usage-audit-no-send-actions.yaml
+++ b/base-kustomize/cinder/base/cinder-volume-usage-audit-no-send-actions.yaml
@@ -1,0 +1,8 @@
+- op: replace
+  path: /data/volume-usage-audit.sh
+  value: |
+    #!/bin/bash
+
+    set -ex
+
+    exec cinder-volume-usage-audit

--- a/base-kustomize/cinder/base/kustomization.yaml
+++ b/base-kustomize/cinder/base/kustomization.yaml
@@ -8,3 +8,9 @@ resources:
   - hpa-cinder-scheduler.yaml
   - hpa-cinder-api.yaml
   - policies.yaml
+patches:
+  - path: cinder-volume-usage-audit-no-send-actions.yaml
+    target:
+      version: v1
+      kind: ConfigMap
+      name: cinder-bin


### PR DESCRIPTION
### Summary
This PR backports three unrelated bug fixes from the `main` branch to the current release branch.

### Cherry-Picks Included
* **fix(gnocchi)**: Extend resource retention to 90d
  * Source Commit: `37101cf6`
  * Original PR: #1579
* **fix(cinder)**: Disable send_actions in volume usage audit job
  * Source Commit: `f67cb52f`
  * Original PR: #1588
* **fix(OSPC-2109)**: increase memcache pod memory limit
  * Source Commit: `6114d72e`
  * Original PR: #1616