### PR TITLE
fix: remove deprecated heartbeat_in_pthread overrides

### DIFF
--- a/ansible/roles/trove_enablement_techpreview/templates/trove-guestagent.conf.j2
+++ b/ansible/roles/trove_enablement_techpreview/templates/trove-guestagent.conf.j2
@@ -70,7 +70,6 @@ driver = noop
 
 #[oslo_messaging_rabbit]
 #amqp_durable_queues = false
-#heartbeat_in_pthread = true
 #heartbeat_rate = 3
 #heartbeat_timeout_threshold = 60
 #kombu_reconnect_delay = 0.5

--- a/base-helm-configs/blazar/blazar-helm-overrides.yaml
+++ b/base-helm-configs/blazar/blazar-helm-overrides.yaml
@@ -87,7 +87,6 @@ conf:
       rabbit_interval_max: 10
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
-      heartbeat_in_pthread: true
       kombu_reconnect_delay: 0.5
     oslo_messaging_notifications:
       driver: messagingv2

--- a/base-helm-configs/designate/designate-helm-overrides.yaml
+++ b/base-helm-configs/designate/designate-helm-overrides.yaml
@@ -436,8 +436,6 @@ conf:
       # https://opendev.org/openstack/oslo.messaging/commit/36fb5bceabe08a982ebd52e4a8f005cd26fdf6b8
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
-      # DEPRECIATION:  (warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: true
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617

--- a/base-helm-configs/heat/heat-helm-overrides.yaml
+++ b/base-helm-configs/heat/heat-helm-overrides.yaml
@@ -105,8 +105,6 @@ conf:
       # https://opendev.org/openstack/oslo.messaging/commit/36fb5bceabe08a982ebd52e4a8f005cd26fdf6b8
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
-      # DEPRECIATION:  (warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: true
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617

--- a/base-helm-configs/magnum/magnum-helm-overrides.yaml
+++ b/base-helm-configs/magnum/magnum-helm-overrides.yaml
@@ -120,8 +120,6 @@ conf:
       # https://opendev.org/openstack/oslo.messaging/commit/36fb5bceabe08a982ebd52e4a8f005cd26fdf6b8
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
-      # NOTE (deprecation warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: true
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617

--- a/base-helm-configs/masakari/masakari-helm-overrides.yaml
+++ b/base-helm-configs/masakari/masakari-helm-overrides.yaml
@@ -159,8 +159,6 @@ conf:
       # https://opendev.org/openstack/oslo.messaging/commit/36fb5bceabe08a982ebd52e4a8f005cd26fdf6b8
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
-      # DEPRECIATION:  (warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: true
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617

--- a/base-helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/base-helm-configs/neutron/neutron-helm-overrides.yaml
@@ -233,8 +233,6 @@ conf:
       # https://opendev.org/openstack/oslo.messaging/commit/36fb5bceabe08a982ebd52e4a8f005cd26fdf6b8
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
-      # NOTE (deprecation warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: true
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617

--- a/base-helm-configs/nova/nova-helm-overrides.yaml
+++ b/base-helm-configs/nova/nova-helm-overrides.yaml
@@ -182,8 +182,6 @@ conf:
       # https://opendev.org/openstack/oslo.messaging/commit/36fb5bceabe08a982ebd52e4a8f005cd26fdf6b8
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
-      # NOTE (deprecation warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: true
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617

--- a/base-helm-configs/octavia/octavia-helm-overrides.yaml
+++ b/base-helm-configs/octavia/octavia-helm-overrides.yaml
@@ -139,8 +139,6 @@ conf:
       # https://opendev.org/openstack/oslo.messaging/commit/36fb5bceabe08a982ebd52e4a8f005cd26fdf6b8
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
-      # NOTE (deprecation warning) heartbeat_in_pthread will be deprecated in 2024.2
-      heartbeat_in_pthread: true
       # Setting lower kombu_reconnect_delay should resolve issue with HA failing when one node is down
       # https://lists.openstack.org/pipermail/openstack-discuss/2023-April/033314.html
       # https://review.opendev.org/c/openstack/oslo.messaging/+/866617

--- a/base-helm-configs/trove/trove-helm-overrides.yaml
+++ b/base-helm-configs/trove/trove-helm-overrides.yaml
@@ -146,7 +146,6 @@ conf:
       rabbit_interval_max: 10
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
-      heartbeat_in_pthread: true
       kombu_reconnect_delay: 0.5
     oslo_messaging_notifications:
       driver: noop

--- a/base-helm-configs/zaqar/zaqar-helm-overrides.yaml
+++ b/base-helm-configs/zaqar/zaqar-helm-overrides.yaml
@@ -148,7 +148,6 @@ conf:
       rabbit_interval_max: 10
       heartbeat_rate: 3
       heartbeat_timeout_threshold: 60
-      heartbeat_in_pthread: true
       kombu_reconnect_delay: 0.5
     logging:
       logger_root:

--- a/releasenotes/notes/remove-heartbeat-in-pthread-7a31d6e952b04f8c.yaml
+++ b/releasenotes/notes/remove-heartbeat-in-pthread-7a31d6e952b04f8c.yaml
@@ -1,0 +1,11 @@
+---
+upgrade:
+  - |
+    Removed the deprecated ``heartbeat_in_pthread`` override from the
+    oslo.messaging RabbitMQ configuration for Blazar, Designate, Heat,
+    Magnum, Masakari, Neutron, Nova, Octavia, Trove, and Zaqar.
+
+    On oslo.messaging versions where the option is still available,
+    deployments will use the upstream default value of ``false``. The option
+    has been removed entirely in oslo.messaging 18.0.0. Existing heartbeat
+    interval, timeout, and reconnect settings remain unchanged.


### PR DESCRIPTION
  ## Summary
  Remove the deprecated `heartbeat_in_pthread` option from the remaining
  OpenStack service overrides.

  The option was deprecated in oslo.messaging 14.9.0 and removed in
  oslo.messaging 18.0.0. For releases where the option is still available,
  removing the explicit `true` value restores the upstream default of `false`.

  A downstream OpenStack 2025.1 deployment also experienced intermittent
  RabbitMQ reconnects and RPC timeouts in Eventlet-based services while this
  override was enabled. Although it was not confirmed as the sole root cause,
  removing it avoids the mixed native-thread and Eventlet execution path and
  aligns the deployment with upstream guidance.
 
  ## Changes
  - Remove `heartbeat_in_pthread` from:
    - Blazar
    - Designate
    - Heat
    - Magnum
    - Masakari
    - Neutron
    - Nova
    - Octavia
    - Trove
    - Zaqar
  - Remove the stale commented option from the Trove guest agent template.
  - Add a Reno upgrade note describing the behavior change.

  ## References
  - [oslo.messaging 2024.2 deprecation](https://docs.openstack.org/releasenotes/oslo.messaging/2024.2.html)
  - [oslo.messaging 18.0.0 removal](https://docs.openstack.org/releasenotes/oslo.messaging/unreleased.html)