### PR TITLE
Revert "chore: ignore ai garbage"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,5 +141,3 @@ site/
 .beads/
 .gitattributes
 AGENTS.md
-.mcp*
-.claude


### PR DESCRIPTION
Reverts rackerlabs/genestack#1704 due to submodule issue