### PR TITLE
fix(keystone): avoid fernet key ownership race condition during sync

### DIFF
--- a/base-kustomize/keystone/base/fix-fernet-credential-permissions.yaml
+++ b/base-kustomize/keystone/base/fix-fernet-credential-permissions.yaml
@@ -16,12 +16,16 @@ spec:
                 src="$1"
                 dst="$2"
                 mkdir -p "$dst"
+                chown 42424:42424 "$dst"
+                chmod 700 "$dst"
                 for key in "$src"/*; do
                   [ -f "$key" ] || continue
                   name="$(basename "$key")"
                   tmp="$dst/.tmp.$name"
                   rm -f "$tmp"
                   cp -fL "$key" "$tmp"
+                  # Own before the file becomes live so keystone never sees root:root 0400.
+                  chown 42424:42424 "$tmp"
                   chmod 400 "$tmp"
                   mv -f "$tmp" "$dst/$name"
                 done
@@ -77,12 +81,16 @@ spec:
                 src="$1"
                 dst="$2"
                 mkdir -p "$dst"
+                chown 42424:42424 "$dst"
+                chmod 700 "$dst"
                 for key in "$src"/*; do
                   [ -f "$key" ] || continue
                   name="$(basename "$key")"
                   tmp="$dst/.tmp.$name"
                   rm -f "$tmp"
                   cp -fL "$key" "$tmp"
+                  # Own before the file becomes live so keystone never sees root:root 0400.
+                  chown 42424:42424 "$tmp"
                   chmod 400 "$tmp"
                   mv -f "$tmp" "$dst/$name"
                 done


### PR DESCRIPTION
The fernet/credential sync sidecar (from #1628) copied keys as root and only chowned after mv. That left a brief root:root 0400 window every 30s where keystone (uid 42424) could not read fernet keys, causing intermittent HTTP 500 on token issue.

Own and chmod each key before it becomes the live file, and set directory ownership up front.