### PR TITLE
fix: explicitly disable hw offloading in kube-ovn

### DIFF
--- a/base-helm-configs/kube-ovn/kube-ovn-helm-overrides.yaml
+++ b/base-helm-configs/kube-ovn/kube-ovn-helm-overrides.yaml
@@ -40,6 +40,7 @@ func:
   ENABLE_EXTERNAL_VPC: true
   OVSDB_CON_TIMEOUT: 5
   OVSDB_INACTIVITY_TIMEOUT: 30
+  HW_OFFLOAD: "false"  # note needs to be quoted as its not a binary T/F
 
 ipv4:
   POD_CIDR: "10.236.0.0/14"


### PR DESCRIPTION
Explicitly disable HWOFFLOAD in our kube-ovn configuration.  This value CAN be override in /etc/genestack or where ever your overrides live.  