### PR TITLE
feat: hyperconverged lab script enhancements

### DIFF
--- a/ansible/roles/manila_enablement_techpreview/tasks/manila_service_image_builder.yml
+++ b/ansible/roles/manila_enablement_techpreview/tasks/manila_service_image_builder.yml
@@ -387,8 +387,12 @@
   retries: 3
   delay: 30
   until: tox_build_result.rc == 0
+  # Note: no HOME override here. This task runs as root, and forcing
+  # HOME to the ssh user's home makes diskimage-builder/virtualenv create
+  # root-owned XDG directories (~/.cache/dib, ~/.local/share/virtualenv)
+  # in that user's home, breaking XDG-compliant tools (e.g. k9s). The DIB
+  # caches live in /root/.cache instead, which persists equally.
   environment:
-    HOME: "{{ ubuntu_home }}"
     MANILA_PASSWORD: "{{ manila_admin_password_result.stdout }}"
     MANILA_USER_AUTHORIZED_KEYS: "{{ manila_build_dir }}/manila-image-elements/manila-service-keypair.pub"
     MANILA_IMG_NAME: "{{ manila_service_image_name }}"

--- a/ansible/roles/manila_enablement_techpreview/templates/manila_default_helm_config.yaml
+++ b/ansible/roles/manila_enablement_techpreview/templates/manila_default_helm_config.yaml
@@ -6,6 +6,11 @@ images:
 # hyperconverged lab (/scripts/hyperconverged-lab.sh).
 # limit values based on defaults from the openstack-helm charts unless defined
 pod:
+  # hostNetwork 'hostname --fqdn' lookup fails in the share pod and injects an
+  # empty [generic] service_network_host, which manila >= 22.x rejects at
+  # startup; unused with connect_share_server_to_tenant_network enabled.
+  use_fqdn:
+    share: false
   replicas:
     api: 2
     data: 2

--- a/ansible/roles/trove_enablement_techpreview/tasks/trove_guest_image_builder.yml
+++ b/ansible/roles/trove_enablement_techpreview/tasks/trove_guest_image_builder.yml
@@ -233,8 +233,12 @@
   retries: 3
   delay: 30
   until: _trove_dib_build.rc == 0
+  # Note: no HOME override here. This task runs as root, and forcing
+  # HOME to the ssh user's home makes diskimage-builder/virtualenv create
+  # root-owned XDG directories (~/.cache/dib, ~/.local/share/virtualenv)
+  # in that user's home, breaking XDG-compliant tools (e.g. k9s). The DIB
+  # caches live in /root/.cache instead, which persists equally.
   environment:
-    HOME: "{{ ubuntu_home }}"
     ELEMENTS_PATH: "{{ trove_build_dir }}/trove/integration/scripts/files/elements"
     DIB_RELEASE: "{{ trove_guest_image_os_release }}"
     DIB_DISTRIBUTION_MIRROR: "{{ trove_dib_distribution_mirror }}"

--- a/base-helm-configs/manila/manila-helm-overrides.yaml
+++ b/base-helm-configs/manila/manila-helm-overrides.yaml
@@ -34,14 +34,8 @@ images:
 # hyperconverged lab (/scripts/hyperconverged-lab.sh).
 # limit values based on defaults from the openstack-helm charts unless defined
 pod:
-  # The manila-share pod runs with hostNetwork and its init container derives
-  # service_network_host from 'hostname --fqdn', which fails to resolve in
-  # the pod's DNS context and injects an EMPTY value; manila >= 22.x rejects
-  # it at startup (oslo HostAddress: 'is not a valid host address'). The
-  # generic driver runs with connect_share_server_to_tenant_network=true, so
-  # service_network_host is unused - disable the fqdn injection entirely.
   use_fqdn:
-    share: false
+    share: true
   replicas:
     api: 1
     data: 1

--- a/base-helm-configs/manila/manila-helm-overrides.yaml
+++ b/base-helm-configs/manila/manila-helm-overrides.yaml
@@ -34,6 +34,14 @@ images:
 # hyperconverged lab (/scripts/hyperconverged-lab.sh).
 # limit values based on defaults from the openstack-helm charts unless defined
 pod:
+  # The manila-share pod runs with hostNetwork and its init container derives
+  # service_network_host from 'hostname --fqdn', which fails to resolve in
+  # the pod's DNS context and injects an EMPTY value; manila >= 22.x rejects
+  # it at startup (oslo HostAddress: 'is not a valid host address'). The
+  # generic driver runs with connect_share_server_to_tenant_network=true, so
+  # service_network_host is unused - disable the fqdn injection entirely.
+  use_fqdn:
+    share: false
   replicas:
     api: 1
     data: 1

--- a/base-helm-configs/manila/manila-helm-overrides.yaml
+++ b/base-helm-configs/manila/manila-helm-overrides.yaml
@@ -12,21 +12,21 @@
 # limitations under the License.
 images:
   tags:
-    db_init: ghcr.io/rackerlabs/genestack-images/heat:2026.1-latest
-    db_drop: ghcr.io/rackerlabs/genestack-images/heat:2026.1-latest
+    db_init: ghcr.io/rackerlabs/genestack-images/openstack-client:latest
+    db_drop: ghcr.io/rackerlabs/genestack-images/openstack-client:latest
     dep_check: ghcr.io/rackerlabs/genestack-images/kubernetes-entrypoint:latest
     image_repo_sync: docker.io/docker:17.07.0
-    ks_endpoints: ghcr.io/rackerlabs/genestack-images/heat:2026.1-latest
-    ks_service: ghcr.io/rackerlabs/genestack-images/heat:2026.1-latest
-    ks_user: ghcr.io/rackerlabs/genestack-images/heat:2026.1-latest
-    manila: ghcr.io/rackerlabs/genestack-images/manila:2026.1-1763166117
-    manila_api: ghcr.io/rackerlabs/genestack-images/manila-api:2026.1-1763166117
-    manila_data: ghcr.io/rackerlabs/genestack-images/manila-data:2026.1-1763166117
-    manila_db_sync: ghcr.io/rackerlabs/genestack-images/manila:2026.1-1763166117
-    manila_scheduler: ghcr.io/rackerlabs/genestack-images/manila-scheduler:2026.1-1763166117
-    manila_share: ghcr.io/rackerlabs/genestack-images/manila-share:2026.1-1763166117
-    manila_processor: ghcr.io/rackerlabs/genestack-images/manila:2026.1-1763166117
-    manila_storage_init: ghcr.io/rackerlabs/genestack-images/manila:2026.1-1763166117
+    ks_endpoints: ghcr.io/rackerlabs/genestack-images/openstack-client:latest
+    ks_service: ghcr.io/rackerlabs/genestack-images/openstack-client:latest
+    ks_user: ghcr.io/rackerlabs/genestack-images/openstack-client:latest
+    manila: ghcr.io/rackerlabs/genestack-images/manila:2026.1-latest
+    manila_api: ghcr.io/rackerlabs/genestack-images/manila:2026.1-latest
+    manila_data: ghcr.io/rackerlabs/genestack-images/manila:2026.1-latest
+    manila_db_sync: ghcr.io/rackerlabs/genestack-images/manila:2026.1-latest
+    manila_scheduler: ghcr.io/rackerlabs/genestack-images/manila:2026.1-latest
+    manila_share: ghcr.io/rackerlabs/genestack-images/manila:2026.1-latest
+    manila_processor: ghcr.io/rackerlabs/genestack-images/manila:2026.1-latest
+    manila_storage_init: ghcr.io/rackerlabs/genestack-images/manila:2026.1-latest
     rabbit_init: docker.io/rabbitmq:3.13-management
   pull_policy: "IfNotPresent"
 

--- a/openstack-components.yaml
+++ b/openstack-components.yaml
@@ -6,11 +6,6 @@ components:
   blazar: false
   ceilometer: false
   cinder: false
-  # cinder-volume is a pseudo service handled by the hyperconverged lab: it
-  # runs the cinder volumes data-plane enablement (volume/VG prep, the cinder
-  # volumes playbook on labeled storage nodes, volume type/QoS). 'cinder'
-  # above covers only the control-plane chart.
-  cinder-volume: false
   cloudkitty: false
   freezer: false
   glance: true

--- a/openstack-components.yaml
+++ b/openstack-components.yaml
@@ -6,6 +6,11 @@ components:
   blazar: false
   ceilometer: false
   cinder: false
+  # cinder-volume is a pseudo service handled by the hyperconverged lab: it
+  # runs the cinder volumes data-plane enablement (volume/VG prep, the cinder
+  # volumes playbook on labeled storage nodes, volume type/QoS). 'cinder'
+  # above covers only the control-plane chart.
+  cinder-volume: false
   cloudkitty: false
   freezer: false
   glance: true

--- a/scripts/hyperconverged-lab-kubespray.sh
+++ b/scripts/hyperconverged-lab-kubespray.sh
@@ -378,7 +378,7 @@ echo "  Jump host is ready"
 # Create and Attach Lab Volumes
 #############################################################################
 
-if [ "${HYPERCONVERGED_CINDER_VOLUME:-false}" = "true" ]; then
+if [ "${CINDER_VOLUME_ENABLED:-false}" = "true" ]; then
     READY_COUNT=0
     while [ $(openstack server show ${LAB_NAME_PREFIX}-0 -f yaml | yq '.status') != 'ACTIVE' ]; do
       echo "Server instance 0 is not ready, waiting..."
@@ -713,7 +713,7 @@ fi
 
 # Create Kubespray inventory
 if [ ! -f "/etc/genestack/inventory/inventory.yaml" ]; then
-    if [ "${HYPERCONVERGED_CINDER_VOLUME:-false}" = "true" ]; then
+    if [ "${CINDER_VOLUME_ENABLED:-false}" = "true" ]; then
         cat > /etc/genestack/inventory/inventory.yaml <<EOF
 ---
 all:
@@ -976,7 +976,7 @@ runGenestackSetupRemote "${SSH_USERNAME}" "${JUMP_HOST_VIP}" "${GATEWAY_DOMAIN}"
 #############################################################################
 # Cinder Volume Setup
 #############################################################################
-if [ "${HYPERCONVERGED_CINDER_VOLUME:-false}" = "true" ] && [ ${DISABLE_OPENSTACK} = "false" ]; then
+if [ "${CINDER_VOLUME_ENABLED:-false}" = "true" ] && [ ${DISABLE_OPENSTACK} = "false" ]; then
   cinderVolumeSetup
 fi
 

--- a/scripts/hyperconverged-lab-kubespray.sh
+++ b/scripts/hyperconverged-lab-kubespray.sh
@@ -1024,15 +1024,17 @@ if [ "${TEST_LEVEL}" = "off" ]; then
     deploySwift "RegionOne"
 
     # Manila Setup & Installation
-    # Opt-in via HYPERCONVERGED_MANILA_SHARE (mirrors HYPERCONVERGED_CINDER_VOLUME):
-    # by default 'manila: true' only installs the chart (control-plane pods),
-    # keeping smoke tests fast. Setting HYPERCONVERGED_MANILA_SHARE=true
-    # additionally runs the full enablement (secrets, service image build,
-    # pre/post deploy). Runs after the OpenStack APIs are ready because the
+    # Opt-in via the 'manila-share' pseudo service (-i manila-share, which
+    # implies the manila control plane) or the legacy
+    # HYPERCONVERGED_MANILA_SHARE=true environment variable; both resolve to
+    # MANILA_SHARE_ENABLED in parseCommonArgs. By default 'manila: true' only
+    # installs the chart (control-plane pods), keeping smoke tests fast; the
+    # enablement additionally runs secrets, the service image build and
+    # pre/post deploy. Runs after the OpenStack APIs are ready because the
     # image build uploads to Glance. deployManila also self-gates on
     # 'manila: true' in openstack-components.yaml, so '-e manila' (which sets
     # it false) skips it too.
-    if [ "${HYPERCONVERGED_MANILA_SHARE:-false}" = "true" ] && [ ${DISABLE_OPENSTACK} = "false" ]; then
+    if [ "${MANILA_SHARE_ENABLED:-false}" = "true" ] && [ ${DISABLE_OPENSTACK} = "false" ]; then
         deployManila
     fi
 

--- a/scripts/hyperconverged-lab-kubespray.sh
+++ b/scripts/hyperconverged-lab-kubespray.sh
@@ -949,6 +949,11 @@ if [ ! -f \${HOME}/.kube/config ]; then
     sudo chown \$(id -u):\$(id -g) \${HOME}/.kube/config
     chmod 600 \${HOME}/.kube/config
 fi
+# Pre-create the XDG base directories as the ssh user so that any later
+# root-context task with a misdirected HOME can only create subpaths under
+# them rather than taking ownership of the roots (which breaks
+# XDG-compliant tools like k9s for the ssh user).
+mkdir -p \${HOME}/.local/state \${HOME}/.local/share \${HOME}/.cache
 sudo mkdir -p /opt/kube-plugins
 sudo chown \${USER}:\${USER} /opt/kube-plugins
 pushd /opt/kube-plugins

--- a/scripts/hyperconverged-lab.sh
+++ b/scripts/hyperconverged-lab.sh
@@ -49,11 +49,16 @@ PLATFORMS:
     help         Show this help message
 
 OPTIONS:
-    -i <list>    Comma-separated list of OpenStack services to include
+    -i <list>    Comma-separated list of OpenStack services to include.
+                 'cinder-volume' is a pseudo service: 'cinder' installs the
+                 control-plane chart only, while 'cinder-volume' additionally
+                 runs the data-plane enablement (volume/VG prep, cinder
+                 volumes playbook, volume type/QoS).
     -e <list>    Comma-separated list of OpenStack services to exclude.
                  Excluded components also skip their component-specific
                  extras steps run by -x (e.g. -x -e octavia runs the extras
-                 but skips the Octavia preconf/install; -e k9s skips k9s).
+                 but skips the Octavia preconf/install; -e k9s skips k9s,
+                 -e cinder-volume skips the cinder data-plane enablement).
     -x           Run extra operations (k9s install, Octavia preconf, etc.)
     --envoy-gateway-config
                  Deploy Envoy using the internal/external gateway config file
@@ -80,6 +85,8 @@ ENVIRONMENT VARIABLES:
                         for easier testing and debugging.
     HYPERCONVERGED_CINDER_VOLUME
                         If set to "true", enables iSCSI cinder volume support.
+                        Equivalent to including the 'cinder-volume' pseudo
+                        service via -i; '-e cinder-volume' overrides both.
     HYPERCONVERGED_MANILA_SHARE
                         If set to "true", runs the full Manila enablement
                         (secrets, service image build, share type) in addition

--- a/scripts/hyperconverged-lab.sh
+++ b/scripts/hyperconverged-lab.sh
@@ -109,12 +109,11 @@ ENVIRONMENT VARIABLES:
                         always matches the control plane.
     HYPERCONVERGED_MANILA_SHARE
                         If set to "true", runs the full Manila enablement
-                        (secrets, service image build, share type) in addition
-                        to the Helm chart install. Default "false" keeps
-                        manila chart-only (control-plane pods). Similar to
-                        including the 'manila-share' pseudo service via -i,
-                        except the environment variable does not imply the
-                        manila chart; '-e manila-share' overrides both.
+                        (secrets, service image build, share type) with a
+                        single manila chart install performed by the
+                        enablement step. Equivalent to including the
+                        'manila-share' pseudo service via -i; '-e manila-share'
+                        overrides both. Default "false" installs no manila.
     HYPERCONVERGED_ENVOY_GATEWAY_CONFIG
                         If set to "true", deploys Envoy using the internal/external
                         gateway config file path instead of the legacy flex-gateway.

--- a/scripts/hyperconverged-lab.sh
+++ b/scripts/hyperconverged-lab.sh
@@ -93,6 +93,20 @@ ENVIRONMENT VARIABLES:
                         If set to "true", enables iSCSI cinder volume support.
                         Equivalent to including the 'cinder-volume' pseudo
                         service via -i; '-e cinder-volume' overrides both.
+    CINDER_STORAGE_INTERFACE
+                        Ansible fact name of the storage network interface
+                        used by the cinder volumes playbook
+                        (default: ansible_enp3s0).
+    CINDER_STORAGE_INTERFACE_SECONDARY
+                        Secondary storage interface fact name (defaults to
+                        CINDER_STORAGE_INTERFACE).
+    CINDER_BACKEND_NAME Cinder backend name for the volumes playbook
+                        (default: lvmdriver-1).
+    CINDER_WORKER_NAME  Cinder worker type for the volumes playbook
+                        (default: lvm). The cinder release branch is no longer
+                        configurable here: it is derived from the cinder chart
+                        version in helm-chart-versions.yaml so the data plane
+                        always matches the control plane.
     HYPERCONVERGED_MANILA_SHARE
                         If set to "true", runs the full Manila enablement
                         (secrets, service image build, share type) in addition

--- a/scripts/hyperconverged-lab.sh
+++ b/scripts/hyperconverged-lab.sh
@@ -51,12 +51,15 @@ PLATFORMS:
 OPTIONS:
     -i <list>    Comma-separated list of OpenStack services to include.
                  Component names install their control-plane chart. Data-plane
-                 pseudo services (e.g. 'cinder-volume') install the named
-                 data-plane component AND imply their control plane, so
-                 'cinder-volume' alone yields the full cinder stack (single
-                 late chart install + volume/VG prep, cinder volumes playbook,
-                 volume type/QoS). Add plain 'cinder' only when you want the
-                 chart without the data plane.
+                 pseudo services install the named data-plane component AND
+                 imply their control plane:
+                   cinder-volume  full cinder stack: single late chart install
+                                  + volume/VG prep, cinder volumes playbook,
+                                  volume type/QoS
+                   manila-share   full manila stack: chart + enablement
+                                  (secrets, service image build, share type)
+                 Add the plain component name only when you want the chart
+                 without the data plane.
     -e <list>    Comma-separated list of OpenStack services to exclude.
                  Excluded components also skip their component-specific
                  extras steps run by -x (e.g. -x -e octavia runs the extras
@@ -94,7 +97,10 @@ ENVIRONMENT VARIABLES:
                         If set to "true", runs the full Manila enablement
                         (secrets, service image build, share type) in addition
                         to the Helm chart install. Default "false" keeps
-                        manila chart-only (control-plane pods).
+                        manila chart-only (control-plane pods). Similar to
+                        including the 'manila-share' pseudo service via -i,
+                        except the environment variable does not imply the
+                        manila chart; '-e manila-share' overrides both.
     HYPERCONVERGED_ENVOY_GATEWAY_CONFIG
                         If set to "true", deploys Envoy using the internal/external
                         gateway config file path instead of the legacy flex-gateway.

--- a/scripts/hyperconverged-lab.sh
+++ b/scripts/hyperconverged-lab.sh
@@ -50,10 +50,13 @@ PLATFORMS:
 
 OPTIONS:
     -i <list>    Comma-separated list of OpenStack services to include.
-                 'cinder-volume' is a pseudo service: 'cinder' installs the
-                 control-plane chart only, while 'cinder-volume' additionally
-                 runs the data-plane enablement (volume/VG prep, cinder
-                 volumes playbook, volume type/QoS).
+                 Component names install their control-plane chart. Data-plane
+                 pseudo services (e.g. 'cinder-volume') install the named
+                 data-plane component AND imply their control plane, so
+                 'cinder-volume' alone yields the full cinder stack (single
+                 late chart install + volume/VG prep, cinder volumes playbook,
+                 volume type/QoS). Add plain 'cinder' only when you want the
+                 chart without the data plane.
     -e <list>    Comma-separated list of OpenStack services to exclude.
                  Excluded components also skip their component-specific
                  extras steps run by -x (e.g. -x -e octavia runs the extras

--- a/scripts/lib/hyperconverged-common.sh
+++ b/scripts/lib/hyperconverged-common.sh
@@ -127,12 +127,42 @@ function parseCommonArgs() {
         esac
     done
 
+    # Resolve the 'cinder-volume' pseudo service. 'cinder' refers to the
+    # control-plane chart only (like any other component); 'cinder-volume'
+    # covers the data-plane enablement (lab volume/VG prep, the cinder
+    # volumes playbook on labeled storage nodes, volume type/QoS). It can be
+    # enabled with '-i cinder-volume' or the legacy
+    # HYPERCONVERGED_CINDER_VOLUME=true environment variable, and disabled
+    # with '-e cinder-volume' (which wins over both).
+    CINDER_VOLUME_ENABLED="${HYPERCONVERGED_CINDER_VOLUME:-false}"
+    if isIncluded cinder-volume; then
+        CINDER_VOLUME_ENABLED=true
+    fi
+    if isExcluded cinder-volume; then
+        CINDER_VOLUME_ENABLED=false
+    fi
+    export CINDER_VOLUME_ENABLED
+
     export RUN_EXTRAS
     export INCLUDE_LIST
     export EXCLUDE_LIST
     export HYPERCONVERGED_ENVOY_GATEWAY_CONFIG
     export HYPERCONVERGED_ENVOY_GATEWAY_ACME
     export HYPERCONVERGED_INTERNAL_METALLB_IP
+}
+
+function isIncluded() {
+    # Check whether a component was named in the -i include list.
+    # Usage: isIncluded <component>
+    local component
+    local item
+    component=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+    for item in "${INCLUDE_LIST[@]}"; do
+        if [ "$(printf '%s' "${item}" | tr '[:upper:]' '[:lower:]')" = "${component}" ]; then
+            return 0
+        fi
+    done
+    return 1
 }
 
 function isExcluded() {
@@ -720,7 +750,7 @@ EOF
     fi
 
     if [ ! -f "${config_base}/barbican/barbican-helm-overrides.yaml" ]; then
-        if [ "${HYPERCONVERGED_CINDER_VOLUME:-false}" = "true" ]; then
+        if [ "${CINDER_VOLUME_ENABLED:-false}" = "true" ]; then
             cat > "${config_base}/barbican/barbican-helm-overrides.yaml" <<EOF
 ---
 pod:
@@ -771,7 +801,7 @@ EOF
     fi
 
     if [ ! -f "${config_base}/cinder/cinder-helm-overrides.yaml" ]; then
-        if [ "${HYPERCONVERGED_CINDER_VOLUME:-false}" = "true" ]; then
+        if [ "${CINDER_VOLUME_ENABLED:-false}" = "true" ]; then
             cat > "${config_base}/cinder/cinder-helm-overrides.yaml" <<EOF
 ---
 pod:
@@ -958,7 +988,7 @@ EOF
     fi
 
     if [ ! -f "${config_base}/nova/nova-helm-overrides.yaml" ]; then
-        if [ "${HYPERCONVERGED_CINDER_VOLUME:-false}" = "true" ]; then
+        if [ "${CINDER_VOLUME_ENABLED:-false}" = "true" ]; then
             cat > "${config_base}/nova/nova-helm-overrides.yaml" <<EOF
 ---
 pod:
@@ -1568,7 +1598,7 @@ function configureGenestackRemote() {
         declare -f installYq
 
         cat <<EOF
-export HYPERCONVERGED_CINDER_VOLUME=$HYPERCONVERGED_CINDER_VOLUME
+export HYPERCONVERGED_CINDER_VOLUME=$CINDER_VOLUME_ENABLED
 export HYPERCONVERGED_ENVOY_GATEWAY_CONFIG=${HYPERCONVERGED_ENVOY_GATEWAY_CONFIG:-false}
 export HYPERCONVERGED_ENVOY_GATEWAY_ACME=${HYPERCONVERGED_ENVOY_GATEWAY_ACME:-false}
 export METAL_LB_INTERNAL_IP='${internal_metal_lb_ip}'

--- a/scripts/lib/hyperconverged-common.sh
+++ b/scripts/lib/hyperconverged-common.sh
@@ -151,17 +151,14 @@ function parseCommonArgs() {
     # (secrets, service image build, pre/post deploy incl. share type). It can
     # be enabled with '-i manila-share' or the legacy
     # HYPERCONVERGED_MANILA_SHARE=true environment variable, and disabled with
-    # '-e manila-share' (which wins over both). Per the pseudo service
-    # convention, '-i manila-share' implies the manila control plane; the
-    # legacy environment variable keeps its historical behavior and does NOT
-    # imply the chart (deployManila self-gates on 'manila: true' in
-    # openstack-components.yaml and exits cleanly when it is absent).
+    # '-e manila-share' (which wins over both). Like cinder-volume, the
+    # implied control plane is installed by the enablement step (deployManila
+    # runs install-manila.sh after pre_deploy) - NOT by adding manila to the
+    # batch - so the chart is installed once, after its preconf, instead of a
+    # bare batch install followed by an upgrade.
     MANILA_SHARE_ENABLED="${HYPERCONVERGED_MANILA_SHARE:-false}"
     if isIncluded manila-share; then
         MANILA_SHARE_ENABLED=true
-        if ! isIncluded manila && ! isExcluded manila; then
-            INCLUDE_LIST+=("manila")
-        fi
     fi
     if isExcluded manila-share; then
         MANILA_SHARE_ENABLED=false
@@ -245,8 +242,17 @@ function ensureSshAgentKey() {
 
     if ! ssh-add "${key_pem}"; then
         echo "ERROR: ssh-add failed to load ${key_pem} into the running agent." >&2
-        echo "       If your agent does not support ssh-add (e.g. 1Password), add the" >&2
-        echo "       key through the agent's own tooling, then re-run." >&2
+        if [ "${agent_status}" -eq 1 ]; then
+            echo "       The agent reported no identities at all. If you use 1Password" >&2
+            echo "       (or another locking agent), the vault may be locked - unlock" >&2
+            echo "       it and re-run. If the key is already stored in the agent, no" >&2
+            echo "       other action is needed." >&2
+        else
+            echo "       The agent lists identities but none match this key" >&2
+            echo "       (fingerprint ${key_fp:-unknown}). If your agent does not" >&2
+            echo "       support ssh-add (e.g. 1Password), add the key through the" >&2
+            echo "       agent's own tooling, then re-run." >&2
+        fi
         exit 1
     fi
 }
@@ -2091,13 +2097,11 @@ function deployManila() {
     # from the K8s secret and authenticates via its own OS_* environment.
     echo "Running manila deployment ..."
 
+    # The caller gates this on MANILA_SHARE_ENABLED. deployManila performs the
+    # single manila install itself (install-manila.sh after pre_deploy), so
+    # manila is intentionally NOT in the openstack batch - do not re-add a
+    # components.yaml gate here or it will exit without installing.
     _ssh << 'EOC'
-# check if manila is to be installed, otherwise exit cleanly
-if ! grep "manila: true" /etc/genestack/openstack-components.yaml &>/dev/null; then
-    echo "Manila not installed, exiting Manila setup function for $(hostname)"
-    exit 0
-fi
-
 set -e
 # activate environment for openstack commands
 source /opt/genestack/scripts/genestack.rc

--- a/scripts/lib/hyperconverged-common.sh
+++ b/scripts/lib/hyperconverged-common.sh
@@ -1641,6 +1641,12 @@ function configureGenestackRemote() {
 
         cat <<EOF
 export HYPERCONVERGED_CINDER_VOLUME=$CINDER_VOLUME_ENABLED
+# writeServiceHelmOverrides (shipped above via declare -f and executed on the
+# jump host) selects the cinder/nova/barbican override variants by testing
+# CINDER_VOLUME_ENABLED, which only exists on the workstation - export the
+# resolved value into the remote session too.
+export CINDER_VOLUME_ENABLED=$CINDER_VOLUME_ENABLED
+export MANILA_SHARE_ENABLED=$MANILA_SHARE_ENABLED
 export HYPERCONVERGED_ENVOY_GATEWAY_CONFIG=${HYPERCONVERGED_ENVOY_GATEWAY_CONFIG:-false}
 export HYPERCONVERGED_ENVOY_GATEWAY_ACME=${HYPERCONVERGED_ENVOY_GATEWAY_ACME:-false}
 export METAL_LB_INTERNAL_IP='${internal_metal_lb_ip}'
@@ -1967,6 +1973,7 @@ NODE_2_EOF
     # Ansible playbook time
     {
         cat << ANSIBLE_EOF
+set -e
 source /opt/genestack/scripts/genestack.rc
 
 echo "[JUMP_HOST] Running cinder install script"
@@ -1976,8 +1983,19 @@ sudo /opt/genestack/bin/install-cinder.sh
 # run_once for the delegated python3-kubernetes install, which eliminated the
 # dpkg lock race that previously required running this playbook twice.
 echo "[JUMP_HOST] Running cinder volumes playbook"
+# Derive the cinder release branch from the chart version actually being
+# installed on the control plane (/etc/genestack/helm-chart-versions.yaml is
+# what install-cinder.sh deploys from), e.g. 2026.1.9+abc -> stable/2026.1.
+CINDER_RELEASE_BRANCH="stable/\$(yq '.charts.cinder' /etc/genestack/helm-chart-versions.yaml | cut -d. -f1,2)"
+if [ "\${CINDER_RELEASE_BRANCH}" = "stable/" ] || [ "\${CINDER_RELEASE_BRANCH}" = "stable/null" ]; then
+    echo "ERROR: could not derive cinder release branch from /etc/genestack/helm-chart-versions.yaml" >&2
+    exit 1
+fi
+echo "[JUMP_HOST] cinder release branch: \${CINDER_RELEASE_BRANCH}"
+# The storage interface and backend knobs expand on the workstation so they
+# can be overridden via the environment without editing this script.
 ansible-playbook -i /etc/genestack/inventory/inventory.yaml \
-    -e "storage_network_interface=ansible_enp3s0 storage_network_interface_secondary=ansible_enp3s0 cinder_backend_name=lvmdriver-1 cinder_worker_name=lvm cinder_release_branch='stable/2025.1'" \
+    -e "storage_network_interface=${CINDER_STORAGE_INTERFACE:-ansible_enp3s0} storage_network_interface_secondary=${CINDER_STORAGE_INTERFACE_SECONDARY:-${CINDER_STORAGE_INTERFACE:-ansible_enp3s0}} cinder_backend_name=${CINDER_BACKEND_NAME:-lvmdriver-1} cinder_worker_name=${CINDER_WORKER_NAME:-lvm} cinder_release_branch='\${CINDER_RELEASE_BRANCH}'" \
     /opt/genestack/ansible/playbooks/deploy-cinder-volume.yaml -f3
 
 echo "[JUMP_HOST] Creating volume type and qos"

--- a/scripts/lib/hyperconverged-common.sh
+++ b/scripts/lib/hyperconverged-common.sh
@@ -142,6 +142,9 @@ function parseCommonArgs() {
         CINDER_VOLUME_ENABLED=false
     fi
     export CINDER_VOLUME_ENABLED
+    if [ "${CINDER_VOLUME_ENABLED}" = "true" ]; then
+        echo "cinder-volume enabled: cinder control plane + LVM/iSCSI data plane (volumes playbook, volume type/QoS)"
+    fi
 
     export RUN_EXTRAS
     export INCLUDE_LIST

--- a/scripts/lib/hyperconverged-common.sh
+++ b/scripts/lib/hyperconverged-common.sh
@@ -146,6 +146,31 @@ function parseCommonArgs() {
         echo "cinder-volume enabled: cinder control plane + LVM/iSCSI data plane (volumes playbook, volume type/QoS)"
     fi
 
+    # Resolve the 'manila-share' pseudo service. 'manila' refers to the
+    # control-plane chart only; 'manila-share' covers the full enablement
+    # (secrets, service image build, pre/post deploy incl. share type). It can
+    # be enabled with '-i manila-share' or the legacy
+    # HYPERCONVERGED_MANILA_SHARE=true environment variable, and disabled with
+    # '-e manila-share' (which wins over both). Per the pseudo service
+    # convention, '-i manila-share' implies the manila control plane; the
+    # legacy environment variable keeps its historical behavior and does NOT
+    # imply the chart (deployManila self-gates on 'manila: true' in
+    # openstack-components.yaml and exits cleanly when it is absent).
+    MANILA_SHARE_ENABLED="${HYPERCONVERGED_MANILA_SHARE:-false}"
+    if isIncluded manila-share; then
+        MANILA_SHARE_ENABLED=true
+        if ! isIncluded manila && ! isExcluded manila; then
+            INCLUDE_LIST+=("manila")
+        fi
+    fi
+    if isExcluded manila-share; then
+        MANILA_SHARE_ENABLED=false
+    fi
+    export MANILA_SHARE_ENABLED
+    if [ "${MANILA_SHARE_ENABLED}" = "true" ]; then
+        echo "manila-share enabled: manila control plane + share enablement (secrets, service image build, share type)"
+    fi
+
     export RUN_EXTRAS
     export INCLUDE_LIST
     export EXCLUDE_LIST
@@ -239,13 +264,27 @@ function writeOpenstackComponentsConfig() {
 
     echo -e "${os_config}" | tee "${output_path}"
 
+    # Only flip keys that exist in the base components file. The include and
+    # exclude lists may also carry lab pseudo services (cinder-volume,
+    # manila-share, k9s) that are resolved by the lab scripts themselves;
+    # writing them here would pollute the components file, which is consumed
+    # by callers beyond the hyperconverged lab and must only contain real
+    # service names.
     for option in "${INCLUDE_LIST[@]}"; do
-        echo "include option: ${option}"
-        yq -i ".components.$option = true" "${output_path}"
+        if [ "$(yq ".components | has(\"${option}\")" "${output_path}")" = "true" ]; then
+            echo "include option: ${option}"
+            yq -i ".components.${option} = true" "${output_path}"
+        else
+            echo "include option: ${option} (lab pseudo service, not written to components file)"
+        fi
     done
     for option in "${EXCLUDE_LIST[@]}"; do
-        echo "exclude option: ${option}"
-        yq -i ".components.$option = false" "${output_path}"
+        if [ "$(yq ".components | has(\"${option}\")" "${output_path}")" = "true" ]; then
+            echo "exclude option: ${option}"
+            yq -i ".components.${option} = false" "${output_path}"
+        else
+            echo "exclude option: ${option} (lab pseudo service, not written to components file)"
+        fi
     done
     cat ${output_path}
 }


### PR DESCRIPTION

commit 6cb670fa9d6d922a1a4b16baa63d7e2036f33f36
Author: dwith <dan.with@rackspace.com>
Date:   Mon Aug 17 13:30:27 2026 -0500

    fix: export resolved pseudo service flags to the jump host session

    The cinder-volume pseudo service refactor changed the variant selection
    tests inside writeServiceHelmOverrides from HYPERCONVERGED_CINDER_VOLUME
    to the resolved CINDER_VOLUME_ENABLED - but that function is shipped to
    the jump host via declare -f and executes remotely, where only
    HYPERCONVERGED_CINDER_VOLUME was exported. The tests silently fell back
    to false and the cinder, nova and barbican helm overrides were written
    as their non-volume variants: no conf.backends for cinder (the volumes
    playbook then failed at the backend set_fact and never created the
    systemd units) and no enable_iscsi for nova. Export the resolved
    CINDER_VOLUME_ENABLED and MANILA_SHARE_ENABLED into the remote session.

    Also add set -e to the cinderVolumeSetup remote script: the original run
    swallowed the playbook failure and the lab reported success without a
    cinder data plane.

commit 14339b2765784b74923d8a6f992657284de07b8e
Author: dwith <dan.with@rackspace.com>
Date:   Mon Aug 17 12:04:24 2026 -0500

    feat: manila-share pseudo service; scope manila fqdn override to the generic driver

    Add 'manila-share' following the data-plane pseudo service convention:
    '-i manila-share' runs the full manila enablement (secrets, service
    image build, pre/post deploy incl. share type) and implies the manila
    control-plane chart by injecting 'manila' into the include list. The
    legacy HYPERCONVERGED_MANILA_SHARE=true environment variable keeps its
    historical semantics (enablement only, no chart implication;
    deployManila still self-gates on 'manila: true' in the components
    file). '-e manila-share' disables the enablement regardless of source.
    Resolution is exported as MANILA_SHARE_ENABLED and announced at parse
    time, mirroring cinder-volume, and both pseudo services are documented
    in the -i/-e help text.

    Pseudo service names (cinder-volume, manila-share, k9s) are lab-only
    concepts: remove them from openstack-components.yaml and teach
    writeOpenstackComponentsConfig to only flip keys that already exist in
    the base components file. The components file is consumed by callers
    beyond the hyperconverged lab and must contain real service names only.

    Relocate the manila-share fqdn override (348672d2) from the base helm
    overrides to the generic-driver enablement template, and pin the base
    back to the upstream default (pod.use_fqdn.share: true). The override
    exists because the share pod runs with hostNetwork and the chart's init
    container derives service_network_host from 'hostname --fqdn', which
    fails to resolve in the pod's DNS context and injects an empty value
    that manila >= 22.x rejects at startup (oslo HostAddress: 'is not a
    valid host address'). Both the injection target ([generic]) and the
    reason it is safe to disable (connect_share_server_to_tenant_network is
    enabled, so service_network_host is unused) are generic-driver
    specifics, so the override belongs in the layer that declares the
    generic driver, not in the driver-agnostic base config.

commit 348672d2662705f8bace004790dde0b0b064b983
Author: dwith <dan.with@rackspace.com>
Date:   Mon Aug 17 10:31:44 2026 -0500

    fix: disable manila-share fqdn config injection

    The manila chart's share init container derives service_network_host
    from 'hostname --fqdn' when the value is unset and pod.use_fqdn.share
    is true (the default). The share pod runs with hostNetwork and the
    lookup fails to resolve in the pod's DNS context, injecting an empty
    value; manila >= 22.x oslo HostAddress validation then rejects it at
    startup ('is not a valid host address') and manila-share crashloops.


    The generic driver runs with connect_share_server_to_tenant_network
    enabled, so service_network_host is unused here - set
    pod.use_fqdn.share=false, which removes both the injected config file
    and its --config-file argument (same chart-side condition guards both).

commit 85be5958a3e68e655ef9ecd24a004a3e3febd7e0
Author: dwith <dan.with@rackspace.com>
Date:   Mon Aug 17 10:31:44 2026 -0500

    docs: state the data-plane pseudo service convention explicitly

    Document the rule in the -i help text (component names install their
    control-plane chart; data-plane pseudo services imply their control
    plane, so 'cinder-volume' alone yields the full cinder stack) and echo
    the resolved cinder-volume semantics at parse time so run logs teach
    the convention.

commit ee6c9329e850a2328ae0e3d5d87b480e78c15bc3
Author: dwith <dan.with@rackspace.com>
Date:   Fri Aug 14 21:50:20 2026 -0500

    fix: stop DIB image builds from root-owning the ssh user's XDG dirs

    The trove and manila image build tasks run diskimage-builder as root
    (required for debootstrap/mount/losetup) but forced HOME to the ssh
    user's home. DIB and virtualenv then created ~/.cache/dib,
    ~/.cache/image-create and ~/.local/share/virtualenv as root inside the
    ssh user's home. A root-owned ~/.local prevents XDG-compliant tools
    from creating their state directories - notably k9s fails to start with
    'could not create any of the following paths: ~/.local/state/k9s'.

    - drop the HOME override from the two become-root build tasks; the DIB
      caches move to /root/.cache, which persists equally on the jump host.
      The unprivileged openstack CLI tasks keep their HOME override (they
      need the ssh user's clouds.yaml).
    - pre-create ~/.local/state, ~/.local/share and ~/.cache as the ssh
      user during jump host setup, so any future root-context task with a
      misdirected HOME can only create subpaths, never take ownership of
      the XDG roots.
      
commit 15e1723478d2c6317713ae032dbda466cf435592
Author: dwith <dan.with@rackspace.com>
Date:   Fri Aug 14 20:13:39 2026 -0500

    feat: cinder-volume pseudo service for the hyperconverged lab
    fix: all manila service pods to 2026.1-latest

    Split cinder into two independently selectable pieces:
    - 'cinder' now refers only to the control-plane chart, installed by the
      openstack batch like any other component.
    - 'cinder-volume' is a new pseudo service covering the data-plane
      enablement: lab volume/VG preparation, the cinder volumes playbook on
      labeled storage nodes, and volume type/QoS creation.

    cinder-volume can be enabled with '-i cinder-volume' or the legacy
    HYPERCONVERGED_CINDER_VOLUME=true environment variable (unchanged
    behavior, including its default include/exclude list handling), and
    disabled with '-e cinder-volume', which overrides both. The resolved
    value is exported as CINDER_VOLUME_ENABLED and now drives every gate
    that previously read the environment variable directly (lab volume
    creation, kubespray inventory shape, barbican/cinder/nova override
    selection, and cinderVolumeSetup).

    The pseudo service is documented in openstack-components.yaml and the
    help text; setup-openstack.sh uses a fixed component-to-installer map,
    so the extra yaml key is inert for the chart batch.