### PR TITLE
fix(ceilometer): assign ResellerAdmin role

### DIFF
--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -2398,6 +2398,12 @@ dependencies:
 # values, but should include all endpoints
 # required by this chart
 endpoints:
+  identity:
+    auth:
+      ceilometer:
+        role:
+          - admin
+          - ResellerAdmin
   metering:
     port:
       api:


### PR DESCRIPTION
## Jira Card
- https://rackspace.atlassian.net/browse/OSPC-2031

## Summary

Configure the Ceilometer Keystone service user with the
`ResellerAdmin` role in addition to its existing `admin` role.

## Why

Ceilometer requires `ResellerAdmin` access to poll Swift accounts and
collect Object Storage consumption meters. Without this assignment,
Swift meters are unavailable even when the relevant Ceilometer
pollsters are enabled.

The existing `ceilometer-ks-user` job supports multiple roles. It
creates missing roles and assigns them to the Ceilometer user in the
service project, so no additional Keystone job is required.

## Changes

- Configure `endpoints.identity.auth.ceilometer.role` as a list.
- Retain the existing `admin` role.
- Add the `ResellerAdmin` role.

## Validation

After deploying or upgrading the chart:

```bash
openstack role assignment list \
  --user ceilometer \
  --project service \
  --names