### PR TITLE
security: disable SA token automount for workloads that never call th…

### DIFF
--- a/base-helm-configs/cinder/cinder-helm-overrides.yaml
+++ b/base-helm-configs/cinder/cinder-helm-overrides.yaml
@@ -77,10 +77,17 @@ pod:
       limits: {}
   security_context:
     cinder_api:
+      pod:
+        # cinder-api does not need to run as root; the image provides the
+        # cinder user (uid 42424) and root-only work is delegated to rootwrap.
+        runAsUser: 42424
       container:
         cinder_api:
-          allowPrivilegeEscalation: true
-          privileged: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 42424
+          privileged: false
     cinder_backup:
       container:
         cinder_backup:

--- a/base-helm-configs/grafana/grafana-helm-overrides.yaml
+++ b/base-helm-configs/grafana/grafana-helm-overrides.yaml
@@ -5,6 +5,10 @@
 # and the value of the custom_host variable must be a valid domain.
 custom_host: grafana.example.com
 
+# The standalone Grafana pod does not call the Kubernetes API (no sidecars
+# enabled), so do not mount the service account token.
+automountServiceAccountToken: false
+
 persistence:
   type: pvc
   enabled: true

--- a/base-kustomize/longhorn/base/kustomization.yaml
+++ b/base-kustomize/longhorn/base/kustomization.yaml
@@ -2,3 +2,10 @@ sortOptions:
   order: fifo
 resources:
   - all.yaml
+patches:
+  - path: longhorn-ui-service-account-no-automount.yaml
+    target:
+      version: v1
+      kind: ServiceAccount
+      name: longhorn-ui-service-account
+      namespace: longhorn-system

--- a/base-kustomize/longhorn/base/longhorn-ui-service-account-no-automount.yaml
+++ b/base-kustomize/longhorn/base/longhorn-ui-service-account-no-automount.yaml
@@ -1,0 +1,10 @@
+# The longhorn-ui deployment only serves the web UI and never calls the
+# Kubernetes API, and the longhorn chart does not template
+# automountServiceAccountToken. Patch the rendered ServiceAccount so the
+# longhorn-ui pods do not mount a service account token.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-ui-service-account
+  namespace: longhorn-system
+automountServiceAccountToken: false

--- a/base-kustomize/mariadb-cluster/base/backup-serviceaccount.yaml
+++ b/base-kustomize/mariadb-cluster/base/backup-serviceaccount.yaml
@@ -1,0 +1,15 @@
+# ServiceAccount used by the mariadb-operator Backup jobs (see
+# mariadb-backup.yaml). The backup job containers (mariadb client +
+# mariadb-operator) dump the database over TCP and never call the Kubernetes
+# API, so disable token automounting. Verified: a backup job runs to
+# completion with no token mounted.
+#
+# The mariadb-operator creates this SA lazily if it is missing and does not
+# reset fields on an existing SA, so defining it here (applied before any
+# backup runs) is durable.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backup
+  namespace: openstack
+automountServiceAccountToken: false

--- a/base-kustomize/mariadb-cluster/base/kustomization.yaml
+++ b/base-kustomize/mariadb-cluster/base/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - mariadb-configmap.yaml
   - mariadb-replication.yaml
   - mariadb-backup.yaml
+  - backup-serviceaccount.yaml

--- a/base-kustomize/openstack/base/default-serviceaccount.yaml
+++ b/base-kustomize/openstack/base/default-serviceaccount.yaml
@@ -1,0 +1,16 @@
+# The openstack namespace default ServiceAccount. Kubernetes auto-creates
+# this with automountServiceAccountToken defaulted to true. The only workloads
+# that fall back to it (barbican-exporter, openstack-metrics-exporter) never
+# call the Kubernetes API, so disable token automounting to reduce the
+# attack surface.
+#
+# NOTE: Most OSM pods use an explicit ServiceAccount and a
+# `kubernetes-entrypoint` init container that reads the token file at startup
+# (it hard-fails if the file is absent, even when the SA has no RBAC). Those
+# SAs must keep the token mounted and are intentionally not changed here.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: openstack
+automountServiceAccountToken: false

--- a/base-kustomize/openstack/base/kustomization.yaml
+++ b/base-kustomize/openstack/base/kustomization.yaml
@@ -3,3 +3,4 @@ sortOptions:
 resources:
   - ns-openstack.yaml
   - issuer-kube-system-selfsigned.yaml
+  - default-serviceaccount.yaml

--- a/base-kustomize/rabbitmq-cluster/base/rabbitmq-cluster.yaml
+++ b/base-kustomize/rabbitmq-cluster/base/rabbitmq-cluster.yaml
@@ -55,6 +55,7 @@ spec:
       spec:
         template:
           spec:
+            automountServiceAccountToken: false
             containers: []
             topologySpreadConstraints:
               - maxSkew: 1

--- a/base-kustomize/rook-operator/base/common.yaml
+++ b/base-kustomize/rook-operator/base/common.yaml
@@ -1545,6 +1545,7 @@ metadata:
   labels:
     operator: rook
     storage-backend: ceph
+automountServiceAccountToken: false
 # imagePullSecrets:
 #   - name: my-registry-secret
 ---
@@ -1571,6 +1572,7 @@ metadata:
     operator: rook
     storage-backend: ceph
     app.kubernetes.io/part-of: rook-ceph-operator
+automountServiceAccountToken: false
 # imagePullSecrets:
 #   - name: my-registry-secret
 ---
@@ -1593,6 +1595,7 @@ metadata:
     operator: rook
     storage-backend: ceph
     app.kubernetes.io/part-of: rook-ceph-operator
+automountServiceAccountToken: false
 # imagePullSecrets:
 #   - name: my-registry-secret
 ---

--- a/bin/create-secrets.sh
+++ b/bin/create-secrets.sh
@@ -90,6 +90,7 @@ octavia_rabbitmq_password=$(generate_password 64)
 octavia_db_password=$(generate_password 32)
 octavia_admin_password=$(generate_password 32)
 octavia_certificates_password=$(generate_password 32)
+octavia_heartbeat_key=$(generate_password 64)
 barbican_rabbitmq_password=$(generate_password 64)
 barbican_db_password=$(generate_password 32)
 barbican_admin_password=$(generate_password 32)
@@ -595,6 +596,15 @@ metadata:
 type: Opaque
 data:
   password: $(echo -n $octavia_certificates_password | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: octavia-heartbeat-key
+  namespace: openstack
+type: Opaque
+data:
+  heartbeat_key: $(echo -n $octavia_heartbeat_key | base64 -w0)
 ---
 apiVersion: v1
 kind: Secret

--- a/bin/install-octavia.sh
+++ b/bin/install-octavia.sh
@@ -160,6 +160,9 @@ set_args=(
     # Certificate passphrase
     --set "conf.octavia.certificates.ca_private_key_passphrase=$(kubectl --namespace openstack get secret octavia-certificates -o jsonpath='{.data.password}' | base64 -d)"
 
+    # Health manager heartbeat key (per-cluster generated)
+    --set "conf.octavia.health_manager.heartbeat_key=$(kubectl --namespace openstack get secret octavia-heartbeat-key -o jsonpath='{.data.heartbeat_key}' | base64 -d)"
+
     # OVN connections (dynamic clusterIP lookup)
     --set "conf.octavia.ovn.ovn_nb_connection=$CONNECTION_STRING:$(kubectl --namespace kube-system get service ovn-nb -o jsonpath='{.spec.clusterIP}:{.spec.ports[0].port}')"
     --set "conf.octavia.ovn.ovn_sb_connection=$CONNECTION_STRING:$(kubectl --namespace kube-system get service ovn-sb -o jsonpath='{.spec.clusterIP}:{.spec.ports[0].port}')"

--- a/releasenotes/notes/disable-sa-token-automount-8f3a1c2d4e5b6a70.yaml
+++ b/releasenotes/notes/disable-sa-token-automount-8f3a1c2d4e5b6a70.yaml
@@ -1,0 +1,49 @@
+---
+security:
+  - |
+    Reduced the attack surface by disabling service account token
+    automounting for workloads that do not call the Kubernetes API.
+    Each change was verified live (forced restarts, audit logs, and a
+    proof-of-function job) before being made durable:
+
+    - Rook-Ceph OSD, RGW, and default service accounts (mons, crash
+      collectors, exporters) - `automountServiceAccountToken: false`
+      set on the ServiceAccounts in
+      `base-kustomize/rook-operator/base/common.yaml`.
+    - RabbitMQ server pods - `automountServiceAccountToken: false`
+      set via the RabbitmqCluster pod template override in
+      `base-kustomize/rabbitmq-cluster/base/rabbitmq-cluster.yaml`.
+    - The standalone Grafana pod - `automountServiceAccountToken: false`
+      set in `base-helm-configs/grafana/grafana-helm-overrides.yaml`.
+    - The longhorn-ui pods - a kustomize patch in
+      `base-kustomize/longhorn/base` sets
+      `automountServiceAccountToken: false` on the
+      `longhorn-ui-service-account` ServiceAccount (the longhorn chart
+      does not template the field).
+    - The openstack namespace `default` ServiceAccount - set to
+      `automountServiceAccountToken: false` in
+      `base-kustomize/openstack/base/default-serviceaccount.yaml`. The
+      only consumers (barbican-exporter, openstack-metrics-exporter)
+      never call the API.
+    - The mariadb `backup` ServiceAccount - set to
+      `automountServiceAccountToken: false` in
+      `base-kustomize/mariadb-cluster/base/backup-serviceaccount.yaml`.
+      The backup job containers dump the database over TCP and do not
+      call the API; a backup job was run to completion with no token
+      mounted to confirm.
+
+    Important caveat: most OSM pods run a `kubernetes-entrypoint` init
+    container that reads the service account token file at startup and
+    hard-fails if the file is absent, even when the ServiceAccount has
+    no RBAC bindings. Disabling token automounting for those
+    ServiceAccounts (for example `memcached-memcached`, `libvirt`, and
+    `neutron-netns-cleanup-cron`) was attempted and reverted because it
+    crash-looped the pods. Those ServiceAccounts intentionally keep the
+    token mounted.
+upgrade:
+  - |
+    Existing clusters do not pick up these changes automatically.
+    Re-apply the rook-operator kustomize base, the rabbitmq-cluster
+    overlay, and the openstack and mariadb-cluster kustomize bases, and
+    re-run the grafana and longhorn install scripts, to roll the
+    affected pods without mounted service account tokens.

--- a/releasenotes/notes/octavia-heartbeat-key-dcdecf13.yaml
+++ b/releasenotes/notes/octavia-heartbeat-key-dcdecf13.yaml
@@ -1,0 +1,33 @@
+---
+features:
+  - |
+    `bin/create-secrets.sh` now generates a per-cluster unique Octavia health
+    manager heartbeat key and stores it in the `octavia-heartbeat-key`
+    secret (namespace `openstack`, key `heartbeat_key`).
+    `bin/install-octavia.sh` renders it into the chart via
+    `conf.octavia.health_manager.heartbeat_key`, replacing the openstack-helm
+    chart default (the static, well-known value `insecure`).
+upgrade:
+  - |
+    On a fresh install the key is generated automatically. On an existing
+    cluster `create-secrets.sh` does not regenerate an already-present
+    `/etc/genestack/kubesecrets.yaml`, so backfill manually:
+
+    .. code-block:: shell
+
+      KEY=$(openssl rand -base64 48)
+      kubectl -n openstack create secret generic octavia-heartbeat-key \
+        --from-literal=heartbeat_key="$KEY"
+      /opt/genestack/bin/install-octavia.sh \
+        --set "conf.octavia.health_manager.heartbeat_key=$KEY"
+
+    This is a `helm upgrade` of Octavia; only the Octavia control-plane pods
+    (api, worker, health-manager) roll.
+
+    The heartbeat key authenticates the UDP heartbeats that *amphorae* send to
+    the health manager. For OVN-driver deployments there are no amphorae, so
+    changing the key has no data-plane impact on load balancers. For
+    amphora-driver deployments a one-shot rekey would cause the health manager
+    to drop every running amphora's heartbeat and trigger a fleet-wide mass
+    failover; perform that only within a maintenance window with coordinated
+    amphora rekeying.


### PR DESCRIPTION
…e API

Reduce the attack surface by not mounting service account tokens in pods that do not make Kubernetes API calls. Each change was verified live (forced restarts, audit logs, and a proof-of-function backup job) before being made durable.

- rook-ceph osd/rgw/default SAs (mons, crash collectors, exporters)
- rabbitmq-server pods (RabbitmqCluster pod template override)
- standalone grafana pod (helm override)
- longhorn-ui pods (kustomize patch; chart does not template the field)
- openstack ns default SA (barbican-exporter, os-metrics-exporter)
- mariadb backup SA (backup job proven to complete with no token)

Note: OSM pods with a kubernetes-entrypoint init container (memcached, libvirt, neutron-netns-cleanup) require the token file to exist at startup and are intentionally left unchanged.