### PR TITLE
feat(telemetry): swift HTTP request-class metrics

### DIFF
--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -1379,6 +1379,12 @@ conf:
           storage.containers.objects.size:
           storage.containers.objects.outgoing.bytes:
             archive_policy_name: low
+          storage.objects.http.class.a:
+            archive_policy_name: low
+          storage.objects.http.class.b:
+            archive_policy_name: low
+          storage.objects.http.class.c:
+            archive_policy_name: low
 
       - resource_type: volume
         metrics:
@@ -1965,6 +1971,71 @@ conf:
           - "name"
           - "volume"
           - "resource_id"
+
+      # NOTE(LukeRepko): Account-level Swift HTTP request-class meters.
+      #
+      # Classify each successful objectstore.http.request notification into
+      # one of three tiered counters based on the HTTP method recorded in
+      # payload.target.action (set by ceilometermiddleware to method.lower()):
+      #   class.a: put, post, copy   -- expensive-tier writes / metadata
+      #   class.b: get               -- reads
+      #   class.c: delete, head, options
+      #
+      # Counted against the account-level swift_account resource via
+      # resource_id = payload.target.id (the bare project_id), matching the
+      # existing catch-all Swift meter convention. Container-level resources
+      # are not targeted.
+      #
+      # Gating uses the same idiom as the per-container outgoing-bytes meter:
+      # the `name` field is built by AND-ing two `sub(...)` matches via `+`
+      # (action regex AND outcome=success). Either side returning [] collapses
+      # the concat to []; with `name` in `lookup`, the meter early-returns via
+      # nb_samples<=0 -- no sample, no warning, no traceback.
+      #
+      # `volume` filters $.payload.measurements for storage.api.request, which
+      # ceilometermiddleware >= 3.11.0 always emits with result=1 for every
+      # objectstore.http.request notification. A JSONPath that resolves to
+      # [1] (not the literal int 1) keeps `volume` compatible with `lookup`
+      # mode, which expects list-shaped attributes.
+      #
+      # Counting policy: success only. The catch-all Swift meter above does
+      # not filter outcome because it is a passthrough for byte counters; for
+      # tier classification, success-only matches the design spec.
+      - name: $.payload.target.action.`sub(/^(put|post|copy)$/, storage.objects.http.class.a)` + $.payload.outcome.`sub(/^success$/, )`
+        event_type: "objectstore.http.request"
+        type: "delta"
+        unit: "request"
+        volume: $.payload.measurements[?(@.metric.name='storage.api.request')].result
+        resource_id: $.payload.target.id
+        user_id: $.payload.initiator.id
+        project_id: $.payload.initiator.project_id
+        lookup:
+          - "name"
+          - "volume"
+
+      - name: $.payload.target.action.`sub(/^get$/, storage.objects.http.class.b)` + $.payload.outcome.`sub(/^success$/, )`
+        event_type: "objectstore.http.request"
+        type: "delta"
+        unit: "request"
+        volume: $.payload.measurements[?(@.metric.name='storage.api.request')].result
+        resource_id: $.payload.target.id
+        user_id: $.payload.initiator.id
+        project_id: $.payload.initiator.project_id
+        lookup:
+          - "name"
+          - "volume"
+
+      - name: $.payload.target.action.`sub(/^(delete|head|options)$/, storage.objects.http.class.c)` + $.payload.outcome.`sub(/^success$/, )`
+        event_type: "objectstore.http.request"
+        type: "delta"
+        unit: "request"
+        volume: $.payload.measurements[?(@.metric.name='storage.api.request')].result
+        resource_id: $.payload.target.id
+        user_id: $.payload.initiator.id
+        project_id: $.payload.initiator.project_id
+        lookup:
+          - "name"
+          - "volume"
 
       - name: "memory"
         event_type: &instance_events compute.instance.(?!create.start|update).*

--- a/base-helm-configs/gnocchi/gnocchi-helm-overrides.yaml
+++ b/base-helm-configs/gnocchi/gnocchi-helm-overrides.yaml
@@ -51,9 +51,23 @@ conf:
     </VirtualHost>
   gnocchi:
     DEFAULT:
-      coordination_url: memcached://memcached-memcached-0.memcached.openstack.svc.cluster.local:11211?hosts=memcached-memcached-1.memcached.openstack.svc.cluster.local:11211&hosts=memcached-memcached-2.memcached.openstack.svc.cluster.local:11211
+      coordination_url: "memcached://memcached-memcached-0.memcached.openstack.svc.cluster.local:11211\
+        ?hosts=memcached-memcached-1.memcached.openstack.svc.cluster.local:11211\
+        &hosts=memcached-memcached-2.memcached.openstack.svc.cluster.local:11211"
+    api:
+      max_limit: 10000
+      operation_timeout: 20
     metricd:
-      workers: 2
+      workers: 4
+      metric_processing_delay: 5
+      metric_reporting_delay: 60
+      processing_replicas: 4
+    incoming:
+      driver: redis
+      redis_url: "redis://redis-sentinel-sentinel-0.redis-sentinel-sentinel-headless.redis-systems.svc.cluster.local:26379?sentinel=myMaster\
+        &sentinel_fallback=redis-sentinel-sentinel-1.redis-sentinel-sentinel-headless.redis-systems.svc.cluster.local:26379\
+        &sentinel_fallback=redis-sentinel-sentinel-2.redis-sentinel-sentinel-headless.redis-systems.svc.cluster.local:26379\
+        &db=0"
   gnocchi_api_wsgi:
     wsgi:
       processes: 2

--- a/docs/metering-gnocchi.md
+++ b/docs/metering-gnocchi.md
@@ -50,16 +50,18 @@ Gnocchi supports various storage backends for incoming measures and aggregated
 metrics, including:
 
  - File
- - Ceph (_flex default for `incoming` & `storage`_)
+ - Ceph (_flex default for `storage`_)
  - OpenStack Swift
  - Amazon S3
- - Redis
+ - Redis (_flex default for `incoming`_)
 
 For smaller architectures, using the file driver to store data on disk may be
 sufficient. However, S3, Ceph, and Swift offer more scalable storage options,
-with Ceph being the recommended choice due to its better consistency. In
-larger or busier deployments, a common recommendation is to use Redis for
-incoming measure storage and Ceph for aggregate storage.
+with Ceph being the recommended choice due to its better consistency for
+aggregated time-series storage. Genestack pairs Ceph storage with Redis
+(via the in-cluster `redis-sentinel` cluster) for incoming measures so that
+`gnocchi-metricd` does not backlog on small-object I/O against Ceph under
+event-driven workloads such as Swift notification meters.
 
 ### Indexing
 

--- a/docs/openstack-gnocchi.md
+++ b/docs/openstack-gnocchi.md
@@ -8,6 +8,17 @@ gnocchi-metricd).
 
 [![Gnocchi Architecture](assets/images/gnocchi-architecture.svg)](openstack-gnocchi.md)
 
+## Prerequisites
+
+Gnocchi depends on three pre-existing platform services. Confirm each is
+deployed and reachable from the `openstack` namespace before continuing.
+
+| Component  | Used for                                          | Deployment guide |
+|------------|---------------------------------------------------|------------------|
+| PostgreSQL | Indexer (resources, metrics, archive policies)    | [Deploy PostgreSQL](infrastructure-postgresql.md) |
+| Ceph       | Aggregated time-series storage                    | [Rook-Ceph Internal](storage-ceph-rook-internal.md) / [Rook-Ceph External](storage-ceph-rook-external.md) |
+| Redis      | Incoming-measure queue (via `redis-sentinel`)     | [Deploy Redis](infrastructure-redis.md) |
+
 ## Create Secrets
 
 !!! note "Information about the secretes used"
@@ -29,6 +40,15 @@ gnocchi-metricd).
         ```
 
 ## Object Storage Options
+
+!!! note "Incoming-measure storage"
+
+    Gnocchi's incoming-measure queue is configured to use the in-cluster
+    `redis-sentinel` cluster (deployed by the `redis-operator`). The
+    aggregated time-series backend selected below is used for storage
+    only. This split keeps `gnocchi-metricd` responsive under
+    event-driven workloads where small-bundle ingestion against Ceph
+    would otherwise bottleneck.
 
 === "Ceph Internal _(default)_"
 

--- a/releasenotes/notes/gnocchi-redis-incoming-driver-7f2e8b4a3d1c9f6e.yaml
+++ b/releasenotes/notes/gnocchi-redis-incoming-driver-7f2e8b4a3d1c9f6e.yaml
@@ -1,0 +1,29 @@
+---
+upgrade:
+  - |
+    Gnocchi's incoming-measure store now defaults to Redis via the
+    in-cluster ``redis-sentinel`` service instead of Ceph; aggregated
+    time-series storage continues to use Ceph. The redis-sentinel
+    cluster deployed by the redis-operator is therefore a prerequisite
+    for the next ``install-gnocchi.sh`` run. Pending incoming bundles
+    still queued in the Ceph incoming pool at the moment of the
+    switchover are orphaned -- ``gnocchi-metricd`` only reads from
+    Redis after the upgrade -- so roll the chart during a quiet window
+    or after metricd has caught up. No aggregated time-series data is
+    affected.
+
+  - |
+    The Gnocchi ``low`` archive policy's ``back_window`` was raised
+    from 0 to 1 (one 5-minute granularity, ~5 minutes of permissible
+    lateness) to absorb intra-batch timestamp reordering. Measures
+    arriving microseconds behind a peer in the same metricd batch are
+    no longer silently dropped at ingestion. ``back_window`` is
+    monotonic and cannot be decreased on an existing policy.
+
+other:
+  - |
+    Together these changes let event-driven Swift telemetry --
+    notification-emitted ``storage.objects.outgoing.bytes`` and the new
+    ``storage.objects.http.class.{a,b,c}`` request-class counters --
+    keep up with production-shape workloads without metricd backlog
+    growth on the ``gnocchi.metrics`` Ceph pool.


### PR DESCRIPTION
Adds three account-level Swift HTTP request-class counters and the
Gnocchi backend tuning needed to keep up with their sample volume.

## What's new

- **`storage.objects.http.class.{a,b,c}`** — account-level request
  classification driven by `payload.target.action` on
  `objectstore.http.request` events:
  - **A:** PUT, POST, COPY (writes / metadata)
  - **B:** GET (reads)
  - **C:** DELETE, HEAD, OPTIONS
  Each successful event contributes value 1 to exactly one class.
  Lands on the existing account-level `swift_account` resource, no
  new resource type.
- **Gnocchi incoming → redis-sentinel** — moves the high-frequency
  bundle queue off the `gnocchi.metrics` Ceph pool. Adding the new
  event-driven meters multiplied small-object I/O against Ceph
  enough to backlog metricd; Redis turns each bundle drain into a
  microsecond op and the queue stays drained under load. The `low`
  archive policy's `back_window` was also bumped from 0 to 1 to
  absorb intra-batch timestamp reordering.

## About the gating in the new meters

Ceilometer's declarative meter language has no `if`/`when` clause, so
each meter encodes its match as a `sub(...) + sub(...)` AND-gate in
the `name:` field — left side rewrites the action regex into the
class name, right side requires `outcome=success`. When either half
returns `[]` the sample is silently skipped. Documented inline.