### PR TITLE
feat(barbican): OSPC-2302: adding inert PKCS#11 p11_crypto_plugin config

### DIFF
--- a/base-helm-configs/barbican/barbican-helm-overrides.yaml
+++ b/base-helm-configs/barbican/barbican-helm-overrides.yaml
@@ -86,6 +86,30 @@ conf:
       kombu_reconnect_delay: 0.5
     oslo_middleware:
       enable_proxy_headers_parsing: true
+
+    # PKCS#11 Crypto Plugin
+    # INERT until "p11_crypto" is added to crypto.enabled_crypto_plugins.
+    # login (HSM PIN) injected at deploy time by install-barbican.sh.
+    p11_crypto_plugin:
+      library_path: ""
+      token_serial_number: ""
+      token_labels: []
+      login: ""
+      mkek_label: "barbican_mkek"
+      mkek_length: 32
+      hmac_label: "barbican_hmac"
+      hmac_mechanism: CKM_SHA256_HMAC
+      encryption_mechanism: CKM_AES_CBC
+      hmac_key_type: CKK_AES
+      hmac_keygen_mechanism: CKM_AES_KEY_GEN
+      key_wrap_mechanism: CKM_AES_CBC_PAD
+      slot_id: 1
+      plugin_name: "PKCS11 HSM"
+
+    crypto:
+      enabled_crypto_plugins:
+        - simple_crypto
+
   barbican_api_uwsgi:
     uwsgi:
       processes: 2


### PR DESCRIPTION
Adding the `p11_crypto_plugin` section to `barbican-helm-overrides.yaml`.

Config is inert — `p11_crypto` is not yet added to `enabled_crypto_plugins`, so `simple_crypto` remains the active backend. No behavioural change.

- Added `p11_crypto_plugin` with default `mkek_label`/`hmac_label` mechanisms
- Uses `hmac_mechanism` (replaces deprecated `hmac_keywrap_mechanism`)
- login (HSM PIN) would be injected at deploy time via `install-barbican.sh`
- `library_path`/`token_labels`/`slot_id` would be set per-cluster in flex override

Activation requires per-cluster flex override to add `p11_crypto` to `crypto.enabled_crypto_plugins`. Existing `simple_crypto` secrets remain fully readable in dual-plugin mode.

Refs: [OSPC-1979](https://rackspace.atlassian.net/browse/OSPC-1979)