### PR TITLE
fix: pin k8s to latest supported version in kubespray 2.31.0

### DIFF
--- a/ansible/inventory/genestack/group_vars/k8s_cluster/k8s-cluster.yml
+++ b/ansible/inventory/genestack/group_vars/k8s_cluster/k8s-cluster.yml
@@ -17,7 +17,7 @@ kube_token_dir: "{{ kube_config_dir }}/tokens"
 kube_api_anonymous_auth: true
 
 ## Change this to use another Kubernetes version, e.g. a current beta release
-kube_version: 1.35.6
+kube_version: 1.35.4
 
 # Where the binaries will be downloaded.
 # Note: ensure that you've enough disk space (about 1G)


### PR DESCRIPTION
fix a regression in the kubernetes version.  kubespray v2.31.0 only supports up to k8s 1.35.4.