### PR TITLE
feat: add TC flower audit script and cleanup playbook for hw-offload …

### DIFF
--- a/ansible/playbooks/clear-stale-tc-flower.yaml
+++ b/ansible/playbooks/clear-stale-tc-flower.yaml
@@ -1,0 +1,285 @@
+---
+# clear-stale-tc-flower.yaml
+#
+# Removes stranded TC flower datapath filters left on OVS hosts after
+# kube-ovn HW_OFFLOAD is flipped from true to false. With offload on, OVS runs
+# its datapath as TC flower filters in software on the host NICs; after the
+# flip OVS stops managing those filters but does not remove them, and they
+# keep intercepting traffic ahead of OVS with frozen actions (silent,
+# selective black-holing of tenant traffic). This playbook is the Ansible
+# form of MOP section 18A.4.
+#
+# Safety properties:
+#   - DRY RUN BY DEFAULT: reports what it would delete; nothing is changed
+#     until run with -e tc_cleanup_dry_run=false
+#   - Per-host gate: a host is skipped (SKIPPED-NOT-FLIPPED) unless OVS on
+#     that node reports ZERO live TC datapath flows, i.e. the HW_OFFLOAD
+#     flip has completed there. Before the flip the TC filters ARE the live
+#     datapath and must not be touched.
+#   - Only chain-0 "flower" filters are deleted (the live interception
+#     points). kube-ovn QoS filters (matchall/police) are never matched.
+#     Entries for tap*/veth (*_h) devices in the output are expected.
+#   - Hosts without an ovs-ovn pod are skipped (NO-OVS-POD).
+#   - A final coverage check lists any node running an ovs-ovn pod that this
+#     run did not process (wrong --limit, unreachable, or failed) so nothing
+#     is silently missed.
+#
+# Requirements:
+#   - kubernetes.core collection and the python kubernetes client on the
+#     controller. Both are provided by the standard Genestack bootstrap
+#     (ansible-collection-requirements.yml / requirements.txt); run from the
+#     deployment/overseer node with the genestack venv active.
+#   - Inventory hostnames must equal Kubernetes node names; if a host
+#     differs, set k8s_node_name for it in inventory.
+#   - Hosts unreachable by Ansible are NOT cleaned by this playbook; handle
+#     them with the MOP's kubectl-exec fallback (Appendix A) and re-run the
+#     coverage check.
+#   - The per-host cleanup task uses ansible.builtin.shell deliberately:
+#     there is no Ansible module that manages TC flower filters or shared
+#     ingress blocks, and the discovery/delete/verify must be atomic per
+#     host.
+#
+# Usage:
+#   Report only (default, non-destructive):
+#     ansible-playbook -i /etc/genestack/inventory/inventory.yaml \
+#       /opt/genestack/ansible/playbooks/clear-stale-tc-flower.yaml
+#
+#   Execute the cleanup:
+#     ansible-playbook -i /etc/genestack/inventory/inventory.yaml \
+#       /opt/genestack/ansible/playbooks/clear-stale-tc-flower.yaml \
+#       -e tc_cleanup_dry_run=false
+#
+#   Optional targeting / pacing:
+#     --limit <group>            restrict the pass (run a final unlimited
+#                                pass so the coverage check sees every node)
+#     -e tc_serial=20            hosts per batch (default 10)
+#     -e tc_strict=true          fail the run if any node is skipped,
+#                                failed or uncovered
+#
+# Variables:
+#   target_hosts        host pattern for the cleanup play (default: all)
+#   tc_cleanup_dry_run  default true
+#   tc_serial           default 10
+#   tc_strict           default false
+#   kubeconfig          path to kubeconfig (default: environment/standard)
+#   k8s_node_name       per-host override when inventory name != node name
+#   tc_cleanup_log      default /home/ubuntu/maintenances/flex-2026.2/tc-flush-ansible.log
+
+- name: Gather ovs-ovn pod map from the Kubernetes API
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Find ovs-ovn pods by label
+      kubernetes.core.k8s_info:
+        kind: Pod
+        namespace: kube-system
+        label_selectors:
+          - app=ovs-ovn
+        kubeconfig: "{{ kubeconfig | default(omit) }}"
+      register: tc_pods_by_label
+
+    - name: Fall back to name-prefix match when the label finds nothing
+      kubernetes.core.k8s_info:
+        kind: Pod
+        namespace: kube-system
+        kubeconfig: "{{ kubeconfig | default(omit) }}"
+      register: tc_pods_all
+      when: tc_pods_by_label.resources | length == 0
+
+    - name: Select the ovs-ovn pod list
+      ansible.builtin.set_fact:
+        tc_ovs_pods: >-
+          {{ tc_pods_by_label.resources
+             if tc_pods_by_label.resources | length > 0
+             else tc_pods_all.resources
+                  | selectattr('metadata.name', 'match', '^ovs-ovn-')
+                  | list }}
+
+    - name: Build the map of node name to ovs-ovn pod name
+      ansible.builtin.set_fact:
+        ovs_pod_by_node: >-
+          {{ dict(tc_ovs_pods | map(attribute='spec.nodeName')
+                  | zip(tc_ovs_pods | map(attribute='metadata.name'))) }}
+
+    - name: Report OVS node count
+      ansible.builtin.debug:
+        msg: >-
+          ovs-ovn pods found on {{ ovs_pod_by_node | length }} nodes;
+          dry_run={{ tc_cleanup_dry_run | default(true) }}
+
+
+- name: Clear stranded chain-0 TC flower filters per node
+  hosts: "{{ target_hosts | default('all') }}"
+  gather_facts: false
+  become: true
+  serial: "{{ tc_serial | default(10) }}"
+  vars:
+    node_name: "{{ k8s_node_name | default(inventory_hostname) }}"
+    ovs_pod: "{{ hostvars['localhost'].ovs_pod_by_node[node_name] | default('') }}"
+    dry_run: "{{ tc_cleanup_dry_run | default(true) | bool }}"
+  tasks:
+    - name: Skip hosts that do not run an ovs-ovn pod
+      when: ovs_pod | length == 0
+      block:
+        - name: Mark NO-OVS-POD
+          ansible.builtin.set_fact:
+            tc_status: NO-OVS-POD
+            tc_result: ""
+        - name: End host (no ovs-ovn pod)
+          ansible.builtin.meta: end_host
+
+    - name: Gate - list live OVS TC datapath flows (via the node's ovs-ovn pod)
+      kubernetes.core.k8s_exec:
+        namespace: kube-system
+        pod: "{{ ovs_pod }}"
+        container: openvswitch
+        command: ovs-appctl dpctl/dump-flows type=tc
+        kubeconfig: "{{ kubeconfig | default(omit) }}"
+      delegate_to: localhost
+      become: false
+      register: tc_flows
+      changed_when: false
+      failed_when: false
+
+    - name: Compute live TC flow count
+      ansible.builtin.set_fact:
+        tc_live_flows: >-
+          {{ (tc_flows.stdout | default('') | trim).split('\n')
+             | reject('equalto', '') | list | length }}
+
+    - name: Skip hosts where the gate itself failed
+      when: (tc_flows.rc | default(tc_flows.return_code | default(1))) | int != 0
+      block:
+        - name: Mark GATE-ERROR
+          ansible.builtin.set_fact:
+            tc_status: GATE-ERROR
+            tc_result: "k8s_exec failed: {{ tc_flows.stderr | default('') | trim }}"
+        - name: Report gate error
+          ansible.builtin.debug:
+            msg: "{{ node_name }} [GATE-ERROR]: {{ tc_result }}"
+        - name: End host (gate error)
+          ansible.builtin.meta: end_host
+
+    - name: Skip hosts that have NOT flipped (OVS still using the TC datapath)
+      when: tc_live_flows | int != 0
+      block:
+        - name: Mark SKIPPED-NOT-FLIPPED
+          ansible.builtin.set_fact:
+            tc_status: SKIPPED-NOT-FLIPPED
+            tc_result: "OVS reports {{ tc_live_flows }} live tc flows; do not clean before the HW_OFFLOAD flip"
+        - name: Report skip
+          ansible.builtin.debug:
+            msg: "{{ node_name }} [SKIPPED-NOT-FLIPPED]: {{ tc_result }}"
+        - name: End host (not flipped)
+          ansible.builtin.meta: end_host
+
+    # ansible.builtin.shell is intentional here: no module manages TC flower
+    # filters / shared ingress blocks, and discovery + chain-0 deletion +
+    # re-count must happen atomically on the host.
+    - name: "{{ dry_run | ternary('Report (dry run)', 'Clear') }} chain-0 flower filters on shared blocks and per-device qdiscs"
+      ansible.builtin.shell: |
+        set -o pipefail
+        out=""
+        for b in $(tc qdisc show | grep -oP "ingress_block \K\d+" | sort -un); do
+          pre=$(tc filter show block $b chain 0 | grep -c "^filter.*flower")
+          if [ "$DRY" != "1" ] && [ "$pre" -gt 0 ]; then tc filter del block $b 2>/dev/null; fi
+          post=$(tc filter show block $b chain 0 | grep -c "^filter.*flower")
+          out="$out block$b:$pre->$post"
+        done
+        for d in $(tc qdisc show | grep -E "^qdisc (ingress|clsact)" | grep -v ingress_block | awk "{print \$5}"); do
+          pre=$(tc filter show dev $d ingress chain 0 2>/dev/null | grep -c "^filter.*flower")
+          if [ "$pre" -gt 0 ]; then
+            if [ "$DRY" != "1" ]; then tc filter del dev $d ingress 2>/dev/null; fi
+            post=$(tc filter show dev $d ingress chain 0 | grep -c "^filter.*flower")
+            out="$out $d:$pre->$post"
+          fi
+        done
+        echo "${out:- nothing-to-do}"
+      args:
+        executable: /bin/bash
+      environment:
+        DRY: "{{ dry_run | ternary('1', '0') }}"
+      register: tc_clean
+      changed_when: (not dry_run) and (tc_clean.stdout is search(':[1-9][0-9]*->'))
+      failed_when: (not dry_run) and (tc_clean.stdout is search('->[1-9]'))
+
+    - name: Record result
+      ansible.builtin.set_fact:
+        tc_status: "{{ dry_run | ternary('DRY-RUN', 'CLEANED') }}"
+        tc_result: "{{ tc_clean.stdout | trim }}"
+
+    - name: Per-host result
+      ansible.builtin.debug:
+        msg: "{{ node_name }} [{{ tc_status }}]: {{ tc_result }}"
+
+
+- name: Summary and coverage check
+  hosts: localhost
+  gather_facts: false
+  vars:
+    log_path: "{{ tc_cleanup_log | default('/home/ubuntu/maintenances/flex-2026.2/tc-flush-ansible.log') }}"
+  tasks:
+    - name: Collect per-host results
+      ansible.builtin.set_fact:
+        tc_lines: >-
+          {{ tc_lines | default([])
+             + [(hostvars[item].k8s_node_name | default(item))
+                ~ ' [' ~ hostvars[item].tc_status ~ ']: '
+                ~ (hostvars[item].tc_result | default(''))] }}
+        tc_covered: >-
+          {{ tc_covered | default([])
+             + [hostvars[item].k8s_node_name | default(item)] }}
+      loop: "{{ groups['all'] }}"
+      when: hostvars[item].tc_status is defined
+      loop_control:
+        label: "{{ item }}"
+
+    - name: Compute uncovered OVS nodes (in cluster, not processed by this run)
+      ansible.builtin.set_fact:
+        tc_uncovered: >-
+          {{ ovs_pod_by_node | default({}) | list
+             | difference(tc_covered | default([])) }}
+        tc_skipped: >-
+          {{ tc_lines | default([])
+             | select('search', 'SKIPPED-NOT-FLIPPED|GATE-ERROR') | list }}
+
+    - name: Ensure log directory exists
+      ansible.builtin.file:
+        path: "{{ log_path | dirname }}"
+        state: directory
+        mode: "0755"
+
+    - name: Write summary log
+      ansible.builtin.copy:
+        dest: "{{ log_path }}"
+        mode: "0644"
+        content: |
+          # clear-stale-tc-flower run {{ now(utc=true, fmt='%Y-%m-%dT%H:%M:%SZ') }}
+          # dry_run={{ tc_cleanup_dry_run | default(true) }}
+          {% for line in tc_lines | default([]) %}
+          {{ line }}
+          {% endfor %}
+          # skipped / gate errors: {{ tc_skipped | length }}
+          # uncovered OVS nodes ({{ tc_uncovered | length }}):
+          {% for n in tc_uncovered %}
+          #   {{ n }}
+          {% endfor %}
+
+    - name: Summary
+      ansible.builtin.debug:
+        msg:
+          - "processed: {{ tc_lines | default([]) | length }}"
+          - "skipped / gate errors: {{ tc_skipped | length }}"
+          - "uncovered OVS nodes: {{ tc_uncovered }}"
+          - "log: {{ log_path }}"
+
+    - name: Strict gate (only with -e tc_strict=true)
+      ansible.builtin.assert:
+        that:
+          - tc_uncovered | length == 0
+          - tc_skipped | length == 0
+        fail_msg: >-
+          Fleet is NOT fully cleaned: {{ tc_uncovered | length }} uncovered
+          node(s), {{ tc_skipped | length }} skipped or gate-error node(s).
+          Resolve and re-run (the playbook is idempotent).
+      when: tc_strict | default(false) | bool

--- a/scripts/tc-offload-audit.sh
+++ b/scripts/tc-offload-audit.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# -----------------------------------------------
+#                             _             _
+#                            | |           | |
+#   __ _  ___ _ __   ___  ___| |_ __ _  ___| | __
+#  / _` |/ _ \ '_ \ / _ \/ __| __/ _` |/ __| |/ /
+# | (_| |  __/ | | |  __/\__ \ || (_| | (__|   <
+#  \__, |\___|_| |_|\___||___/\__\__,_|\___|_|\_\
+#   __/ |           ops scripts
+#  |___/
+# -----------------------------------------------
+# tc-offload-audit.sh
+#
+# READ-ONLY audit of every node that runs an ovs-ovn pod.
+#
+# For each node it collects, via "kubectl exec" into the ovs-ovn pod (which
+# shares the host network namespace):
+#
+#   - the kube-ovn HW_OFFLOAD env value on the pod
+#   - the OVS other_config:hw-offload setting
+#   - the count of live OVS TC datapath flows (dpctl/dump-flows type=tc)
+#   - the number of ingress/clsact qdiscs on host devices
+#   - TC "flower" filter counts per shared ingress block and per device,
+#     reported as chain0/total (chain 0 holds the live interception points;
+#     the total includes unreachable residual chains)
+#   - host uptime and Genestack role labels
+#
+# and assigns one verdict per node:
+#
+#   SOURCE-STATE   hw-offload is true and OVS has live TC flows. TC flower
+#                  is the live datapath. Expected before the maintenance.
+#   ORPHANED-LIVE  hw-offload is false, zero live TC flows, but chain-0
+#                  flower filters remain. Stranded filters still intercept
+#                  traffic. NEEDS CLEANUP.
+#   RESIDUAL-ONLY  hw-offload is false, zero live TC flows, chain 0 is
+#                  clear. Only inert leftovers remain. Acceptable.
+#   CLEAN          hw-offload is false, zero live TC flows, and no ingress
+#                  qdiscs at all. The post-reboot state.
+#   UNREACHABLE    kubectl exec failed for the node's pod.
+#   REVIEW         any other combination, for example hw-offload true with
+#                  zero TC flows. Investigate.
+#
+# The script makes NO changes anywhere. Safe to run at any time.
+#
+# Usage:
+#   bash /opt/genestack/scripts/tc-offload-audit.sh
+#
+# Environment overrides:
+#   P    parallel kubectl execs (default 8)
+#   OUT  output TSV path (default ~/maint/tc-offload-audit-<date>.tsv)
+#
+# Exit status:
+#   0  no node needs attention
+#   2  at least one node is UNREACHABLE, ORPHANED-LIVE, or REVIEW
+#
+# Intended use: pre/post audit and fleet gate for kube-ovn HW_OFFLOAD=false
+# maintenances. Run before the change to record the source state, and after
+# the per-node TC cleanup to verify no node remains ORPHANED-LIVE before
+# any OpenStack service upgrade proceeds.
+#
+# shellcheck disable=SC2016,SC2086
+set -u
+set -o pipefail
+
+P="${P:-8}"
+OUT="${OUT:-$HOME/maint/tc-offload-audit-$(date +%F-%H%M).tsv}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+LABELS_FILE="$TMP/labels.tsv"    # <node> <tab> <role labels>
+PODS_FILE="$TMP/pods.tsv"        # <pod> <tab> <node> <tab> <HW_OFFLOAD env>
+RESULTS_FILE="$TMP/results.tsv"  # one audit line per node, unsorted
+
+# ---------------------------------------------------------------------------
+# The collector below runs INSIDE each ovs-ovn pod (openvswitch container,
+# host network namespace, tc and ovs tools present). It is read-only.
+#
+# It prints a single line of six pipe-separated fields:
+#
+#   hw_offload | live_tc_flows | ingress_qdisc_count | blocks | devices | uptime
+#
+# where "blocks" is a space-separated list like "block8=617/653" and
+# "devices" is a space-separated list like "genev_sys_6081=152/279",
+# each value being <chain-0 flower count>/<total flower count>.
+# ---------------------------------------------------------------------------
+export COLLECTOR='
+hw=$(ovs-vsctl get Open_vSwitch . other_config:hw-offload 2>/dev/null | tr -d "\"")
+if [ -z "$hw" ]; then
+  hw=unset
+fi
+
+live_flows=$(ovs-appctl dpctl/dump-flows type=tc 2>/dev/null | wc -l | tr -d " ")
+
+qdisc_count=$(tc qdisc show | grep -cE "^qdisc (ingress|clsact)")
+
+# Flower filter counts on each shared ingress block (bond slaves).
+blocks=""
+for block_id in $(tc qdisc show | grep -oP "ingress_block \K\d+" | sort -un); do
+  chain0=$(tc filter show block $block_id chain 0 2>/dev/null | grep -c "^filter.*flower")
+  total=$(tc filter show block $block_id 2>/dev/null | grep -c "^filter.*flower")
+  blocks="${blocks:+$blocks }block$block_id=$chain0/$total"
+done
+
+# Flower filter counts on each per-device ingress qdisc (geneve, taps,
+# pod veths). Devices with no flower filters are omitted.
+devices=""
+for dev in $(tc qdisc show | grep -E "^qdisc (ingress|clsact)" | grep -v ingress_block | awk "{print \$5}"); do
+  total=$(tc filter show dev $dev ingress 2>/dev/null | grep -c "^filter.*flower")
+  if [ "$total" -gt 0 ]; then
+    chain0=$(tc filter show dev $dev ingress chain 0 2>/dev/null | grep -c "^filter.*flower")
+    devices="${devices:+$devices }$dev=$chain0/$total"
+  fi
+done
+
+uptime_days=$(awk "{printf \"%dd\", \$1/86400}" /proc/uptime)
+
+echo "$hw|$live_flows|$qdisc_count|${blocks:-none}|${devices:-none}|$uptime_days"'
+
+# ---------------------------------------------------------------------------
+# gather_node_labels
+#   Writes LABELS_FILE: one line per node with its Genestack role labels
+#   (compute, storage, control, network) or NOLABEL. jsonpath is used so
+#   that empty label values do not shift columns.
+# ---------------------------------------------------------------------------
+gather_node_labels() {
+  local jsonpath
+  jsonpath='{range .items[*]}{.metadata.name}{"\t"}'
+  jsonpath+='{.metadata.labels.openstack-compute-node}{"\t"}'
+  jsonpath+='{.metadata.labels.openstack-storage-node}{"\t"}'
+  jsonpath+='{.metadata.labels.openstack-control-plane}{"\t"}'
+  jsonpath+='{.metadata.labels.openstack-network-node}{"\n"}{end}'
+
+  if ! kubectl get nodes -o jsonpath="$jsonpath" > "$TMP/nodes.raw"; then
+    echo "kubectl get nodes failed; cannot gather role labels" >&2
+    exit 1
+  fi
+
+  awk -F'\t' '
+        {
+          labels = ""
+          if ($2 == "enabled") labels = labels "compute,"
+          if ($3 == "enabled") labels = labels "storage,"
+          if ($4 == "enabled") labels = labels "control,"
+          if ($5 == "enabled") labels = labels "network,"
+          sub(/,$/, "", labels)
+          if (labels == "") labels = "NOLABEL"
+          print $1 "\t" labels
+        }' "$TMP/nodes.raw" > "$LABELS_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# gather_ovs_pods
+#   Writes PODS_FILE: one line per ovs-ovn pod with its node and its
+#   HW_OFFLOAD env value. Pods are selected by name prefix because label
+#   sets vary between kube-ovn chart versions.
+# ---------------------------------------------------------------------------
+gather_ovs_pods() {
+  local jsonpath
+  jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.nodeName}{"\t"}'
+  jsonpath+='{.spec.containers[0].env[?(@.name=="HW_OFFLOAD")].value}{"\n"}{end}'
+
+  if ! kubectl -n kube-system get pods -o jsonpath="$jsonpath" > "$TMP/pods.raw"; then
+    echo "kubectl get pods failed; cannot enumerate ovs-ovn pods" >&2
+    exit 1
+  fi
+
+  awk -F'\t' '$1 ~ /^ovs-ovn-/' "$TMP/pods.raw" > "$PODS_FILE"
+
+  if [ ! -s "$PODS_FILE" ]; then
+    echo "no ovs-ovn pods found in kube-system" >&2
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# audit_one_node <pod> <node> [env]
+#   Runs the collector inside the node's ovs-ovn pod, assigns a verdict,
+#   and prints one tab-separated result line. Exported for xargs workers.
+# ---------------------------------------------------------------------------
+audit_one_node() {
+  local pod="$1"
+  local node="$2"
+  local env_value="${3:-unset}"
+
+  local raw
+  raw=$(echo "$COLLECTOR" \
+        | timeout 120 kubectl -n kube-system exec -i "$pod" -c openvswitch -- bash -s 2>/dev/null)
+  if [ -z "$raw" ]; then
+    raw="EXEC-FAILED|?|?|?|?|?"
+  fi
+
+  local hw live_flows qdisc_count blocks devices uptime_days
+  IFS='|' read -r hw live_flows qdisc_count blocks devices uptime_days <<< "$raw"
+
+  # Highest chain-0 flower count seen on any block or device. A value
+  # above zero means live interception points remain.
+  local chain0_max=0
+  local entry value
+  for entry in $blocks $devices; do
+    value="${entry#*=}"      # strip "name=" prefix
+    value="${value%%/*}"     # keep the chain-0 half of chain0/total
+    if [[ "$value" =~ ^[0-9]+$ ]] && [ "$value" -gt "$chain0_max" ]; then
+      chain0_max="$value"
+    fi
+  done
+
+  local verdict
+  if [ "$hw" = "EXEC-FAILED" ]; then
+    verdict="UNREACHABLE"
+  elif [ "$hw" = "true" ] && [ "$live_flows" != "0" ]; then
+    verdict="SOURCE-STATE"
+  elif [ "$hw" = "false" ] && [ "$live_flows" = "0" ] && [ "$chain0_max" -eq 0 ] && [ "$qdisc_count" = "0" ]; then
+    verdict="CLEAN"
+  elif [ "$hw" = "false" ] && [ "$live_flows" = "0" ] && [ "$chain0_max" -gt 0 ]; then
+    verdict="ORPHANED-LIVE"
+  elif [ "$hw" = "false" ] && [ "$live_flows" = "0" ]; then
+    verdict="RESIDUAL-ONLY"
+  else
+    verdict="REVIEW"
+  fi
+
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$node" "$pod" "$env_value" "$hw" "$live_flows" "$qdisc_count" \
+    "$blocks" "$devices" "$uptime_days" "$verdict"
+}
+export -f audit_one_node
+
+# ---------------------------------------------------------------------------
+# run_audit
+#   Audits every pod in PODS_FILE, P at a time, into RESULTS_FILE.
+# ---------------------------------------------------------------------------
+run_audit() {
+  awk -F'\t' '{print $1, $2, ($3 == "" ? "unset" : $3)}' "$PODS_FILE" \
+    | xargs -P "$P" -L1 bash -c 'audit_one_node "$@"' _ > "$RESULTS_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# write_report
+#   Joins the role labels onto the results and writes the sorted TSV with a
+#   header row to OUT.
+# ---------------------------------------------------------------------------
+write_report() {
+  {
+    printf 'NODE\tPOD\tENV_HW_OFFLOAD\tOVS_HW_OFFLOAD\tOVS_TC_FLOWS\t'
+    printf 'INGRESS_QDISCS\tBLOCKS(chain0/total)\tDEVS(chain0/total)\t'
+    printf 'UPTIME\tVERDICT\tROLE_LABELS\n'
+    awk -F'\t' '
+      NR == FNR { labels[$1] = $2; next }
+      { print $0 "\t" (($1 in labels) ? labels[$1] : "?") }
+    ' "$LABELS_FILE" "$RESULTS_FILE" | sort
+  } > "$OUT"
+}
+
+# ---------------------------------------------------------------------------
+# print_summary
+#   Human-readable table and counts. Exits 2 if any node needs attention.
+# ---------------------------------------------------------------------------
+print_summary() {
+  echo "=== per-node (full TSV: $OUT) ==="
+  column -t -s $'\t' "$OUT" | cut -c1-230
+
+  echo
+  echo "=== summary ==="
+  echo "ovs-ovn pods audited : $(wc -l < "$RESULTS_FILE")"
+
+  awk -F'\t' 'NR > 1 { count[$10]++ }
+              END { for (v in count) printf "  %-15s %d\n", v, count[v] }' "$OUT" | sort
+
+  echo "by role label       :"
+  awk -F'\t' 'NR > 1 { count[$11 "/" $10]++ }
+              END { for (k in count) printf "  %-35s %d\n", k, count[k] }' "$OUT" | sort
+
+  echo "OVS hw-offload      : $(awk -F'\t' 'NR > 1 { count[$4]++ }
+              END { for (v in count) printf "%s=%d ", v, count[v] }' "$OUT")"
+  echo "kube-ovn env        : $(awk -F'\t' 'NR > 1 { count[$3]++ }
+              END { for (v in count) printf "%s=%d ", v, count[v] }' "$OUT")"
+
+  echo "nodes needing attention (UNREACHABLE / ORPHANED-LIVE / REVIEW):"
+  awk -F'\t' 'NR > 1 && $10 ~ /UNREACHABLE|ORPHANED-LIVE|REVIEW/ {
+                print "  " $1 "  " $10 "  " $7 "  " $8
+              }' "$OUT"
+
+  awk -F'\t' 'NR > 1 && $10 ~ /UNREACHABLE|ORPHANED-LIVE|REVIEW/ { bad = 1 }
+              END { exit bad ? 2 : 0 }' "$OUT"
+}
+
+main() {
+  if ! command -v kubectl > /dev/null; then
+    echo "kubectl not found" >&2
+    exit 1
+  fi
+  mkdir -p "$(dirname "$OUT")"
+
+  gather_node_labels
+  gather_ovs_pods
+  run_audit
+  write_report
+  print_summary
+}
+
+main "$@"


### PR DESCRIPTION
…disable

Disabling HW_OFFLOAD in kube-ovn strands the software TC flower datapath on host NICs, where the orphaned filters keep intercepting traffic ahead of OVS. Add tooling to detect and remove that state:

- scripts/tc-offload-audit.sh: read-only fleet audit of hw-offload state, live TC flows, and flower filters per node, with per-node verdicts and a gate exit status
- ansible/playbooks/clear-stale-tc-flower.yaml: per-node chain-0 flower cleanup; dry-run by default, gated on OVS reporting zero live TC flows, with fleet coverage check