### PR TITLE
chore(barbican): Remove superflous .conf.cache overrides

### DIFF
--- a/base-helm-configs/barbican/barbican-helm-overrides.yaml
+++ b/base-helm-configs/barbican/barbican-helm-overrides.yaml
@@ -48,9 +48,6 @@ conf:
   barbican:
     DEFAULT:
       host_href: http://barbican-api.openstack.svc.cluster.local:9311
-    cache:
-      enabled: true
-      backend: oslo_cache.memcache_pool
     database:
       connection_debug: 0
       connection_recycle_time: 600


### PR DESCRIPTION
Not shown in docs here:
https://docs.openstack.org/barbican/latest/configuration/config.html

This results in a superfluous rendering in barbican.conf like:

```
[cache]
backend = oslo_cache.memcache_pool
enabled = true
```

Rendering and diffing the whole chart (all.yaml) with `dyff between` shows changes for this like:

```
dyff between barbican_decoded.yaml barbican_barbican_decoded.yaml
     _        __  __
   _| |_   _ / _|/ _|  between barbican_decoded.yaml, 27 documents
 / _' | | | | |_| |_       and barbican_barbican_decoded.yaml, 27 documents
| (_| | |_| |  _|  _|
 \__,_|\__, |_| |_|   returned two differences
        |___/

data.barbican.conf  (v1/Secret/barbican-etc)
  ± value change in multiline text (no inserts, one deletion)
      [DEAFULT]
      rpc_response_timeout = 120
      [DEFAULT]
      host_href = http://barbican-api.openstack.svc.cluster.local:9311
      log_config_append = /etc/barbican/logging.conf
      transport_url = rabbit://barbican:kubectl+--namespace+openstack+get+secret+barbican-rabbitmq-password+-o+jsonpath%3D%7B.data.password%7D@rabbitmq.openstack.svc.cluster.local:5672/barbican
      [barbican_api]
      bind_port = <no value>
    - [cache]
    - backend = oslo_cache.memcache_pool
    - enabled = true
      [database]
      connection = mysql+pymysql://barbican:kubectl --namespace openstack get secret barbican-db-password -o jsonpath={.data.password}@mariadb-cluster-primary:3306/barbican?charset=utf8
      connection_debug = 0
      connection_recycle_time = 600

      [38 lines unchanged)]

      [oslo_policy]
      enforce_new_defaults = true
      enforce_scope = true
      policy_file = /etc/barbican/policy.yaml



spec.template.metadata.annotations.configmap-etc-hash  (apps/v1/Deployment/barbican-api)
  ± value change
    - 64de3767239d023fefab1172429cefc48d54ecfcf51e1514d00aff106647aa58
    + af477458b61fbd72131bf0e168b11234ee1d959df58a313bfff66801329cbccc
```

