### PR TITLE
fix: OSPC-2153: prevent world-writable stevedore cache files in ovn agents

### DIFF
--- a/base-kustomize/neutron/base/kustomization.yaml
+++ b/base-kustomize/neutron/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 
 patches:
   - path: patch-ovn-tls-optional.yaml
+  - path: patch-fix-world-writable-files.yaml
   - target:
       kind: ConfigMap
       name: neutron-bin

--- a/base-kustomize/neutron/base/patch-fix-world-writable-files.yaml
+++ b/base-kustomize/neutron/base/patch-fix-world-writable-files.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: neutron-ovn-metadata-agent-default
+spec:
+  template:
+    spec:
+      containers:
+        - name: neutron-ovn-metadata-agent
+          command:
+            - bash
+            - -c
+            - umask 0022 && /tmp/neutron-ovn-metadata-agent.sh
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: neutron-ovn-vpn-agent-default
+spec:
+  template:
+    spec:
+      containers:
+        - name: neutron-ovn-vpn-agent
+          command:
+            - bash
+            - -c
+            - umask 0022 && /tmp/neutron-ovn-vpn-agent.sh


### PR DESCRIPTION
Added a kustomize patch to fix world-writable files (0666) detected by host-level security scans at /root/.cache/python-entrypoints/ inside
neutron-ovn-metadata-agent and neutron-ovn-vpn-agent containers.

Root cause: stevedore creates cache files via open(filename, 'w'), which applies the process umask. The main container inherits umask 0000, and oslo.privsep's privsep-helper (metadata agent only) hardcodes os.umask(0) at oslo_privsep/daemon.py:397, overriding any parent umask.

Fix applies two layers of defence:
- Set umask 0022 before entrypoint script via container command override
- Mount /root/.cache as read-only (emptyDir + readOnly: true) to block privsep-helper from creating cache files (stevedore handles this gracefully via except OSError: pass)