### PR TITLE
fix: OSPC-2308: use root's venv for Octavia preconf to resolve missing openstack.cloud collection

### DIFF
--- a/scripts/lib/hyperconverged-common.sh
+++ b/scripts/lib/hyperconverged-common.sh
@@ -1840,8 +1840,8 @@ source ~/.venvs/genestack/bin/activate
 
 OCTAVIA_HELM_FILE=/tmp/octavia_helm_overrides.yaml
 
-ANSIBLE_SSH_PIPELINING=0 ansible-playbook /opt/genestack/ansible/playbooks/octavia-preconf-main.yaml \
-    -e octavia_os_password=$(/usr/local/bin/kubectl get secrets keystone-admin -n openstack -o jsonpath='{.data.password}' | base64 -d) \
+sudo ANSIBLE_SSH_PIPELINING=0 /root/.venvs/genestack/bin/ansible-playbook /opt/genestack/ansible/playbooks/octavia-preconf-main.yaml \
+    -e octavia_os_password=$(sudo /usr/local/bin/kubectl get secrets keystone-admin -n openstack -o jsonpath='{.data.password}' | base64 -d) \
     -e octavia_os_region_name=$(sudo ~/.venvs/genestack/bin/openstack --os-cloud=default endpoint list --service keystone --interface internal -c Region -f value) \
     -e octavia_os_auth_url=$(sudo ~/.venvs/genestack/bin/openstack --os-cloud=default endpoint list --service keystone --interface internal -c URL -f value) \
     -e octavia_os_endpoint_type=internal \


### PR DESCRIPTION
The `install_preconf_octavia()` function in `hyperconverged-common.sh` runs as the `ubuntu` user, whose venv lacks the `openstack.cloud` ansible collection.
This causes the playbook to fail with:
`"couldn't resolve module/action 'openstack.cloud.quota'"`

Switch to root's ansible-playbook binary via `sudo` so the correct venv (`/root/.venvs/genestack/`) and installed collections are used. 
Also prefix `kubectl` calls with `sudo` to avoid `KUBECONFIG/localhost:8080 connection errors` in the non-root SSH session.