### PR TITLE
feat: hyperconverged lab hardening, dev-mode worktree support, Manila enablement, Octavia fixes

### DIFF
--- a/ansible/roles/manila_enablement_techpreview/templates/manila_default_helm_config.yaml
+++ b/ansible/roles/manila_enablement_techpreview/templates/manila_default_helm_config.yaml
@@ -1,23 +1,5 @@
 ---
 images:
-  tags:
-    db_init: "ghcr.io/rackerlabs/genestack-images/openstack-client:latest"
-    db_sync: "ghcr.io/rackerlabs/genestack-images/openstack-client:latest"
-    db_drop: "ghcr.io/rackerlabs/genestack-images/openstack-client:latest"
-    dep_check: "ghcr.io/rackerlabs/genestack-images/kubernetes-entrypoint:latest"
-    image_repo_sync: "docker.io/docker:17.07.0"
-    ks_endpoints: "ghcr.io/rackerlabs/genestack-images/openstack-client:latest"
-    ks_service: "ghcr.io/rackerlabs/genestack-images/openstack-client:latest"
-    ks_user: "ghcr.io/rackerlabs/genestack-images/openstack-client:latest"
-    manila: "ghcr.io/rackerlabs/genestack-images/manila:2025.1-latest"
-    manila_api: "ghcr.io/rackerlabs/genestack-images/manila-api:2025.1-latest"
-    manila_data: "ghcr.io/rackerlabs/genestack-images/manila-data:2025.1-latest"
-    manila_db_sync: "ghcr.io/rackerlabs/genestack-images/manila:2025.1-latest"
-    manila_scheduler: "ghcr.io/rackerlabs/genestack-images/manila-scheduler:2025.1-latest"
-    manila_share: "ghcr.io/rackerlabs/genestack-images/manila-share:2025.1-latest"
-    manila_processor: "ghcr.io/rackerlabs/genestack-images/manila:2025.1-latest"
-    manila_storage_init: "ghcr.io/rackerlabs/genestack-images/manila:2025.1-latest"
-    rabbit_init: "docker.io/rabbitmq:3.13-management"
   pull_policy: "Always"
 
 # NOTE: (brew) requests cpu/mem values based on a three node
@@ -68,36 +50,6 @@ pod:
 
 bootstrap:
   enabled: false
-
-dependencies:
-  static:
-    api:
-      jobs:
-        - manila-db-sync
-        - manila-ks-user
-        - manila-ks-endpoints
-    data:
-      jobs:
-        - manila-db-sync
-        - manila-ks-user
-        - manila-ks-endpoints
-    share:
-      jobs:
-        - manila-db-sync
-        - manila-ks-user
-        - manila-ks-endpoints
-    scheduler:
-      jobs:
-        - manila-db-sync
-        - manila-ks-user
-        - manila-ks-endpoints
-    manager:
-      jobs:
-        - manila-db-sync
-        - manila-ks-user
-        - manila-ks-endpoints
-    db_sync:
-      jobs: []
 
 conf:
   manila:
@@ -153,16 +105,8 @@ conf:
       backend: barbican
     database:
       max_retries: -1
-    oslo_policy:
-      policy_file: /etc/manila/policy.yaml
-    oslo_concurrency:
-      lock_path: /var/lib/manila/tmp
     oslo_messaging_notifications:
       driver: noop
-    oslo_middleware:
-      enable_proxy_headers_parsing: true
-    oslo_messaging_rabbit:
-      rabbit_ha_queues: true
   manila_api_uwsgi:
     uwsgi:
       add-header: "Connection: close"

--- a/ansible/roles/octavia_preconf/files/create_health_mgr_ports.sh
+++ b/ansible/roles/octavia_preconf/files/create_health_mgr_ports.sh
@@ -15,7 +15,12 @@ NET_ID=$1
 SECGRP_ID=$2
 CLOUD_NAME=$3
 
-export OS_CLOUD=$CLOUD_NAME
+# Only select a named cloud when one was provided; otherwise leave OS_CLOUD
+# unset so the openstack CLI authenticates via the OS_* environment variables
+# supplied by the calling play's environment block.
+if [ -n "$CLOUD_NAME" ]; then
+  export OS_CLOUD=$CLOUD_NAME
+fi
 
 # Obtain the list of kubernetes nodes with
 # "openstack-control-plane=enabled" label

--- a/ansible/roles/octavia_preconf/files/create_worker_ports.sh
+++ b/ansible/roles/octavia_preconf/files/create_worker_ports.sh
@@ -15,7 +15,12 @@ NET_ID=$1
 SECGRP_ID=$2
 CLOUD_NAME=$3
 
-export OS_CLOUD=$CLOUD_NAME
+# Only select a named cloud when one was provided; otherwise leave OS_CLOUD
+# unset so the openstack CLI authenticates via the OS_* environment variables
+# supplied by the calling play's environment block.
+if [ -n "$CLOUD_NAME" ]; then
+  export OS_CLOUD=$CLOUD_NAME
+fi
 
 # Obtain the list of kubernetes nodes with
 # "openstack-control-plane=enabled" label

--- a/base-kustomize/kustomize.sh
+++ b/base-kustomize/kustomize.sh
@@ -7,5 +7,12 @@ pushd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null
         all_yaml="${KUSTOMIZE_DIR}"/all.yaml
     fi
     cat <&0 > "${all_yaml}"
+    # Helm is typically invoked via sudo'd install scripts, which would leave
+    # all.yaml root-owned inside a user-owned checkout (dev-mode labs rsync
+    # /opt/genestack as the ssh user). Match the file's ownership to its
+    # directory so unprivileged runs can overwrite it later.
+    if [ "$(id -u)" -eq 0 ]; then
+        chown --reference="$(dirname "${all_yaml}")" "${all_yaml}" 2>/dev/null || true
+    fi
     kubectl kustomize "${KUSTOMIZE_DIR}"
 popd &>/dev/null

--- a/bin/setup-infrastructure.sh
+++ b/bin/setup-infrastructure.sh
@@ -234,6 +234,37 @@ function create_rabbitmq() {
   kubectl apply -k /etc/genestack/kustomize/rabbitmq-topology-operator/base
   echo "Waiting for the rabbitmq-cluster-operator to be available"
   kubectl -n rabbitmq-system wait --timeout=5m deployments.apps rabbitmq-cluster-operator --for=condition=available
+
+  # The messaging-topology-operator (deployed by the rabbitmq-topology-operator
+  # kustomize) serves the validating webhooks for the User/Vhost/Permission/
+  # Policy/Queue CRs that openstack-helm charts create. Without an explicit
+  # wait here, keystone (the first openstack service install) frequently
+  # fires before the operator's pod is Ready and its TLS serving cert is
+  # mounted, and the helm install fails with five copies of
+  #   "failed calling webhook ...: dial tcp 10.X.Y.Z:443: connect: connection refused"
+  # against validate-rabbitmq-com-v1beta1-{permission,policy,queue,user,vhost}.
+  # Wait for deployment Available AND the webhook service to have at least one
+  # ready endpoint.
+  echo "Waiting for the messaging-topology-operator to be available"
+  kubectl -n rabbitmq-system wait --timeout=5m deployments.apps messaging-topology-operator --for=condition=available
+
+  echo "Waiting for the messaging-topology-operator webhook service endpoints"
+  RMQ_TOPOLOGY_WEBHOOK_MAX_RETRIES=${RMQ_TOPOLOGY_WEBHOOK_MAX_RETRIES:-30}
+  RMQ_TOPOLOGY_WEBHOOK_RETRY_DELAY=${RMQ_TOPOLOGY_WEBHOOK_RETRY_DELAY:-5}
+  for ((i=1; i<=RMQ_TOPOLOGY_WEBHOOK_MAX_RETRIES; i++)); do
+    if kubectl -n rabbitmq-system get endpoints messaging-topology-webhook-service \
+        -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null | grep -q .; then
+      break
+    fi
+    if [ "${i}" -eq "${RMQ_TOPOLOGY_WEBHOOK_MAX_RETRIES}" ]; then
+      echo "ERROR: messaging-topology-webhook-service has no ready endpoints after waiting."
+      kubectl -n rabbitmq-system get pods -o wide || true
+      kubectl -n rabbitmq-system get endpoints messaging-topology-webhook-service -o yaml || true
+      return 1
+    fi
+    sleep "${RMQ_TOPOLOGY_WEBHOOK_RETRY_DELAY}"
+  done
+
   kubectl apply -k /etc/genestack/kustomize/rabbitmq-cluster/overlay
 }
 

--- a/scripts/hyperconverged-lab-kubespray.sh
+++ b/scripts/hyperconverged-lab-kubespray.sh
@@ -984,7 +984,11 @@ fi
 # Octavia per-configuration
 #############################################################################
 if [ "${RUN_EXTRAS}" -eq 1 ] && [ ${DISABLE_OPENSTACK} = "false" ]; then
-  install_preconf_octavia
+  if isExcluded octavia; then
+    echo "Skipping Octavia preconf/install: 'octavia' is in the exclude list (-e)"
+  else
+    install_preconf_octavia
+  fi
 fi
 
 #############################################################################

--- a/scripts/hyperconverged-lab-kubespray.sh
+++ b/scripts/hyperconverged-lab-kubespray.sh
@@ -897,6 +897,14 @@ if [ ! -f "/usr/local/bin/queue_max.sh" ]; then
     python3 -m venv ~/.venvs/genestack
     ~/.venvs/genestack/bin/pip install -r /opt/genestack/requirements.txt
     source /opt/genestack/scripts/genestack.rc
+    # Install the pinned galaxy collections for the ssh user. bootstrap.sh
+    # installs them for root only, but the trove/manila enablement playbooks
+    # run unprivileged and their openstack.cloud modules require the pinned
+    # collection version (the one bundled with the ansible pip package is
+    # incompatible with openstacksdk >= 4.15).
+    ansible-playbook /opt/genestack/scripts/get-ansible-collection-requirements.yml \
+        -e collections_file=\${ANSIBLE_COLLECTION_FILE} \
+        -e user_collections_file=\${USER_COLLECTION_FILE}
     ANSIBLE_SSH_PIPELINING=0 ansible-playbook /opt/genestack/ansible/playbooks/host-setup.yml --become -e host_required_kernel=\$(uname -r)
 fi
 if [ ! -d "/var/lib/kubelet" ]; then
@@ -930,6 +938,16 @@ if [ ! -d "/var/lib/kubelet" ]; then
 
     cd "\${KUBESPRAY_DIR}"
     ANSIBLE_SSH_PIPELINING=0 ansible-playbook "\${KUBESPRAY_PLAYBOOK}" --become
+fi
+# Give the ssh user a kubeconfig. The trove/manila enablement playbooks run
+# unprivileged and use kubernetes.core modules, and operators expect kubectl
+# to work from the jump host without sudo (previously this only happened as a
+# side effect of the optional -x k9s install).
+if [ ! -f \${HOME}/.kube/config ]; then
+    mkdir -p \${HOME}/.kube
+    sudo cp /etc/kubernetes/admin.conf \${HOME}/.kube/config
+    sudo chown \$(id -u):\$(id -g) \${HOME}/.kube/config
+    chmod 600 \${HOME}/.kube/config
 fi
 sudo mkdir -p /opt/kube-plugins
 sudo chown \${USER}:\${USER} /opt/kube-plugins

--- a/scripts/hyperconverged-lab-kubespray.sh
+++ b/scripts/hyperconverged-lab-kubespray.sh
@@ -203,7 +203,7 @@ else
     fi
 fi
 
-ssh-add "${KEY_PEM}"
+ensureSshAgentKey "${KEY_PEM}"
 
 #############################################################################
 # Create Lab Instances

--- a/scripts/hyperconverged-lab-kubespray.sh
+++ b/scripts/hyperconverged-lab-kubespray.sh
@@ -1014,6 +1014,19 @@ if [ "${TEST_LEVEL}" = "off" ]; then
     # Swift Setup - standalone object-store (gated by swift: true in components.yaml)
     deploySwift "RegionOne"
 
+    # Manila Setup & Installation
+    # Opt-in via HYPERCONVERGED_MANILA_SHARE (mirrors HYPERCONVERGED_CINDER_VOLUME):
+    # by default 'manila: true' only installs the chart (control-plane pods),
+    # keeping smoke tests fast. Setting HYPERCONVERGED_MANILA_SHARE=true
+    # additionally runs the full enablement (secrets, service image build,
+    # pre/post deploy). Runs after the OpenStack APIs are ready because the
+    # image build uploads to Glance. deployManila also self-gates on
+    # 'manila: true' in openstack-components.yaml, so '-e manila' (which sets
+    # it false) skips it too.
+    if [ "${HYPERCONVERGED_MANILA_SHARE:-false}" = "true" ] && [ ${DISABLE_OPENSTACK} = "false" ]; then
+        deployManila
+    fi
+
     # Trove Setup & Installation
     # Must be run after the flat network has been created
     deployTrove "RegionOne" "flat" "false" "trove.cluster.local" "internal" "hyperconverged-key.pem"

--- a/scripts/hyperconverged-lab-kubespray.sh
+++ b/scripts/hyperconverged-lab-kubespray.sh
@@ -993,7 +993,11 @@ fi
 
 if [[ "$RUN_EXTRAS" -eq 1 ]]; then
     echo "Running extra operations..."
-    installK9sRemote "${SSH_USERNAME}" "${JUMP_HOST_VIP}"
+    if isExcluded k9s; then
+        echo "Skipping k9s install: 'k9s' is in the exclude list (-e)"
+    else
+        installK9sRemote "${SSH_USERNAME}" "${JUMP_HOST_VIP}"
+    fi
 fi
 
 #############################################################################

--- a/scripts/hyperconverged-lab-kubespray.sh
+++ b/scripts/hyperconverged-lab-kubespray.sh
@@ -903,6 +903,10 @@ if [ ! -d "/var/lib/kubelet" ]; then
     source /opt/genestack/scripts/genestack.rc
     KUBESPRAY_DIR=/opt/genestack/submodules/kubespray
     if [ ! -f "\${KUBESPRAY_DIR}/cluster.yml" ] && [ ! -f "\${KUBESPRAY_DIR}/playbooks/cluster.yml" ]; then
+        # In dev mode the submodules are reconstructed on the jump host by
+        # reconstructSubmodulesOnJumpHost() before this runs, so we normally
+        # never get here. This remains as a fallback for the non-dev clone flow
+        # (a real /opt/genestack clone with a usable .git).
         echo "Kubespray checkout missing, initializing submodule..."
         pushd /opt/genestack >/dev/null
             sudo git config --global --add safe.directory /opt/genestack

--- a/scripts/hyperconverged-lab-talos.sh
+++ b/scripts/hyperconverged-lab-talos.sh
@@ -355,7 +355,7 @@ if ! openstack keypair show ${LAB_NAME_PREFIX}-key 2>/dev/null; then
     fi
 fi
 
-ssh-add ~/.ssh/${LAB_NAME_PREFIX}-key.pem
+ensureSshAgentKey ~/.ssh/${LAB_NAME_PREFIX}-key.pem
 
 #############################################################################
 # Jump Host Port and Instance

--- a/scripts/hyperconverged-lab-talos.sh
+++ b/scripts/hyperconverged-lab-talos.sh
@@ -760,7 +760,11 @@ runGenestackSetupRemote "${SSH_USERNAME}" "${JUMP_HOST_VIP}" "${GATEWAY_DOMAIN}"
 #############################################################################
 
 if [[ "$RUN_EXTRAS" -eq 1 ]]; then
-    installK9sRemote "${SSH_USERNAME}" "${JUMP_HOST_VIP}"
+    if isExcluded k9s; then
+        echo "Skipping k9s install: 'k9s' is in the exclude list (-e)"
+    else
+        installK9sRemote "${SSH_USERNAME}" "${JUMP_HOST_VIP}"
+    fi
 fi
 
 #############################################################################

--- a/scripts/hyperconverged-lab.sh
+++ b/scripts/hyperconverged-lab.sh
@@ -80,6 +80,11 @@ ENVIRONMENT VARIABLES:
                         for easier testing and debugging.
     HYPERCONVERGED_CINDER_VOLUME
                         If set to "true", enables iSCSI cinder volume support.
+    HYPERCONVERGED_MANILA_SHARE
+                        If set to "true", runs the full Manila enablement
+                        (secrets, service image build, share type) in addition
+                        to the Helm chart install. Default "false" keeps
+                        manila chart-only (control-plane pods).
     HYPERCONVERGED_ENVOY_GATEWAY_CONFIG
                         If set to "true", deploys Envoy using the internal/external
                         gateway config file path instead of the legacy flex-gateway.

--- a/scripts/hyperconverged-lab.sh
+++ b/scripts/hyperconverged-lab.sh
@@ -50,7 +50,10 @@ PLATFORMS:
 
 OPTIONS:
     -i <list>    Comma-separated list of OpenStack services to include
-    -e <list>    Comma-separated list of OpenStack services to exclude
+    -e <list>    Comma-separated list of OpenStack services to exclude.
+                 Excluded components also skip their component-specific
+                 extras steps run by -x (e.g. -x -e octavia runs the extras
+                 but skips the Octavia preconf/install; -e k9s skips k9s).
     -x           Run extra operations (k9s install, Octavia preconf, etc.)
     --envoy-gateway-config
                  Deploy Envoy using the internal/external gateway config file

--- a/scripts/lib/hyperconverged-common.sh
+++ b/scripts/lib/hyperconverged-common.sh
@@ -1434,7 +1434,7 @@ function createPostSetupResources() {
     # Usage: createPostSetupResources <lab_name_prefix>
     local lab_prefix="$1"
 
-    if openstack --version; then
+    if command -v openstack >/dev/null 2>&1; then
         echo "OpenStack CLI found"
     else
         echo "Sourcing OpenStack RC file..."
@@ -1443,10 +1443,10 @@ function createPostSetupResources() {
 
     echo "Running Generic Genestack post setup..."
 
-    if [ ! -f ~/.config/openstack ]; then
-        sudo mkdir -p ~/.config/openstack
-        sudo cp /root/.config/openstack/clouds.yaml ~/.config/openstack
-        sudo chown $(id -u):$(id -g) ~/.config
+    mkdir -p ~/.config/openstack
+    if [ ! -f ~/.config/openstack/clouds.yaml ] && sudo test -f /root/.config/openstack/clouds.yaml; then
+        sudo cp /root/.config/openstack/clouds.yaml ~/.config/openstack/
+        sudo chown -R $(id -u):$(id -g) ~/.config/openstack
     fi
 
     # Create test flavor
@@ -1619,7 +1619,7 @@ function waitForOpenStackAPIsReady() {
 
     echo "Waiting for OpenStack APIs to be ready (timeout: ${timeout}s)..."
 
-    if openstack --version; then
+    if command -v openstack >/dev/null 2>&1; then
         echo "OpenStack CLI found"
     else
         echo "Sourcing OpenStack RC file..."
@@ -1628,10 +1628,10 @@ function waitForOpenStackAPIsReady() {
 
     echo "Running Generic Genestack post setup..."
 
-    if [ ! -f ~/.config/openstack ]; then
-        sudo mkdir -p ~/.config/openstack
-        sudo cp /root/.config/openstack/clouds.yaml ~/.config/openstack
-        sudo chown $(id -u):$(id -g) ~/.config
+    mkdir -p ~/.config/openstack
+    if [ ! -f ~/.config/openstack/clouds.yaml ] && sudo test -f /root/.config/openstack/clouds.yaml; then
+        sudo cp /root/.config/openstack/clouds.yaml ~/.config/openstack/
+        sudo chown -R $(id -u):$(id -g) ~/.config/openstack
     fi
 
     # Wait for Keystone (authentication) to be ready first
@@ -1820,9 +1820,12 @@ SSH_CONFIG_EOF
 source /opt/genestack/scripts/genestack.rc
 
 echo "[JUMP_HOST] Setup for admin operations"
-sudo mkdir -p ~/.config/openstack
-sudo cp /root/.config/openstack/clouds.yaml ~/.config/openstack/
-sudo chown -R $(id -u):$(id -g) ~/.config
+mkdir -p ~/.config/openstack
+if [ ! -f ~/.config/openstack/clouds.yaml ] && sudo test -f /root/.config/openstack/clouds.yaml; then
+    # Note: escaped \$(id ...) so expansion happens on the jump host.
+    sudo cp /root/.config/openstack/clouds.yaml ~/.config/openstack/
+    sudo chown -R "\$(id -u):\$(id -g)" ~/.config/openstack
+fi
 
 echo "[JUMP_HOST] Updating ~/.ssh/config"
 cat >> ~/.ssh/config << SSH_CONFIG_EOF
@@ -1915,13 +1918,13 @@ function install_preconf_octavia() {
     _ssh << 'EOC'
 set -e
 
-if [ ! -f ~/.config/openstack ]; then
-    sudo mkdir -p ~/.config/openstack
-    sudo cp /root/.config/openstack/clouds.yaml ~/.config/openstack
-    sudo chown $(id -u):$(id -g) ~/.config
-fi
-
 source ~/.venvs/genestack/bin/activate
+
+mkdir -p ~/.config/openstack
+if [ ! -f ~/.config/openstack/clouds.yaml ] && sudo test -f /root/.config/openstack/clouds.yaml; then
+    sudo cp /root/.config/openstack/clouds.yaml ~/.config/openstack/
+    sudo chown -R "$(id -u):$(id -g)" ~/.config/openstack
+fi
 
 OCTAVIA_HELM_FILE=/tmp/octavia_helm_overrides.yaml
 

--- a/scripts/lib/hyperconverged-common.sh
+++ b/scripts/lib/hyperconverged-common.sh
@@ -135,6 +135,22 @@ function parseCommonArgs() {
     export HYPERCONVERGED_INTERNAL_METALLB_IP
 }
 
+function isExcluded() {
+    # Check whether a component was excluded via -e. Used to let the exclude
+    # list override component-specific extras (-x) steps, e.g.
+    # `-x -e octavia` runs the extras but skips the Octavia preconf/install.
+    # Usage: isExcluded <component>
+    local component
+    local item
+    component=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+    for item in "${EXCLUDE_LIST[@]}"; do
+        if [ "$(printf '%s' "${item}" | tr '[:upper:]' '[:lower:]')" = "${component}" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 function ensureSshAgentKey() {
     # Ensure the given private key is available in the user's ssh-agent
     # without blindly running ssh-add:

--- a/scripts/lib/hyperconverged-common.sh
+++ b/scripts/lib/hyperconverged-common.sh
@@ -439,13 +439,82 @@ function prepareJumpHostSource() {
         _ssh "while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1; do echo 'Waiting for apt locks to be released...'; sleep 5; done && sudo apt-get update && sudo apt install -y rsync git && sudo mkdir -p /opt/genestack && sudo chown ${SSH_USERNAME}:${SSH_USERNAME} /opt/genestack"
 
         echo "Copying the development source code to the jump host"
-        # Keep .git so the jump host can initialize pinned submodules such as Kubespray.
+        # Exclude .git: when DEV_PATH is a git *worktree*, .git is a pointer file
+        # (gitdir: .../worktrees/<name>) that cannot resolve on the remote and
+        # poisons EVERY git invocation whose cwd is inside /opt/genestack
+        # (e.g. ansible.builtin.git tasks fail with "not a git repository").
+        # Pinned submodules are reconstructed explicitly below instead.
         rsync -avz \
+            --exclude='.git' \
             -e "ssh ${SSH_OPTS_STR}" \
             "${DEV_PATH}/" "${SSH_TARGET}:/opt/genestack/"
+
+        # Remove a stale .git pointer file rsync'd by older versions of this
+        # script (a real .git directory from the clone flow is left alone).
+        _ssh 'if [ -f /opt/genestack/.git ]; then sudo rm -f /opt/genestack/.git; fi'
+
+        reconstructSubmodulesOnJumpHost "${DEV_PATH}" "/opt/genestack"
     else
         cloneGenestackOnJumpHost
     fi
+}
+
+function reconstructSubmodulesOnJumpHost() {
+    # Rebuild each pinned submodule on the jump host directly from .gitmodules
+    # metadata + the parent tree's gitlink SHAs, without relying on `git
+    # submodule` (which needs a working parent .git). This makes dev-mode work
+    # when the local source is a git worktree, and also handles submodules that
+    # are not checked out locally.
+    # Usage: reconstructSubmodulesOnJumpHost <dev_path> [dest_root]
+    local dev_path="$1"
+    local dest_root="${2:-/opt/genestack}"
+    local manifest
+
+    if [ ! -f "${dev_path}/.gitmodules" ]; then
+        return 0
+    fi
+
+    # Build a "path<TAB>url<TAB>sha" manifest, one line per submodule.
+    manifest="$(
+        git -C "${dev_path}" config -f .gitmodules --get-regexp '^submodule\..*\.path$' 2>/dev/null |
+        while read -r key sm_path; do
+            local name url sha
+            name=${key#submodule.}
+            name=${name%.path}
+            url=$(git -C "${dev_path}" config -f .gitmodules "submodule.${name}.url" 2>/dev/null)
+            sha=$(git -C "${dev_path}" ls-tree HEAD "${sm_path}" 2>/dev/null | awk '{print $3}')
+            if [ -n "${url}" ] && [ -n "${sha}" ]; then
+                printf '%s\t%s\t%s\n' "${sm_path}" "${url}" "${sha}"
+            fi
+        done
+    )"
+
+    if [ -z "${manifest}" ]; then
+        echo "No pinned submodules resolved from .gitmodules; skipping remote submodule reconstruction."
+        return 0
+    fi
+
+    echo "Reconstructing pinned submodules on the jump host (worktree-safe):"
+    printf '%s\n' "${manifest}" | sed 's/^/  - /'
+
+    _ssh bash <<EOC
+set -e
+while IFS=\$'\t' read -r sm_path sm_url sm_sha; do
+    [ -z "\${sm_path}" ] && continue
+    dest="${dest_root}/\${sm_path}"
+    if [ -e "\${dest}/.git" ] && sudo git -C "\${dest}" rev-parse --verify --quiet "\${sm_sha}^{commit}" >/dev/null 2>&1; then
+        sudo git -C "\${dest}" checkout --quiet "\${sm_sha}"
+        echo "  \${sm_path}: already present, checked out \${sm_sha}"
+        continue
+    fi
+    echo "  \${sm_path}: cloning \${sm_url} @ \${sm_sha}"
+    sudo rm -rf "\${dest}"
+    sudo git clone --quiet "\${sm_url}" "\${dest}"
+    sudo git -C "\${dest}" checkout --quiet "\${sm_sha}"
+done <<'MANIFEST'
+${manifest}
+MANIFEST
+EOC
 }
 
 function writeMetalLBConfig() {

--- a/scripts/lib/hyperconverged-common.sh
+++ b/scripts/lib/hyperconverged-common.sh
@@ -1993,6 +1993,46 @@ JUMP_HOST_EOF
     } | _ssh bash
 }
 
+function deployManila() {
+    # Run the Manila enablement flow on the jump host:
+    #   secrets → image_build → pre_deploy → helm install → post_deploy
+    # (tag sequence documented in ansible/roles/manila_enablement_techpreview)
+    # The playbook is self-sufficient: it reads the keystone-admin password
+    # from the K8s secret and authenticates via its own OS_* environment.
+    echo "Running manila deployment ..."
+
+    _ssh << 'EOC'
+# check if manila is to be installed, otherwise exit cleanly
+if ! grep "manila: true" /etc/genestack/openstack-components.yaml &>/dev/null; then
+    echo "Manila not installed, exiting Manila setup function for $(hostname)"
+    exit 0
+fi
+
+set -e
+# activate environment for openstack commands
+source /opt/genestack/scripts/genestack.rc
+
+echo "Running playbook for manila secrets"
+ansible-playbook /opt/genestack/ansible/playbooks/manila-enablement-techpreview.yaml \
+    --tags secrets
+
+echo "Running playbook for manila image_build"
+ansible-playbook /opt/genestack/ansible/playbooks/manila-enablement-techpreview.yaml \
+    --tags image_build
+
+echo "Running playbook for manila pre_deploy"
+ansible-playbook /opt/genestack/ansible/playbooks/manila-enablement-techpreview.yaml \
+    --tags pre_deploy
+
+echo "Installing Manila via Helm chart"
+sudo /opt/genestack/bin/install-manila.sh
+
+echo "Running playbook for manila post_deploy"
+ansible-playbook /opt/genestack/ansible/playbooks/manila-enablement-techpreview.yaml \
+    --tags post_deploy
+EOC
+}
+
 function deployTrove() {
     echo "Running Trove deployment ..."
 

--- a/scripts/lib/hyperconverged-common.sh
+++ b/scripts/lib/hyperconverged-common.sh
@@ -135,6 +135,48 @@ function parseCommonArgs() {
     export HYPERCONVERGED_INTERNAL_METALLB_IP
 }
 
+function ensureSshAgentKey() {
+    # Ensure the given private key is available in the user's ssh-agent
+    # without blindly running ssh-add:
+    #   - If no agent is reachable, fail fast with clear guidance.
+    #   - If the key is already loaded (e.g. users of 1Password or other
+    #     custom agents that do not support ssh-add), leave the agent alone.
+    #   - Otherwise attempt ssh-add and fail with guidance if the agent
+    #     refuses it.
+    # Usage: ensureSshAgentKey <path-to-private-key.pem>
+    local key_pem="$1"
+    local agent_status=0
+    local key_fp
+
+    # ssh-add -l exit codes: 0 = keys listed, 1 = agent reachable but empty,
+    # >=2 = cannot connect to the agent socket.
+    ssh-add -l >/dev/null 2>&1 || agent_status=$?
+
+    if [ "${agent_status}" -ge 2 ]; then
+        echo "ERROR: Cannot connect to an ssh-agent (SSH_AUTH_SOCK=${SSH_AUTH_SOCK:-unset})." >&2
+        echo "       The lab relies on agent forwarding to reach cluster nodes, so a" >&2
+        echo "       running agent with ${key_pem} loaded is required." >&2
+        echo "       Start one with:  eval \"\$(ssh-agent)\" && ssh-add ${key_pem}" >&2
+        echo "       1Password/custom agent users: export the agent socket via" >&2
+        echo "       SSH_AUTH_SOCK and make sure the key is available in the agent." >&2
+        exit 1
+    fi
+
+    # Skip ssh-add when the key is already loaded (fingerprint match).
+    key_fp=$(ssh-keygen -lf "${key_pem}" 2>/dev/null | awk '{print $2}')
+    if [ -n "${key_fp}" ] && ssh-add -l 2>/dev/null | grep -qF "${key_fp}"; then
+        echo "SSH key ${key_pem} already present in ssh-agent; skipping ssh-add."
+        return 0
+    fi
+
+    if ! ssh-add "${key_pem}"; then
+        echo "ERROR: ssh-add failed to load ${key_pem} into the running agent." >&2
+        echo "       If your agent does not support ssh-add (e.g. 1Password), add the" >&2
+        echo "       key through the agent's own tooling, then re-run." >&2
+        exit 1
+    fi
+}
+
 function writeOpenstackComponentsConfig() {
     # Write OpenStack components configuration file
     # Usage: writeOpenstackComponentsConfig [output_path]


### PR DESCRIPTION
feat: safe ssh-agent handling for hyperconverged labs

Replace the naked ssh-add with ensureSshAgentKey(): fail fast with
guidance when no agent socket is reachable, skip ssh-add when the key
fingerprint is already loaded (1Password and other read-only agents
reject ssh-add), and error clearly if the agent refuses the key.

fix: make HYPERCONVERGED_DEV work from git worktrees

A git worktree's .git is a pointer file (gitdir: .../worktrees/<name>)
that cannot resolve on the jump host. Rsyncing it poisoned every git
invocation with cwd inside /opt/genestack, e.g. 'git submodule update'
and ansible.builtin.git tasks failed with 'not a git repository'.

- exclude .git from the dev-mode rsync and delete a stale pointer file
  shipped by older script versions
- reconstruct pinned submodules explicitly from .gitmodules metadata and
  the parent tree's gitlink SHAs (plain clone + checkout, no parent
  .git required); also covers submodules not checked out locally

fix: give the jump-host ssh user a kubeconfig and pinned collections

The trove/manila enablement playbooks run unprivileged on the jump host
and need kubernetes.core (kubeconfig) plus the pinned openstack.cloud
collection. Previously the ssh user only received a kubeconfig as a side
effect of the optional -x k9s install, and never received the pinned
collections at all (bootstrap.sh installs them for root only) - the
openstack.cloud version bundled with the ansible pip package fails with
openstacksdk >= 4.15 (AttributeError: module 'openstack' has no
attribute 'version').

fix: hyperconverged lab reliability fixes

- kustomize.sh: chown the generated all.yaml to match its directory so
  sudo'd helm installs no longer leave root-owned files inside a
  user-owned dev checkout (dev-mode labs rsync /opt/genestack as the
  ssh user).
- setup-infrastructure.sh: wait for the messaging-topology-operator and
  its webhook service endpoints before creating the rabbitmq cluster;
  on fresh clusters keystone's helm install raced the webhook pod and
  failed with 'failed calling webhook ... connection refused' for all
  five rabbitmq.com validating webhooks.
- clouds.yaml propagation to the ssh user: copy once when missing
  instead of on every run (the old '! -f ~/.config/openstack' guard
  tested a directory and always re-copied), and expand $(id -u) on the
  jump host rather than on the operator's workstation in the
  cinderVolumeSetup heredoc.
- probe for the openstack CLI with 'command -v' instead of running
  'openstack --version', which printed 'command not found' noise before
  the venv was activated.

feat: let -e exclusions override component-specific -x extras

Add isExcluded() and gate the k9s extras install on it in both the
kubespray and talos labs, so e.g. '-x -e k9s' runs the extras without
installing k9s. Case-insensitive, portable to bash 3.2 (macOS
workstations). Documented in the -e help text.

feat: optional full Manila enablement in the hyperconverged lab

Add deployManila(): runs the manila_enablement_techpreview playbook in
its documented tag order (secrets -> image_build -> pre_deploy), installs
the chart, then post_deploy (share type). Gated by the new
HYPERCONVERGED_MANILA_SHARE environment variable (mirroring
HYPERCONVERGED_CINDER_VOLUME) so 'manila: true' alone stays chart-only
and smoke tests remain fast; also self-gates on openstack-components.yaml
so '-e manila' skips it.

Drop the pinned image tags and static job dependencies from the manila
helm config template so the enablement follows whatever base-helm-configs
ships for the target release, and trim oslo_* sections now handled by
chart defaults.

fix: octavia port scripts honor env-based auth; -e octavia skips extras

The octavia preconf play authenticates its tasks via a play-level OS_*
environment built from the internal keystone endpoint. The port creation
scripts exported OS_CLOUD even when the play passed an empty cloud name,
which can override that environment with a clouds.yaml profile pointing
at the public endpoint (not resolvable at this stage of the lab). Only
export OS_CLOUD when a cloud name was actually provided.
