### PR TITLE
fix: skyline deployment is called skyline

### DIFF
--- a/base-kustomize/skyline/base/hpa-skyline-api-server.yaml
+++ b/base-kustomize/skyline/base/hpa-skyline-api-server.yaml
@@ -2,7 +2,7 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: skyline-api-server
+  name: skyline
   namespace: openstack
 spec:
   maxReplicas: 6
@@ -23,4 +23,4 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: skyline-api-server
+    name: skyline


### PR DESCRIPTION
The openstack-helm skyline chart defines the skyline deployment as "skyline".  In genestack we were override the deployment's min/max Replicas based on a skyline-api-server.  This pr fixes that and brings the base-kustomize overlays inline with the upstream helm-chart.