### PR TITLE
fix(gnocchi): move tooz coordination to redis

### DIFF
--- a/base-helm-configs/gnocchi/gnocchi-helm-overrides.yaml
+++ b/base-helm-configs/gnocchi/gnocchi-helm-overrides.yaml
@@ -51,9 +51,10 @@ conf:
     </VirtualHost>
   gnocchi:
     DEFAULT:
-      coordination_url: "memcached://memcached-memcached-0.memcached.openstack.svc.cluster.local:11211\
-        ?hosts=memcached-memcached-1.memcached.openstack.svc.cluster.local:11211\
-        &hosts=memcached-memcached-2.memcached.openstack.svc.cluster.local:11211"
+      coordination_url: "redis://redis-sentinel-sentinel-0.redis-sentinel-sentinel-headless.redis-systems.svc.cluster.local:26379?sentinel=myMaster\
+        &sentinel_fallback=redis-sentinel-sentinel-1.redis-sentinel-sentinel-headless.redis-systems.svc.cluster.local:26379\
+        &sentinel_fallback=redis-sentinel-sentinel-2.redis-sentinel-sentinel-headless.redis-systems.svc.cluster.local:26379\
+        &db=1"
     api:
       max_limit: 10000
       operation_timeout: 20


### PR DESCRIPTION
metricd was logging "Unable to heartbeat" and "Unknown node" errors as tooz coordination keys were dropped from memcached under load. Memcached LRU-evicts regardless of TTL and shards keys client-side, so a pod rotation or a busy cache silently drops coordination state and lets two workers hold the same lock -- double-processing bundles and skewing sum/count on the new class.{a,b,c} and byte-count aggregations.

Point coordination_url at the existing redis-sentinel cluster (db=1, same URL shape as the incoming driver). Redis fits tooz better on four counts:

  - keys honor TTL; no LRU eviction under memory pressure
  - Sentinel failover promotes a replica with state intact rather than dropping keys with a pod
  - one master holds every lock, no client-side sharding to lose them under
  - atomic SET NX EX plus Lua CAS map cleanly onto tooz's "acquire with TTL" and "extend if still held" primitives, which memcached only approximates

Jira: https://rackspace.atlassian.net/browse/OSPC-2231