### PR TITLE
feat(keystone): sync shibboleth secret on install

### DIFF
--- a/bin/install-keystone.sh
+++ b/bin/install-keystone.sh
@@ -135,6 +135,97 @@ set_args=(
     --set "endpoints.oslo_messaging.auth.keystone.password=$(kubectl --namespace openstack get secret keystone-rabbitmq-password -o jsonpath='{.data.password}' | base64 -d)"
 )
 
+# --- Shibboleth federation detection & idempotent secret sync ---
+# If the rendered chart references the `keystone-shibd-etc` secret (i.e. the
+# operator has wired the keystone overlay to include ../federation), sync the
+# secret from the on-host shibboleth config directory so operator edits under
+# `${GENESTACK_OVERRIDES_DIR}/keystone-sp/shibboleth/` are picked up without a
+# manual `kubectl create secret` step.
+KEYSTONE_SHIBBOLETH_DIR="${KEYSTONE_SHIBBOLETH_DIR:-${GENESTACK_OVERRIDES_DIR}/keystone-sp/shibboleth}"
+KEYSTONE_SHIBBOLETH_SECRET="keystone-shibd-etc"
+# Files the operator must supply before federation can function. Everything
+# else in the shibboleth directory ships as sane defaults in the repo copy at
+# etc/keystone-sp/shibboleth/.
+KEYSTONE_SHIBBOLETH_REQUIRED_FILES=(
+    shibboleth2.xml
+    sp-cert.pem
+    sp-key.pem
+    idp-metadata.xml
+)
+
+skip_shibboleth_secret=false
+if [[ "${SKIP_SHIBBOLETH_SECRET:-}" == "1" ]]; then
+    skip_shibboleth_secret=true
+    echo "SKIP_SHIBBOLETH_SECRET=1 set; bypassing federation secret sync."
+fi
+for _arg in "$@"; do
+    if [[ "$_arg" == "--dry-run" || "$_arg" == --dry-run=* ]]; then
+        skip_shibboleth_secret=true
+        echo "'--dry-run' detected in extra args; bypassing federation secret sync."
+        break
+    fi
+done
+unset _arg
+
+federation_enabled=false
+if ! $skip_shibboleth_secret; then
+    template_command=(
+        helm template "$SERVICE_NAME_DEFAULT" "$HELM_CHART_PATH"
+        --version "${SERVICE_VERSION}"
+        --namespace "$SERVICE_NAMESPACE"
+        "${overrides_args[@]}"
+        "${set_args[@]}"
+        --post-renderer "$GENESTACK_OVERRIDES_DIR/kustomize/kustomize.sh"
+        --post-renderer-args "$SERVICE_NAME_DEFAULT/overlay"
+    )
+    echo "Rendering chart to detect Shibboleth federation..."
+    template_stderr="$(mktemp)"
+    if ! rendered_manifests="$("${template_command[@]}" 2>"$template_stderr")"; then
+        echo "Error: 'helm template' failed while detecting federation. stderr:" >&2
+        cat "$template_stderr" >&2
+        rm -f "$template_stderr"
+        exit 1
+    fi
+    rm -f "$template_stderr"
+    if grep -q "${KEYSTONE_SHIBBOLETH_SECRET}" <<<"$rendered_manifests"; then
+        federation_enabled=true
+    fi
+fi
+
+if $federation_enabled; then
+    echo "Shibboleth federation detected; syncing secret '${KEYSTONE_SHIBBOLETH_SECRET}' in namespace '${SERVICE_NAMESPACE}'."
+    if [[ ! -d "$KEYSTONE_SHIBBOLETH_DIR" ]]; then
+        echo "Error: Shibboleth config directory not found: $KEYSTONE_SHIBBOLETH_DIR" >&2
+        echo "See docs/openstack-keystone-federation.md for how to populate this directory." >&2
+        exit 1
+    fi
+    missing_required=()
+    for required in "${KEYSTONE_SHIBBOLETH_REQUIRED_FILES[@]}"; do
+        if [[ ! -f "$KEYSTONE_SHIBBOLETH_DIR/$required" ]]; then
+            missing_required+=("$required")
+        fi
+    done
+    if (( ${#missing_required[@]} > 0 )); then
+        echo "Error: Federation is enabled but the following required file(s) are missing under ${KEYSTONE_SHIBBOLETH_DIR}:" >&2
+        for f in "${missing_required[@]}"; do
+            echo "  - $f" >&2
+        done
+        echo "Refer to docs/openstack-keystone-federation.md to generate/place these files." >&2
+        exit 1
+    fi
+    if ! (
+        set -o pipefail
+        kubectl --namespace "$SERVICE_NAMESPACE" create secret generic "$KEYSTONE_SHIBBOLETH_SECRET" \
+            --from-file="$KEYSTONE_SHIBBOLETH_DIR" \
+            --dry-run=client -o yaml | kubectl apply -f -
+    ); then
+        echo "Error: failed to sync '${KEYSTONE_SHIBBOLETH_SECRET}' from ${KEYSTONE_SHIBBOLETH_DIR}." >&2
+        exit 1
+    fi
+elif ! $skip_shibboleth_secret; then
+    echo "Shibboleth federation not detected; skipping '${KEYSTONE_SHIBBOLETH_SECRET}' secret sync."
+fi
+
 
 helm_command=(
     helm upgrade --install "$SERVICE_NAME_DEFAULT" "$HELM_CHART_PATH"

--- a/docs/openstack-keystone-federation.md
+++ b/docs/openstack-keystone-federation.md
@@ -384,31 +384,35 @@ openssl req -x509 -newkey rsa:2048 -keyout sp-key.pem -out sp-cert.pem -days 182
 
 #### Upload the SAML2 files to the kubernetes cluster
 
-Ingest all files into the kubernetes secret as a secrete, which will be mounted to the keystone pod.
+The `keystone-shibd-etc` secret holds every file under `/etc/genestack/keystone-sp/shibboleth/` and is mounted at `/etc/shibboleth/` inside the keystone pod.
 
-``` shell
-kubectl -n openstack create secret generic keystone-shibd-etc \
-        --from-file=/etc/genestack/keystone-sp/shibboleth/attrChecker.html \
-        --from-file=/etc/genestack/keystone-sp/shibboleth/attribute-map.xml \
-        --from-file=/etc/genestack/keystone-sp/shibboleth/attribute-policy.xml \
-        --from-file=/etc/genestack/keystone-sp/shibboleth/bindingTemplate.html \
-        --from-file=/etc/genestack/keystone-sp/shibboleth/discoveryTemplate.html \
-        --from-file=/etc/genestack/keystone-sp/shibboleth/globalLogout.html \
-        --from-file=/etc/genestack/keystone-sp/shibboleth/idp-metadata.xml \
-        --from-file=/etc/genestack/keystone-sp/shibboleth/localLogout.html \
-        --from-file=/etc/genestack/keystone-sp/shibboleth/metadataError.html \
-        --from-file=/etc/genestack/keystone-sp/shibboleth/partialLogout.html \
-        --from-file=/etc/genestack/keystone-sp/shibboleth/postTemplate.html \
-        --from-file=/etc/genestack/keystone-sp/shibboleth/protocols.xml \
-        --from-file=/etc/genestack/keystone-sp/shibboleth/security-policy.xml \
-        --from-file=/etc/genestack/keystone-sp/shibboleth/sessionError.html \
-        --from-file=/etc/genestack/keystone-sp/shibboleth/shibboleth2.xml \
-        --from-file=/etc/genestack/keystone-sp/shibboleth/shibd.logger \
-        --from-file=/etc/genestack/keystone-sp/shibboleth/sp-cert.pem \
-        --from-file=/etc/genestack/keystone-sp/shibboleth/sp-key.pem \
-        --from-file=/etc/genestack/keystone-sp/shibboleth/sslError.html \
-        --from-file=/etc/genestack/keystone-sp/shibboleth/sso_callback_template.html
-```
+`install-keystone.sh` manages this secret automatically. When the script renders the chart it inspects the post-rendered manifests for `keystone-shibd-etc`; if the federation overlay is in use, the script re-creates the secret from the shibboleth directory on every run using `kubectl create ... --dry-run=client -o yaml | kubectl apply -f -`. That means updating any file under `/etc/genestack/keystone-sp/shibboleth/` and re-running the installer is sufficient to roll the change out.
+
+!!! note "Required files"
+
+    The installer preflights the shibboleth directory for the following files and aborts with a clear error if any are missing:
+
+    * `shibboleth2.xml`
+    * `sp-cert.pem`
+    * `sp-key.pem`
+    * `idp-metadata.xml`
+
+    The rest of the templates ship in the repo copy at `etc/keystone-sp/shibboleth/` and are copied to `/etc/genestack/keystone-sp/` earlier in this guide.
+
+!!! tip "Overrides and bypasses"
+
+    * Set `KEYSTONE_SHIBBOLETH_DIR` to point the installer at a different shibboleth source directory.
+    * Set `SKIP_SHIBBOLETH_SECRET=1` (or pass `--dry-run` through to helm) to skip the secret sync entirely.
+
+??? example "Manual fallback"
+
+    If you need to sync the secret without running the installer (air-gapped debugging, out-of-band patching, etc.), the equivalent command is:
+
+    ``` shell
+    kubectl -n openstack create secret generic keystone-shibd-etc \
+        --from-file=/etc/genestack/keystone-sp/shibboleth/ \
+        --dry-run=client -o yaml | kubectl apply -f -
+    ```
 
 ### Create the SAML identity provider
 

--- a/releasenotes/notes/keystone-shibboleth-secret-automation-3a7c5f9b2d81e604.yaml
+++ b/releasenotes/notes/keystone-shibboleth-secret-automation-3a7c5f9b2d81e604.yaml
@@ -1,0 +1,27 @@
+---
+features:
+  - |
+    `bin/install-keystone.sh` now auto-manages the `keystone-shibd-etc`
+    secret when Shibboleth federation is enabled. The installer renders the
+    Keystone chart with the same overlay it will apply, detects the presence
+    of the federation overlay via the rendered manifests, and idempotently
+    syncs the secret from `${KEYSTONE_SHIBBOLETH_DIR}` (default
+    `/etc/genestack/keystone-sp/shibboleth/`) using
+    `kubectl create ... --dry-run=client -o yaml | kubectl apply -f -`.
+    Updating any file under the shibboleth directory and re-running the
+    installer is now sufficient to roll the change out.
+
+    The installer preflights the shibboleth directory for the operator-
+    supplied files (`shibboleth2.xml`, `sp-cert.pem`, `sp-key.pem`,
+    `idp-metadata.xml`) and aborts with an actionable error if any are
+    missing.
+upgrade:
+  - |
+    Operators no longer need to run the manual
+    `kubectl create secret generic keystone-shibd-etc --from-file=...`
+    command from `docs/openstack-keystone-federation.md` after editing files
+    under `/etc/genestack/keystone-sp/shibboleth/`. Re-running
+    `install-keystone.sh` handles it. The behaviour can be bypassed by
+    setting `SKIP_SHIBBOLETH_SECRET=1` or by passing `--dry-run` through to
+    helm. Point the installer at a non-default shibboleth source directory
+    via `KEYSTONE_SHIBBOLETH_DIR`.


### PR DESCRIPTION
Previously, updating anything under keystone-sp/shibboleth required an operator to re-run a 21-line kubectl create secret generic keystone-shibd-etc --from-file=... command by hand, straight out of docs/openstack-keystone-federation.md. Nothing in the repo created or updated that secret; the federation overlay only consumed it.

install-keystone.sh now handles the create/update automatically when federation is in use:

* Runs helm template with the same values, --post-renderer, and --post-renderer-args as the real install, so the rendered manifests match what would land in-cluster.
* Detects federation by grepping the render for the keystone-shibd-etc secret reference (works regardless of how the overlay is structured, as long as it pulls in the federation base).
* Preflights ${KEYSTONE_SHIBBOLETH_DIR} (default /etc/genestack/keystone-sp/shibboleth) for shibboleth2.xml, sp-cert.pem, sp-key.pem, and idp-metadata.xml; aborts with a clear error if any are missing.
* Syncs the secret idempotently via kubectl create ... --dry-run=client -o yaml | kubectl apply.
* Skippable via SKIP_SHIBBOLETH_SECRET=1 or by passing --dry-run through to helm.

Doc updates replace the manual kubectl block with a short note about the installer plus a collapsible manual-fallback section. A reno note under releasenotes/notes/ describes the feature and the removed manual step.