### PR TITLE
fix: schedule mariadb backup job in worker for grafana DB backup

### DIFF
--- a/base-kustomize/grafana/base/grafana-database.yaml
+++ b/base-kustomize/grafana/base/grafana-database.yaml
@@ -172,6 +172,14 @@ spec:
       memory: 512Mi
   affinity:
     antiAffinityEnabled: true
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node-role.kubernetes.io/worker
+                operator: In
+                values:
+                  - worker
 ---
 apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database

--- a/base-kustomize/grafana/base/grafana-database.yaml
+++ b/base-kustomize/grafana/base/grafana-database.yaml
@@ -38,10 +38,10 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
-              - key: node-role.kubernetes.io/worker
+              - key: openstack-control-plane
                 operator: In
                 values:
-                  - worker
+                  - enabled
 
   storage:
     size: 10Gi
@@ -176,10 +176,10 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
-              - key: node-role.kubernetes.io/worker
+              - key: openstack-control-plane
                 operator: In
                 values:
-                  - worker
+                  - enabled
 ---
 apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database


### PR DESCRIPTION
Currently we don't have a node selector for mariadb backup job pod to schedule, so we saw an issue when it tried to schedule on a etcd node and pod stuck in init state because PVC was not creating. This PR will fix this. I am putting this pod to worker because mariadb-cluster also runs on worker node as mentioned here https://github.com/rackerlabs/genestack/blob/main/base-kustomize/grafana/base/grafana-database.yaml#L36-L44 for grafana DB.