### PR TITLE
feat(barbican): OSPC-2304: added barbican-hsm-credentials K8s Secret

### DIFF
--- a/bin/create-secrets.sh
+++ b/bin/create-secrets.sh
@@ -93,6 +93,10 @@ octavia_certificates_password=$(generate_password 32)
 barbican_rabbitmq_password=$(generate_password 64)
 barbican_db_password=$(generate_password 32)
 barbican_admin_password=$(generate_password 32)
+# PKCS#11 HSM PIN
+# Hyperconverged lab: auto-generated when BARBICAN_HSM_PIN is not set.
+# Production/Staging: export BARBICAN_HSM_PIN="<pin-from-hsm-admin>" before running.
+barbican_hsm_pin="${BARBICAN_HSM_PIN:-$(generate_password 32)}"
 magnum_rabbitmq_password=$(generate_password 64)
 magnum_db_password=$(generate_password 32)
 magnum_admin_password=$(generate_password 32)
@@ -619,6 +623,15 @@ metadata:
 type: Opaque
 data:
   password: $(echo -n $barbican_admin_password | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: barbican-hsm-credentials
+  namespace: openstack
+type: Opaque
+data:
+  pin: $(echo -n $barbican_hsm_pin | base64 -w0)
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Added PKCS#11 HSM PIN provisioning to `create-secrets.sh` following the existing secret generation pattern used by all other OpenStack services.

- Added `barbican_hsm_pin` variable using `generate_password 32` as fallback
- Added `barbican-hsm-credentials` K8s Secret with base64-encoded PIN
- Production/Staging: operator would set `BARBICAN_HSM_PIN` env var before running `create-secrets.sh` to use HSM Admin provided PIN
- Hyperconverged lab: PIN auto-generated when `BARBICAN_HSM_PIN` is not set

PIN is the PKCS#11 token User PIN — used by Barbican at startup to authenticate to the HSM token via `C_Login()` before accessing `MKEK` and `HMAC` keys. Injected into barbican pod at deploy time by `install-barbican.sh`. Never stored in git.

Refs: [OSPC-1979](https://rackspace.atlassian.net/browse/OSPC-1979)