### PR TITLE
fix: eliminate cinder volumes playbook races and generalize lab cinde…

### DIFF
--- a/ansible/roles/cinder_volumes/tasks/main.yaml
+++ b/ansible/roles/cinder_volumes/tasks/main.yaml
@@ -34,14 +34,33 @@
   when:
     - cinder_worker_name | lower != "lvm"
 
+- name: Wait for apt/dpkg locks to be released
+  ansible.builtin.shell: |
+    while fuser /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend /var/lib/apt/lists/lock /var/cache/apt/archives/lock >/dev/null 2>&1; do
+      echo "apt/dpkg lock held, waiting..."
+      sleep 5
+    done
+  changed_when: false
+  when:
+    - ansible_facts['os_family'] | lower == 'debian'
+
+# run_once: every host in the play delegates this block to the first
+# control-plane node; without it, N parallel apt-get invocations race each
+# other for the dpkg lock on that one node (only one wins). The registered
+# secret result is propagated to all play hosts by run_once.
 - name: K8S Facts block
   delegate_to: "{{ groups['kube_control_plane'][0] }}"
+  run_once: true
   block:
     - name: Ensure python3-kubernetes is available
       ansible.builtin.package:
         name: python3-kubernetes
         state: present
         update_cache: true
+      register: _py3_kubernetes_install
+      until: _py3_kubernetes_install is success
+      retries: 20
+      delay: 5
 
     - name: Read cinder-etc secrets
       kubernetes.core.k8s_info:
@@ -59,8 +78,8 @@
     - cinder_volume_package_list | length > 0
   register: install_packages
   until: install_packages is success
-  retries: 5
-  delay: 2
+  retries: 20
+  delay: 5
 
 - name: Install cinder-backend distro packages
   ansible.builtin.package:
@@ -71,8 +90,8 @@
     - cinder_volume_package_list | length > 0
   register: install_backend_packages
   until: install_backend_packages is success
-  retries: 5
-  delay: 2
+  retries: 20
+  delay: 5
 
 - name: Determine iscsi initiator name
   set_fact:

--- a/scripts/hyperconverged-lab-kubespray.sh
+++ b/scripts/hyperconverged-lab-kubespray.sh
@@ -411,7 +411,7 @@ if [ "${HYPERCONVERGED_CINDER_VOLUME:-false}" = "true" ]; then
 
     if ! openstack volume show ${LAB_NAME_PREFIX}-0-cv1 2>/dev/null; then
       openstack volume create \
-        --size 150 \
+        --size 200 \
         --type Performance \
         --description "cinder-volumes-1 on ${LAB_NAME_PREFIX}-0" \
         ${LAB_NAME_PREFIX}-0-cv1
@@ -419,7 +419,7 @@ if [ "${HYPERCONVERGED_CINDER_VOLUME:-false}" = "true" ]; then
 
     if ! openstack volume show ${LAB_NAME_PREFIX}-1-cv1 2>/dev/null; then
       openstack volume create \
-        --size 150 \
+        --size 200 \
         --type Performance \
         --description "cinder-volumes-1 on ${LAB_NAME_PREFIX}-1" \
         ${LAB_NAME_PREFIX}-1-cv1
@@ -427,7 +427,7 @@ if [ "${HYPERCONVERGED_CINDER_VOLUME:-false}" = "true" ]; then
 
     if ! openstack volume show ${LAB_NAME_PREFIX}-2-cv1 2>/dev/null; then
       openstack volume create \
-        --size 150 \
+        --size 200 \
         --type Performance \
         --description "cinder-volumes-1 on ${LAB_NAME_PREFIX}-2" \
         ${LAB_NAME_PREFIX}-2-cv1

--- a/scripts/lib/hyperconverged-common.sh
+++ b/scripts/lib/hyperconverged-common.sh
@@ -647,23 +647,6 @@ EOF
         if [ "${HYPERCONVERGED_CINDER_VOLUME:-false}" = "true" ]; then
             cat > "${config_base}/cinder/cinder-helm-overrides.yaml" <<EOF
 ---
-images:
-  tags:
-    bootstrap: "ghcr.io/rackerlabs/genestack-images/heat:2024.1-1754784075"
-    cinder_api: "ghcr.io/rackerlabs/genestack-images/cinder:2024.1-1754785862"
-    cinder_backup: "ghcr.io/rackerlabs/genestack-images/cinder:2024.1-1754785862"
-    cinder_backup_storage_init: "quay.io/rackspace/rackerlabs-ceph-config-helper:latest-ubuntu_jammy"
-    cinder_db_sync: "ghcr.io/rackerlabs/genestack-images/cinder:2024.1-1754785862"
-    cinder_scheduler: "ghcr.io/rackerlabs/genestack-images/cinder:2024.1-1754785862"
-    cinder_storage_init: "quay.io/rackspace/rackerlabs-ceph-config-helper:latest-ubuntu_jammy"
-    cinder_volume: "ghcr.io/rackerlabs/genestack-images/cinder:2024.1-1754785862"
-    cinder_volume_usage_audit: "ghcr.io/rackerlabs/genestack-images/cinder:2024.1-1754785862"
-    db_drop: "ghcr.io/rackerlabs/genestack-images/heat:2024.1-1754784075"
-    db_init: "ghcr.io/rackerlabs/genestack-images/heat:2024.1-1754784075"
-    dep_check: "ghcr.io/rackerlabs/genestack-images/kubernetes-entrypoint:latest"
-    ks_endpoints: "ghcr.io/rackerlabs/genestack-images/heat:2024.1-1754784075"
-    ks_service: "ghcr.io/rackerlabs/genestack-images/heat:2024.1-1754784075"
-    ks_user: "ghcr.io/rackerlabs/genestack-images/heat:2024.1-1754784075"
 pod:
   resources:
     enabled: true
@@ -682,13 +665,10 @@ pod:
         cpu: "2"
         memory: "2Gi"
 conf:
-# NOTE: (brew) uncomment to change default log level from INFO
-#  logging:
-#    logger_cinder:
-#      level: DEBUG
-#      handlers: stdout
   policy:
     "volume_extension:types_extra_specs:read_sensitive": "rule:xena_system_admin_or_project_reader"
+    "volume_extension:qos_specs_manage:get_all": "rule:xena_system_admin_or_project_member"
+    "volume_extension:qos_specs_manage:get": "rule:xena_system_admin_or_project_member"
   cinder:
     DEFAULT:
       osapi_volume_workers: 2
@@ -1790,16 +1770,10 @@ source /opt/genestack/scripts/genestack.rc
 echo "[JUMP_HOST] Running cinder install script"
 sudo /opt/genestack/bin/install-cinder.sh
 
-#for node in ${LAB_NAME_PREFIX}-0 ${LAB_NAME_PREFIX}-1 ${LAB_NAME_PREFIX}-2; do
-#    echo "Waiting for apt locks on \${node}..."
-#    ssh -o StrictHostKeyChecking=no \${node} \
-#        'while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do echo "  apt lock held, waiting..."; sleep 5; done'
-#done
-
-echo "[JUMP_HOST] Running cinder volumes playbook (running twice to get past apt lock issue that previous loop should fix but doesn't)"
-ansible-playbook -i /etc/genestack/inventory/inventory.yaml \
-    -e "storage_network_interface=ansible_enp3s0 storage_network_interface_secondary=ansible_enp3s0 cinder_backend_name=lvmdriver-1 cinder_worker_name=lvm cinder_release_branch='stable/2025.1'" \
-    /opt/genestack/ansible/playbooks/deploy-cinder-volume.yaml -f3
+# Single run: the cinder_volumes role now waits for apt/dpkg locks and uses
+# run_once for the delegated python3-kubernetes install, which eliminated the
+# dpkg lock race that previously required running this playbook twice.
+echo "[JUMP_HOST] Running cinder volumes playbook"
 ansible-playbook -i /etc/genestack/inventory/inventory.yaml \
     -e "storage_network_interface=ansible_enp3s0 storage_network_interface_secondary=ansible_enp3s0 cinder_backend_name=lvmdriver-1 cinder_worker_name=lvm cinder_release_branch='stable/2025.1'" \
     /opt/genestack/ansible/playbooks/deploy-cinder-volume.yaml -f3


### PR DESCRIPTION
…r config

- cinder_volumes role: wait for apt/dpkg locks before package work; use run_once for the python3-kubernetes install delegated to the first control-plane node (previously N parallel apt runs raced for the dpkg lock on that node and only one could win); raise package install retries to 20x5s.
- hyperconverged lab: run deploy-cinder-volume.yaml once; the double-run workaround existed only to get past the dpkg lock race fixed above.
- drop pinned image tags from the generated cinder helm overrides so the lab follows whatever base-helm-configs ships for the target release.
- add qos_specs_manage read policy rules for project members.
- grow per-node cinder-volumes disks from 150G to 200G.