### PR TITLE
feat(OSPC-2267): meter CDN bytes by edge location

### DIFF
--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -1405,6 +1405,25 @@ conf:
             archive_policy_name: low
           "storage.objects.http.class.c.policy:replication:Policy-0":
             archive_policy_name: low
+          # NOTE(LukeRepko): CDN egress bytes, keyed by provider and edge
+          # location. Must stay in sync with the branches of the
+          # cdn.bandwidth meter under conf.meters.metric: a name the meter
+          # emits without a registration here is dropped by the Gnocchi
+          # publisher with only a warning, so those samples are lost.
+          "storage.cdn.outgoing.bytes.akamai:north_america":
+            archive_policy_name: low
+          "storage.cdn.outgoing.bytes.akamai:south_america":
+            archive_policy_name: low
+          "storage.cdn.outgoing.bytes.akamai:emea":
+            archive_policy_name: low
+          "storage.cdn.outgoing.bytes.akamai:japan":
+            archive_policy_name: low
+          "storage.cdn.outgoing.bytes.akamai:india":
+            archive_policy_name: low
+          "storage.cdn.outgoing.bytes.akamai:apac":
+            archive_policy_name: low
+          storage.cdn.outgoing.bytes.unknown:
+            archive_policy_name: low
 
       - resource_type: volume
         metrics:
@@ -2100,6 +2119,71 @@ conf:
         resource_id: $.payload.target.id
         user_id: $.payload.initiator.id
         project_id: $.payload.initiator.project_id
+
+      # NOTE(LukeRepko): CDN egress bytes, per provider and edge location.
+      #
+      # cdn.bandwidth notifications arrive on the swift vhost, one per
+      # tenant per accounting window, and land on the tenant's
+      # account-level swift_account resource as
+      # storage.cdn.outgoing.bytes.<provider>:<edge_location_slug>. The
+      # geographic dimension is payload.edge_location; payload.region is
+      # an OpenStack region (e.g. DFW-DEV), kept only as metadata.
+      #
+      # `name` is a jsonpath union of seven branches, each metric name
+      # carried as the replacement text of an anchored `sub()` gate: a
+      # gate that misses returns [] and collapses its branch, so the six
+      # attributed branches are mutually exclusive and non-lookup mode
+      # takes the first that yields a value. Matching is exact, so an
+      # unrecognized cdn_provider or edge_location falls through to the
+      # last branch, .unknown -- counted, never dropped. The fallback
+      # writes the dot as [.] because jsonpath-rw strips backslashes
+      # inside backticks; event_type is anchored because ceilometer
+      # re.match()es it and would otherwise also claim cdn.bandwidth2.
+      #
+      # Every name emitted here must also be registered under
+      # swift_account in gnocchi_resources -- the Gnocchi publisher drops
+      # unregistered names with only a warning, so those samples are lost
+      # with no error surfaced anywhere. To onboard a provider or edge
+      # location: add a branch here, register the name there with
+      # archive_policy_name: low, then restart ceilometer-notification.
+      # Until then that traffic lands in .unknown.
+      #
+      # Timestamps come from payload.end_time so bytes land in the
+      # accounting window they describe, else metadata.timestamp.
+      - name: >-
+          ($.payload.cdn_provider.`sub(/^akamai$/, )`
+          + $.payload.edge_location.`sub(/^North America$/, storage.cdn.outgoing.bytes.akamai:north_america)`)
+          |
+          ($.payload.cdn_provider.`sub(/^akamai$/, )`
+          + $.payload.edge_location.`sub(/^South America$/, storage.cdn.outgoing.bytes.akamai:south_america)`)
+          |
+          ($.payload.cdn_provider.`sub(/^akamai$/, )`
+          + $.payload.edge_location.`sub(/^EMEA$/, storage.cdn.outgoing.bytes.akamai:emea)`)
+          |
+          ($.payload.cdn_provider.`sub(/^akamai$/, )`
+          + $.payload.edge_location.`sub(/^Japan$/, storage.cdn.outgoing.bytes.akamai:japan)`)
+          |
+          ($.payload.cdn_provider.`sub(/^akamai$/, )`
+          + $.payload.edge_location.`sub(/^India$/, storage.cdn.outgoing.bytes.akamai:india)`)
+          |
+          ($.payload.cdn_provider.`sub(/^akamai$/, )`
+          + $.payload.edge_location.`sub(/^APAC$/, storage.cdn.outgoing.bytes.akamai:apac)`)
+          |
+          ($.payload.event_type.`sub(/^cdn[.]bandwidth$/, storage.cdn.outgoing.bytes.unknown)`)
+        event_type: "^cdn\\.bandwidth$"
+        type: "delta"
+        unit: "B"
+        volume: $.payload.bandwidth_cdn
+        resource_id: $.payload.resource_id
+        project_id: $.payload.tenant_id
+        timestamp: $.payload.end_time
+        metadata:
+          cdn_provider: $.payload.cdn_provider
+          edge_location: $.payload.edge_location
+          region: $.payload.region
+          data_center: $.payload.data_center
+          start_time: $.payload.start_time
+          end_time: $.payload.end_time
 
       - name: "memory"
         event_type: &instance_events compute.instance.(?!create.start|update).*

--- a/releasenotes/notes/cdn-bandwidth-edge-location-meters-4c1e7a92b6d035f8.yaml
+++ b/releasenotes/notes/cdn-bandwidth-edge-location-meters-4c1e7a92b6d035f8.yaml
@@ -1,0 +1,36 @@
+---
+features:
+  - |
+    CDN egress bytes reported by the usage reporter are now metered per
+    CDN provider and per geographic edge location. Ceilometer consumes
+    ``cdn.bandwidth`` notifications from the ``swift`` vhost and emits one
+    ``delta`` sample in bytes per notification against the tenant's
+    account-level ``swift_account`` Gnocchi resource. Seven metric names
+    are added, all on ``swift_account`` with archive policy ``low``::
+
+      storage.cdn.outgoing.bytes.akamai:north_america
+      storage.cdn.outgoing.bytes.akamai:south_america
+      storage.cdn.outgoing.bytes.akamai:emea
+      storage.cdn.outgoing.bytes.akamai:japan
+      storage.cdn.outgoing.bytes.akamai:india
+      storage.cdn.outgoing.bytes.akamai:apac
+      storage.cdn.outgoing.bytes.unknown
+
+    The geography comes from ``payload.edge_location``, not
+    ``payload.region`` (an OpenStack region such as ``DFW-DEV``, recorded
+    only as sample metadata). Matching is exact, so an unregistered
+    provider or edge location -- including a case or whitespace variant of
+    a registered one -- is counted against
+    ``storage.cdn.outgoing.bytes.unknown`` rather than dropped.
+
+  - |
+    Every CDN metric name must be present in TWO places in
+    ``base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml``: in
+    the branches of the ``cdn.bandwidth`` meter definition under
+    ``conf.meters.metric``, and under ``resource_type: swift_account`` in
+    ``conf.gnocchi_resources``. A name the meter emits without a matching
+    registration is discarded by Ceilometer's Gnocchi publisher with only
+    a warning, so those samples are lost. Onboarding a new provider or
+    edge location therefore requires both edits plus a
+    ``ceilometer-notification`` restart; until then the traffic is counted
+    against ``storage.cdn.outgoing.bytes.unknown``.


### PR DESCRIPTION
Meter cdn.bandwidth notifications from the usage reporter (publisher_id usage.reporter) on the swift vhost as per-provider, per-geography byte deltas on the tenant's account-level swift_account resource. Seven names, all archive policy low:

  storage.cdn.outgoing.bytes.akamai:{north_america,south_america, emea,japan,india,apac}
  storage.cdn.outgoing.bytes.unknown

The geographic dimension is payload.edge_location. payload.region carries an OpenStack region (DFW-DEV) and is not a partitioning dimension; it is kept as sample metadata only.

Implemented as one meter definition whose `name` is a jsonpath union of seven branches rather than seven separate definitions. Seven definitions would need a negative-lookahead regex to express "edge_location is none of the six" for the fallback, putting the enumeration in three places instead of two and guarding the no-dropped-samples property with the least readable regex in the file. The union also makes single-sample-per-notification structural: non-lookup mode returns the first branch that yields a value, so at most one sample can be emitted, rather than depending on seven independent gates never overlapping. This matches the idiom the adjacent storage.objects.http.class.* meters establish.

Each branch carries its full literal metric name as the replacement text of an anchored sub() gate, so the names grep from both the meter and the registration. A gate that misses returns [] and collapses its branch. cdn_provider is whitelist-gated the same way, so an unregistered provider or edge location collapses every attributed branch and lands in .unknown -- counted, never dropped. Samples already recorded under .unknown stay there after onboarding.

Two upstream quirks are load-time failures that lint cannot catch: the fallback writes the dot as [.] because jsonpath-rw's lexer strips backslash escapes inside backticks, and event_type is anchored (^cdn\.bandwidth$) because ceilometer re.match()es it and an unanchored value would also claim cdn.bandwidth2 and cdn.bandwidth.foo.

Registration under swift_account is mandatory, not cosmetic: the Gnocchi publisher builds a strict metric map from gnocchi_resources and discards samples whose name is not a key, logging only a warning. Onboarding a provider or geography therefore needs a branch in the meter, an entry in the registration, and a ceilometer-notification restart.

Samples are delta, so consumers sum them; this assumes payload.bandwidth_cdn is a per-window total, not a running counter. Timestamps come from payload.end_time so bytes land in the accounting window they describe, falling back to metadata.timestamp when end_time is absent or unparseable.

resource_metadata carries cdn_provider, edge_location, region, data_center, start_time and end_time, but swift_account declares no attributes mapping, so none of it is queryable in Gnocchi. Provider and geography ride in the metric name for that reason.

Redelivered notifications are counted again; de-duplication stays with the reporting service and downstream consumers.

No new RabbitMQ vhost, pipeline source, archive policy, Gnocchi resource-type change, or image bump: the swift vhost is already in messaging_urls, conf.pipeline already selects meters ["*"], and low is a Gnocchi-provided policy referenced by name.

Adds a reno note listing the seven names and the two-place sync requirement.

Verified against the pinned ceilometer image: all 55 meter definitions in the file construct without error; the six registered edge locations with akamai each yield their attributed name while case variants, unknown geographies, unknown providers, and absent or empty fields all yield .unknown; match_type accepts cdn.bandwidth and rejects cdn.bandwidth.foo, cdn.bandwidth2 and usage.cdn.bandwidth; sample fields and all six metadata keys populate as configured; 7 names emitted == 7 registered, all on policy low; both files parse with no duplicate keys.