### PR TITLE
cherry-pick: fix(keystone): avoid fernet key ownership race condition during sync (#1682)

### DIFF
--- a/base-kustomize/keystone/base/fix-fernet-credential-permissions.yaml
+++ b/base-kustomize/keystone/base/fix-fernet-credential-permissions.yaml
@@ -16,12 +16,16 @@ spec:
                 src="$1"
                 dst="$2"
                 mkdir -p "$dst"
+                chown 42424:42424 "$dst"
+                chmod 700 "$dst"
                 for key in "$src"/*; do
                   [ -f "$key" ] || continue
                   name="$(basename "$key")"
                   tmp="$dst/.tmp.$name"
                   rm -f "$tmp"
                   cp -fL "$key" "$tmp"
+                  # Own before the file becomes live so keystone never sees root:root 0400.
+                  chown 42424:42424 "$tmp"
                   chmod 400 "$tmp"
                   mv -f "$tmp" "$dst/$name"
                 done
@@ -77,12 +81,16 @@ spec:
                 src="$1"
                 dst="$2"
                 mkdir -p "$dst"
+                chown 42424:42424 "$dst"
+                chmod 700 "$dst"
                 for key in "$src"/*; do
                   [ -f "$key" ] || continue
                   name="$(basename "$key")"
                   tmp="$dst/.tmp.$name"
                   rm -f "$tmp"
                   cp -fL "$key" "$tmp"
+                  # Own before the file becomes live so keystone never sees root:root 0400.
+                  chown 42424:42424 "$tmp"
                   chmod 400 "$tmp"
                   mv -f "$tmp" "$dst/$name"
                 done


### PR DESCRIPTION
Cherry-picked from main (#1682) into release-2026.2