### PR TITLE
fix: OSPC-2251: pinning openstacksdk and upgrade openstack.cloud to resolve version mismatch

### DIFF
--- a/ansible-collection-requirements.yml
+++ b/ansible-collection-requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: https://opendev.org/openstack/ansible-collections-openstack
-    version: 2.2.0
+    version: 2.6.0
     type: git
   - name: https://github.com/ansible-collections/ansible.posix
     version: 1.5.4

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -134,6 +134,8 @@ python3 -m venv "${HOME}/.venvs/genestack"
 "${HOME}/.venvs/genestack/bin/pip" install pip --upgrade
 source "${HOME}/.venvs/genestack/bin/activate" && success "Switched to venv ~/.venvs/genestack."
 pip install -r "${BASEDIR}/requirements.txt" && success "Installed ansible package."
+PYTHON_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+rm -rf "${HOME}/.ansible/collections/ansible_collections/openstack"
 ansible-playbook "${BASEDIR}/scripts/get-ansible-collection-requirements.yml" \
   -e collections_file="${ANSIBLE_COLLECTION_FILE}" \
   -e user_collections_file="${USER_COLLECTION_FILE}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ pbr==5.11.1
 ruamel.yaml==0.18.6
 ruamel.yaml.clib==0.2.12
 kubernetes>=24.2.0
-openstacksdk>=1.0.0
+openstacksdk>=4.6.0,<5.0.0
 python-openstackclient==8.2.0
 dictdiffer==0.9.0


### PR DESCRIPTION
The ansible pip package installs `openstacksdk` with no upper bound (`>=1.0.0`), which resolves to `4.17.0`.
The `openstack.cloud` collection pinned at `2.2.0` calls `openstack.version.__version__` which was removed in `SDK 4.x`, causing:
`AttributeError: module 'openstack' has no attribute 'version'`

Fix:
- Pin `openstacksdk` to `>=4.6.0,<5.0.0` (compatible range for collection 2.6.0)
- Upgrade `openstack.cloud` collection from `2.2.0` to `2.6.0`
- Remove stale pip-bundled collection in `bootstrap.sh` before galaxy install