### PR TITLE
fix: OSPC-2314: activating genestack venv in port creation scripts

### DIFF
--- a/ansible/roles/octavia_preconf/files/create_health_mgr_ports.sh
+++ b/ansible/roles/octavia_preconf/files/create_health_mgr_ports.sh
@@ -6,6 +6,9 @@
 
 set -xe
 
+# Activate the genestack venv to ensure openstack CLI is available
+source "${HOME}/.venvs/genestack/bin/activate"
+
 # Obtain the network_id and secgroup_id from and
 # cloud name from ansible task
 NET_ID=$1

--- a/ansible/roles/octavia_preconf/files/create_worker_ports.sh
+++ b/ansible/roles/octavia_preconf/files/create_worker_ports.sh
@@ -6,6 +6,9 @@
 
 set -xe
 
+# Activate the genestack venv to ensure openstack CLI is available
+source "${HOME}/.venvs/genestack/bin/activate"
+
 # Obtain the network_id and secgroup_id from and
 # cloud name from ansible task
 NET_ID=$1

--- a/ansible/roles/octavia_preconf/tasks/octavia_health_mgr_ports.yml
+++ b/ansible/roles/octavia_preconf/tasks/octavia_health_mgr_ports.yml
@@ -18,5 +18,5 @@
 
 - name: run the shell script to create health_mgr ports if required
   script:
-    cmd: create_health_mgr_ports.sh {{ lb_mgmt_info.networks[0].id }} {{ lb_health_mgr_secgrp_info.security_groups[0].id }} {{ lookup('env', 'OS_CLOUD') | default('openstack_helm') }}
+    cmd: create_health_mgr_ports.sh {{ lb_mgmt_info.networks[0].id }} {{ lb_health_mgr_secgrp_info.security_groups[0].id }} {{ lookup('env', 'OS_CLOUD') | default('default') }}
     creates: /tmp/octavia_hm_controller_ip_port_list

--- a/ansible/roles/octavia_preconf/tasks/octavia_worker_ports.yml
+++ b/ansible/roles/octavia_preconf/tasks/octavia_worker_ports.yml
@@ -18,5 +18,5 @@
 
 - name: run the shell script to create worker ports if required
   script:
-    cmd: create_worker_ports.sh {{ lb_mgmt_info.networks[0].id }} {{ lb_worker_secgrp_info.security_groups[0].id }} {{ lookup('env', 'OS_CLOUD') | default('openstack_helm') }}
+    cmd: create_worker_ports.sh {{ lb_mgmt_info.networks[0].id }} {{ lb_worker_secgrp_info.security_groups[0].id }} {{ lookup('env', 'OS_CLOUD') | default('default') }}
     creates: /tmp/octavia_worker_controller_ip_port_list


### PR DESCRIPTION
create_health_mgr_ports.sh and create_worker_ports.sh were failing with `openstack: command not found` because the scripts ran in a bare shell without the genestack venv activated.

Adding `source "${HOME}/.venvs/genestack/bin/activate"` to both scripts so the openstack CLI is available regardless of which user runs the playbook.

Also, updating default OS_CLOUD value from `openstack_helm` to `default` for consistency across all hyperconverged lab services.