### PR TITLE
chore(doc): Update deprecated kubectl flag in doc

### DIFF
--- a/docs/ovn-alert-claim-storm.md
+++ b/docs/ovn-alert-claim-storm.md
@@ -183,7 +183,7 @@ Some tips and recommendations:
   gateway node(s):
 
   ```
-  kubectl drain <gateway-node> --ignore-daemonsets --delete-local-data --force
+  kubectl drain <gateway-node> --ignore-daemonsets --delete-emptydir-data --force
   # reboot the node
   kubectl uncordon <gateway-node> # after return from reboot
   ```


### PR DESCRIPTION
`--delete-local-data` got deprecated for k8s v1.20

(cherry picked from commit 037e95cf6d733330fc75220853914b7816ce952d)