### PR TITLE
chore: Remove superflous .conf.cache overrides for services without that memcache support

### DIFF
--- a/base-helm-configs/blazar/blazar-helm-overrides.yaml
+++ b/base-helm-configs/blazar/blazar-helm-overrides.yaml
@@ -60,9 +60,6 @@ conf:
       host_href: "http://blazar-api.openstack.svc.cluster.local:1234"
       enable_notification_events: true
       notification_format: versioned
-    cache:
-      enabled: true
-      backend: oslo_cache.memcache_pool
     database:
       connection_debug: 0
       connection_recycle_time: 600

--- a/base-helm-configs/cinder/cinder-helm-overrides.yaml
+++ b/base-helm-configs/cinder/cinder-helm-overrides.yaml
@@ -146,9 +146,6 @@ conf:
       scheduler_default_filters: "AvailabilityZoneFilter,CapacityFilter,CapabilitiesFilter"
       storage_availability_zone: az1
       use_multipath_for_image_xfer: false
-    cache:
-      enabled: true
-      backend: oslo_cache.memcache_pool
     database:
       connection_debug: 0
       connection_recycle_time: 600

--- a/base-helm-configs/designate/designate-helm-overrides.yaml
+++ b/base-helm-configs/designate/designate-helm-overrides.yaml
@@ -395,9 +395,6 @@ conf:
       enable_api_admin: true
       enabled_extensions_v2: quotas,reports
       workers: 2
-    cache:
-      enabled: true
-      backend: oslo_cache.memcache_pool
     service:worker:
       enabled: true
       notify: false

--- a/base-helm-configs/freezer/freezer-helm-overrides.yaml
+++ b/base-helm-configs/freezer/freezer-helm-overrides.yaml
@@ -51,9 +51,6 @@ conf:
   freezer:
     DEFAULT:
       host_href: "http://freezer-api.openstack.svc.cluster.local:9090"
-    cache:
-      enabled: true
-      backend: oslo_cache.memcache_pool
     database:
       connection_debug: 0
       connection_recycle_time: 600

--- a/base-helm-configs/glance/glance-helm-overrides.yaml
+++ b/base-helm-configs/glance/glance-helm-overrides.yaml
@@ -63,9 +63,6 @@ conf:
       cinder_use_multipath: true
       cinder_enforce_multipath: false
       show_image_direct_url: false
-    cache:
-      enabled: true
-      backend: oslo_cache.memcache_pool
     oslo_middleware:
       enable_proxy_headers_parsing: true
     keystone_authtoken:

--- a/base-helm-configs/ironic/ironic-helm-overrides.yaml
+++ b/base-helm-configs/ironic/ironic-helm-overrides.yaml
@@ -80,9 +80,6 @@ conf:
     redfish:
       use_swift: false
       kernel_append_params: "nofb nomodeset vga=normal ipa-debug=1"
-    cache:
-      enabled: true
-      backend: oslo_cache.memcache_pool
     database:
       connection_debug: 0
       connection_recycle_time: 600

--- a/base-helm-configs/manila/manila-helm-overrides.yaml
+++ b/base-helm-configs/manila/manila-helm-overrides.yaml
@@ -202,9 +202,6 @@ conf:
       api_paste_config: /etc/manila/api-paste.ini
       enabled_share_backends: generic
       enabled_share_protocols: NFS
-    cache:
-      enabled: true
-      backend: oslo_cache.memcache_pool
     keystone_authtoken:
       auth_type: password
       auth_version: v3

--- a/base-helm-configs/masakari/masakari-helm-overrides.yaml
+++ b/base-helm-configs/masakari/masakari-helm-overrides.yaml
@@ -125,9 +125,6 @@ conf:
       nova_catalog_admin_info: compute:nova:adminURL
       service_down_time: 30
       wait_period_after_service_update: 30
-    cache:
-      enabled: true
-      backend: oslo_cache.memcache_pool
     host_failure:
       evacuate_all_instances: false
       ignore_instances_in_error_state: true

--- a/base-helm-configs/octavia/octavia-helm-overrides.yaml
+++ b/base-helm-configs/octavia/octavia-helm-overrides.yaml
@@ -125,9 +125,6 @@ conf:
     nova:
       enable_anti_affinity: "True"
       endpoint_type: internalURL
-    cache:
-      enabled: true
-      backend: oslo_cache.memcache_pool
     oslo_concurrency:
       lock_path: /tmp/octavia
     oslo_messaging_rabbit:

--- a/base-helm-configs/placement/placement-helm-overrides.yaml
+++ b/base-helm-configs/placement/placement-helm-overrides.yaml
@@ -51,9 +51,6 @@ conf:
       service_token_roles: service
       service_token_roles_required: true
       service_type: placement
-    cache:
-      enabled: true
-      backend: oslo_cache.memcache_pool
     oslo_concurrency:
       lock_path: /tmp/placement
     placement:


### PR DESCRIPTION
This removes superfluous `.conf.cache` Helm overrides

Individual commit messages tend to link to sample configuration files from upstream OpenStack which show no `[config]` section, and configuration references, which often have a major heading for each INI-style header in the config (like `[cache]`), and don't actually *have* a `cache` section. The documentation standards vary in minor ways between services, but each service here appears to need this section just removed.

I went through the list of services where I expected I just needed to remove the `.conf.cache`. I will likely do another PR for the remaining ones. I have attempted to work through it in a manner so as to produce PRs where the needed classes of changes look similar. (I mention this to explain the superficially random appearance of the services in this PR)