### PR TITLE
fix: Update Masakari to Epoxy release

### DIFF
--- a/base-helm-configs/masakari/masakari-helm-overrides.yaml
+++ b/base-helm-configs/masakari/masakari-helm-overrides.yaml
@@ -13,14 +13,14 @@
 ---
 images:
   tags:
-    db_init: ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest
-    db_sync: ghcr.io/rackerlabs/genestack-images/masakari:2024.1-latest
-    db_drop: ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest
-    ks_endpoints: ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest
-    ks_service: ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest
-    ks_user: ghcr.io/rackerlabs/genestack-images/heat:2024.1-latest
-    masakari_api: ghcr.io/rackerlabs/genestack-images/masakari:2024.1-latest
-    masakari_engine: ghcr.io/rackerlabs/genestack-images/masakari:2024.1-latest
+    db_init: ghcr.io/rackerlabs/genestack-images/heat:2025.1-latest
+    db_sync: ghcr.io/rackerlabs/genestack-images/masakari:2025.1-latest
+    db_drop: ghcr.io/rackerlabs/genestack-images/heat:2025.1-latest
+    ks_endpoints: ghcr.io/rackerlabs/genestack-images/heat:2025.1-latest
+    ks_service: ghcr.io/rackerlabs/genestack-images/heat:2025.1-latest
+    ks_user: ghcr.io/rackerlabs/genestack-images/heat:2025.1-latest
+    masakari_api: ghcr.io/rackerlabs/genestack-images/masakari:2025.1-latest
+    masakari_engine: ghcr.io/rackerlabs/genestack-images/masakari:2025.1-latest
     masakari_host_monitor: ghcr.io/rackerlabs/genestack-images/masakari-monitors:master-latest
     masakari_process_monitor: ghcr.io/rackerlabs/genestack-images/masakari-monitors:master-latest
     masakari_instance_monitor: ghcr.io/rackerlabs/genestack-images/masakari-monitors:master-latest


### PR DESCRIPTION
1. updating image tags to use 2025.1