### PR TITLE
feat(barbican): OSPC-2303: injecting PKCS#11 HSM PIN at deploy time

### DIFF
--- a/bin/install-barbican.sh
+++ b/bin/install-barbican.sh
@@ -138,6 +138,18 @@ set_args=(
     --set "conf.barbican.keystone_authtoken.memcache_secret_key=$(kubectl --namespace openstack get secret os-memcached -o jsonpath='{.data.memcache_secret_key}' | base64 -d)"
 )
 
+# PKCS#11 HSM PIN Injection
+# Reads PIN from barbican-hsm-credentials K8s Secret (created by create-secrets.sh).
+# No-op when secret doesn't exist or PIN is empty.
+hsm_pin="$(kubectl --namespace openstack get secret barbican-hsm-credentials \
+    -o jsonpath='{.data.pin}' 2>/dev/null | base64 -d)" || true
+if [[ -n "${hsm_pin}" ]]; then
+    echo "HSM credentials found - injecting p11_crypto_plugin.login"
+    set_args+=(
+        --set "conf.barbican.p11_crypto_plugin.login=${hsm_pin}"
+    )
+fi
+unset hsm_pin
 
 helm_command=(
     helm upgrade --install "$SERVICE_NAME_DEFAULT" "$HELM_CHART_PATH"


### PR DESCRIPTION
Add HSM PIN injection to `install-barbican.sh` to pass the PKCS#11 token User PIN into the barbican helm release at deploy time via `--set` flag.

PIN is read from `barbican-hsm-credentials` K8s Secret (created by `create-secrets.sh`) and injected into `p11_crypto_plugin.login`. It is never stored in git or in the helm values files.

- No-op when `barbican-hsm-credentials` secret does not exist
- No-op when PIN is empty (`p11_crypto` not yet activated)
- Unsets `hsm_pin` variable immediately after use (no env var leakage)
- No other changes to `install-barbican.sh`

Refs: [OSPC-1979](https://rackspace.atlassian.net/browse/OSPC-1979)