### PR TITLE
fix: Add Envoy Gateway traffic policies for Glance bulk image transfers

### DIFF
--- a/base-kustomize/glance/base/glance-backendtrafficpolicy.yaml
+++ b/base-kustomize/glance/base/glance-backendtrafficpolicy.yaml
@@ -1,0 +1,57 @@
+---
+# BackendTrafficPolicy — upstream (Envoy -> glance-api) settings.
+#
+# Namespace MUST match the HTTPRoute's namespace (openstack).
+#
+# This is the policy that actually fixes the download failure. The 15s Envoy
+# route timeout lives on the upstream side; no amount of client-side idle
+# timeout will help without requestTimeout: 0s here.
+#
+# PRECEDENCE WARNING: if custom-glance-gateway-route ever gains
+# spec.rules[].timeouts, the HTTPRoute wins and this timeout block is ignored
+# entirely. Set timeouts in one place only. Current route has none:
+#   kubectl -n openstack get httproute custom-glance-gateway-route \
+#     -o yaml | grep -A10 timeouts
+#
+# Verify attachment:
+#   kubectl -n openstack get backendtrafficpolicy glance-bulk-transfer \
+#     -o jsonpath='{range .status.ancestors[*]}{range .conditions[*]}{.type}={.status}{" "}{.message}{"\n"}{end}{end}'
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: glance-bulk-transfer
+  namespace: openstack
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: custom-glance-gateway-route
+
+  connection:
+    # per_connection_buffer_limit_bytes is set independently on the listener
+    # (client policy) and the cluster (here). Raising only the downstream side
+    # leaves the default watermark on the upstream read from glance-api.
+    bufferLimit: 16Mi
+
+  timeout:
+    tcp:
+      connectTimeout: 30s
+    http:
+      # 0s disables the route timeout. 7200s without it Envoy cuts
+      # the response at 15s no matter how long the client connection stays up.
+      requestTimeout: 7200s
+      connectionIdleTimeout: 3600s
+
+  # No http2 block here on purpose. glance-api runs eventlet WSGI, HTTP/1.1
+  # only, and Envoy will not use h2 upstream unless the route explicitly
+  # enables it. Confirm:
+  #   EG=$(kubectl -n envoy-gateway get pod \
+  #     -l gateway.envoyproxy.io/owning-gateway-name=flex-gateway -o name | head -1)
+  #   kubectl -n envoy-gateway exec $EG -c envoy -- \
+  #     curl -s localhost:19000/config_dump | \
+  #     jq '.configs[] | select(."@type"|test("Clusters")) | .dynamic_active_clusters[] |
+  #         select(.cluster.name|test("glance")) |
+  #         {n:.cluster.name, opts:.cluster.typed_extension_protocol_options}'
+  # Expect explicit_http_config.http_protocol_options, not http2_protocol_options.
+
+  # No retry block on purpose. Retrying a 2GB GET is worse than failing it.

--- a/base-kustomize/glance/base/glance-clienttrafficpolicy.yaml
+++ b/base-kustomize/glance/base/glance-clienttrafficpolicy.yaml
@@ -1,0 +1,75 @@
+---
+# ClientTrafficPolicy — downstream (client -> Envoy) settings for the
+# glance-https listener only.
+#
+# Namespace MUST match the Gateway's namespace (envoy-gateway), not the
+# namespace of the backend service.
+#
+# IMPORTANT: Envoy Gateway does NOT field-merge a sectionName-scoped policy
+# over a Gateway-scoped one. This policy REPLACES flex-gateway-client-policy
+# wholesale for the glance-https listener. That is why clientIPDetection is
+# re-declared below -- omit it and glance loses XFF parsing while every other
+# listener keeps it.
+#
+# Verify attachment:
+#   kubectl -n envoy-gateway get clienttrafficpolicy flex-gateway-glance-policy \
+#     -o jsonpath='{range .status.ancestors[*]}{.ancestorRef.sectionName}{"\t"}{range .conditions[*]}{.type}={.status}{" "}{.message}{"\n"}{end}{end}'
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: flex-gateway-glance-policy
+  namespace: envoy-gateway
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: flex-gateway
+      sectionName: glance-https
+
+  # Carried over from flex-gateway-client-policy. Required because a
+  # section-scoped policy replaces rather than merges.
+  clientIPDetection:
+    xForwardedFor:
+      numTrustedHops: 2
+
+  connection:
+    # Envoy default is 1Mi; the base policy sets 16Ki, which is far too small
+    # for multi-GB image streams.
+    #
+    # This is a per-connection high-watermark, not a preallocation, but
+    # concurrent image pulls multiply it. Check Envoy pod memory limits before
+    # raising past 16Mi:
+    #   kubectl -n envoy-gateway get pod \
+    #     -l gateway.envoyproxy.io/owning-gateway-name=flex-gateway \
+    #     -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[?(@.name=="envoy")].resources.limits.memory}{"\n"}{end}'
+    #
+    # Watch actual usage before going higher:
+    #   cluster.*.upstream_cx_rx_bytes_buffered
+    bufferLimit: 16Mi
+
+  timeout:
+    http:
+      # Base policy sets 5s. At ~2.8 MB/s from remote Swift, any inter-segment
+      # gap longer than that tears the stream down and glance logs
+      # BrokenPipeError. 5s is also below the RTT budget of normal API calls.
+      idleTimeout: 3600s
+
+  http2:
+    # Envoy default is 64Ki (confirmed via kubectl explain -- Envoy Gateway
+    # does not override it). Per-stream throughput is capped at window / RTT
+    # regardless of bandwidth or buffer size:
+    #
+    #   64Ki @ 30ms RTT  = ~2.1 MB/s   <- hard ceiling
+    #    4Mi @ 30ms RTT  = ~137 MB/s
+    #
+    # Only takes effect if clients actually negotiate h2. Note that
+    # python-openstackclient (requests/urllib3) is HTTP/1.1 only, so for CLI
+    # image pulls this is inert and bufferLimit is the operative lever.
+    # Confirm what real clients negotiate:
+    #   curl -so /dev/null -w 'proto=%{http_version} ttfb=%{time_starttransfer}\n' \
+    #     https://glance.api.sat0.cloudnull.dev/
+    #
+    # Keep connection window >= 4x stream window so one stream cannot starve
+    # the connection.
+    initialStreamWindowSize: 4Mi
+    initialConnectionWindowSize: 16Mi

--- a/base-kustomize/glance/base/kustomization.yaml
+++ b/base-kustomize/glance/base/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
   - all.yaml
   - hpa-glance-api.yaml
   - policies.yaml
+  - glance-clienttrafficpolicy.yaml
+  - glance-backendtrafficpolicy.yaml
 
 patches:
   - target:


### PR DESCRIPTION
Image downloads through the gateway were failing with BrokenPipeError in glance-api's eventlet WSGI handler. Three separate limits in the gateway path were cutting multi-GB streams:

- flex-gateway-client-policy sets idleTimeout: 5s gateway-wide. Any inter-segment gap on the remote Swift read longer than that tears the connection down mid-stream.
- The HTTPRoute carries no timeouts, so Envoy falls back to its default 15s route timeout, capping every download at 15 seconds.
- connection.bufferLimit is 16Ki against an Envoy default of 1Mi.

Direct pulls to the pod IP bypass Envoy entirely and complete normally (1.97 GB / 697s), which isolates the failure to the gateway path.

Adds two section-scoped policies:

ClientTrafficPolicy flex-gateway-glance-policy (envoy-gateway) targets the glance-https listener with idleTimeout: 3600s, bufferLimit: 16Mi, and initialStreamWindowSize: 4Mi. The h2 window defaults to 64Ki, which caps per-stream throughput at window/RTT (~2.1 MB/s at 30ms) regardless of bandwidth. clientIPDetection is re-declared because a sectionName scoped policy replaces rather than merges with the Gateway-scoped one.

BackendTrafficPolicy glance-bulk-transfer (openstack) targets custom-glance-gateway-route with requestTimeout: 0s to disable the route timeout, plus a matching upstream bufferLimit. No http2 block, since glance-api is HTTP/1.1 only. No retry block, since retrying a 2GB GET is worse than failing it. Scoped to the glance listener and route rather than changing gateway defaults, so the other 36 listeners are unaffected.