### PR TITLE
feat(ceilometer): per-container Swift egress metric

### DIFF
--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -1377,6 +1377,8 @@ conf:
           storage.objects.containers:
           storage.containers.objects:
           storage.containers.objects.size:
+          storage.containers.objects.outgoing.bytes:
+            archive_policy_name: low
 
       - resource_type: volume
         metrics:
@@ -1923,6 +1925,46 @@ conf:
           - "name"
           - "unit"
           - "volume"
+
+      # NOTE(LukeRepko): Container-scoped Swift outgoing bytes.
+      #
+      # The catch-all Swift meter above attaches storage.objects.outgoing.bytes
+      # to the account-level swift_account resource (resource_id =
+      # payload.target.id, which is the bare project_id). To get per-container
+      # visibility we emit a distinct metric, storage.containers.objects.outgoing.bytes,
+      # against the per-container swift_account resource (resource_id =
+      # <project_id>_<container>) created by the storage.containers.objects
+      # pollster. Distinct metric name avoids any double-count or aggregation
+      # ambiguity with the account-level total, and mirrors the upstream
+      # storage.objects.X (account) vs storage.containers.objects.X (container)
+      # convention.
+      #
+      # Gating off payload.target.metadata.container is unsafe: it is null on
+      # account-only requests and jsonpath-rw-ext's `sub` calls re.sub on the
+      # value with no try/except, raising TypeError and taking the whole
+      # notification batch with it (catch-all account-level sample included).
+      #
+      # Drive both name and resource_id off payload.target.metadata.path,
+      # which the middleware always sets. The path is
+      # 'v1/AUTH_<project>/<container>...' for container/object requests and
+      # 'v1/AUTH_<project>' for account-only requests. `sub` returns no match
+      # when its regex doesn't match, so on account-only paths the path-sub
+      # collapses to [] and the `+` concat in name collapses with it. The
+      # measurements filter in name handles the symmetric case (no outgoing
+      # bytes on this request, e.g. PUT). With name in `lookup`, the meter
+      # silently early-returns via nb_samples<=0 in both cases.
+      - name: $.payload.measurements[?(@.metric.name='storage.objects.outgoing.bytes')].metric.name.`sub(/^.*$/, storage.containers.objects.outgoing.bytes)` + $.payload.target.metadata.path.`sub(/^v1\/AUTH_[^\/]+\/[^\/]+.*$/, )`
+        event_type: "objectstore.http.request"
+        type: "delta"
+        unit: "B"
+        volume: $.payload.measurements[?(@.metric.name='storage.objects.outgoing.bytes')].result
+        resource_id: $.payload.target.metadata.path.`sub(/^v1\/AUTH_([^\/]+)\/([^\/]+).*$/, \\1_\\2)`
+        user_id: $.payload.initiator.id
+        project_id: $.payload.initiator.project_id
+        lookup:
+          - "name"
+          - "volume"
+          - "resource_id"
 
       - name: "memory"
         event_type: &instance_events compute.instance.(?!create.start|update).*


### PR DESCRIPTION
Adds `storage.containers.objects.outgoing.bytes` so Swift download bytes can be attributed to the container they came from, not just the parent account. Account-level `storage.objects.outgoing.bytes` is untouched.

The notification from the Swift proxy already carries the container name; a new meter consumes it and emits a sample against the existing per-container `swift_account` resource (`<project>_<container>`).

## About the `name:` expression

It's two checks AND-ed together. Ceilometer has no `if`/`when` clause, so the gate is encoded in the expression itself — return nothing = skip:

- **Left:** did this request actually send bytes out? (filter measurements for `storage.objects.outgoing.bytes`, rewrite to the new name)
- **Right:** was the request scoped to a container? (regex on the URL path)
- **`+`:** logical AND — if either side is empty, no sample.

Net effect: only object/container GETs with a non-empty response body accrue. HEAD / POST / PUT / DELETE on a container or object don't, since the Swift middleware only emits outgoing-bytes when `bytes_sent > 0`.

## Querying

| Use case | Metric | Resource |
| --- | --- | --- |
| Account total | `storage.objects.outgoing.bytes` | `<project>` |
| Per container | `storage.containers.objects.outgoing.bytes` | `<project>_<container>` |

## Validation

- Dry-run against representative `objectstore.http.request` payloads (incl. the original crash payload).
- Staging: no tracebacks, container measures accrue as expected, account total tracks slightly higher (account HEAD / listing traffic), as predicted.

Config-only change, easy revert.
