### PR TITLE
feat(ironic): monitoring integration, enhance configuration and documentation

### DIFF
--- a/.github/workflows/helm-ironic.yaml
+++ b/.github/workflows/helm-ironic.yaml
@@ -1,0 +1,57 @@
+---
+name: Helm GitHub Actions for ironic
+
+on:
+  pull_request:
+    paths:
+      - base-helm-configs/ironic/**
+      - base-kustomize/ironic/**
+      - helm-chart-versions.yaml
+      - .github/workflows/helm-ironic.yaml
+jobs:
+  helm:
+    strategy:
+      matrix:
+        overlays:
+          - base
+    name: Helm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: azure/setup-helm@v3
+        with:
+          version: v3.14.3
+          token: ${{ secrets.GITHUB_TOKEN }}
+        id: helm
+      - name: Kubectl Install
+        working-directory: /usr/local/bin/
+        run: |
+          if [ ! -f /usr/local/bin/kubectl ]; then
+            curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+            chmod +x ./kubectl
+          fi
+      - name: Get chart version
+        uses: ./.github/actions/get-chart-version
+        id: chart-version
+        with:
+          chart-name: ironic
+      - name: Pull OSH repositories
+        run: |
+          helm repo add openstack-helm https://tarballs.opendev.org/openstack/openstack-helm
+          helm repo update
+      - name: Run Helm Template
+        run: |
+          ${{ steps.helm.outputs.helm-path }} template ironic openstack-helm/ironic \
+            --version ${{ steps.chart-version.outputs.version }} \
+            --namespace=openstack \
+            --wait \
+            --timeout 120m \
+            -f ${{ github.workspace }}/base-helm-configs/ironic/ironic-helm-overrides.yaml \
+            --post-renderer ${{ github.workspace }}/base-kustomize/kustomize.sh \
+            --post-renderer-args ironic/${{ matrix.overlays }} > /tmp/rendered.yaml
+      - name: Return helm Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: helm-ironic-artifact-${{ matrix.overlays }}
+          path: /tmp/rendered.yaml

--- a/.github/workflows/helm-ironic.yaml
+++ b/.github/workflows/helm-ironic.yaml
@@ -8,6 +8,8 @@ on:
       - base-kustomize/ironic/**
       - helm-chart-versions.yaml
       - .github/workflows/helm-ironic.yaml
+permissions:
+  contents: read
 jobs:
   helm:
     strategy:

--- a/base-helm-configs/ironic/ironic-helm-overrides.yaml
+++ b/base-helm-configs/ironic/ironic-helm-overrides.yaml
@@ -60,11 +60,18 @@ conf:
       default_boot_option: "local"
       iso_master_path: "/var/lib/ironic/master_iso_images"
     agent:
+      require_tls: true
+      verify_ca: True
+      certificates_path: /var/lib/ironic/certificates
       efi_boot_partition: "/boot/efi"
       image_download_source: "http"
       deploy_logs_collect: "always"
       deploy_logs_storage_backend: "local"
       deploy_logs_local_path: "/var/lib/ironic/logs"
+    dhcp:
+      dhcp_provider: "neutron"
+    api:
+      ramdisk_heartbeat_timeout: 3600
     pxe:
       kernel_append_params: "nofb nomodeset vga=normal ipa-debug=1"
       images_path: /var/lib/openstack-helm/ironic/images
@@ -74,6 +81,7 @@ conf:
       pxe_bootfile_name: "undionly.kpxe"
       uefi_pxe_bootfile_name: "ipxe.efi"
       ipxe_enabled: true
+      # image_cache_size: "21474836480"
     ilo:
       use_web_server_for_images: "True"
       kernel_append_params: "nofb nomodeset vga=normal ipa-debug=1"
@@ -104,10 +112,24 @@ conf:
       valid_interfaces: internal
     neutron:
       auth_type: password
-      cleaning_network: "baremetal-cleaning-network"
+      cleaning_network: "baremetal-provisioning-network"
       provisioning_network: "baremetal-provisioning-network"
     service_catalog:
       valid_interfaces: public
+    sensor_data:
+      send_sensor_data: true
+      interval: 120
+      workers: 4
+      data_types: ALL
+      enable_for_conductor: true
+      enable_for_nodes: true
+      enable_for_undeployed_nodes: true
+    metrics:
+      backend: collector
+    oslo_messaging_notifications:
+      driver: prometheus_exporter
+      transport_url: fake://
+      location: /var/lib/ironic/metrics
     oslo_messaging_rabbit:
       amqp_durable_queues: false
       rabbit_ha_queues: false
@@ -146,6 +168,61 @@ network:
     neutron_subnet_alloc_start: 172.24.6.100
     neutron_subnet_alloc_end: 172.24.6.200
     neutron_subnet_dns_nameserver: 8.8.8.8 # Aligned with Neutron's OVN DNS
+
+conductor:
+  extraContainers:
+    - name: ironic-prometheus-exporter
+      image: ghcr.io/rackerlabs/genestack-images/ironic-prometheus-exporter:2026.1-latest
+      imagePullPolicy: "IfNotPresent"
+      env:
+        - name: IRONIC_CONFIG
+          value: /etc/ironic/ironic.conf
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+      command:
+        - /bin/sh
+        - -c
+        - |
+          exec gunicorn \
+            --bind "${POD_IP}:9608" \
+            --workers 4 \
+            --access-logfile - \
+            --error-logfile - \
+            ironic_prometheus_exporter.app.wsgi:application
+      ports:
+        - name: metrics
+          containerPort: 9608
+          protocol: TCP
+      readinessProbe:
+        httpGet:
+          path: /metrics
+          port: metrics
+          scheme: HTTP
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        timeoutSeconds: 2
+        successThreshold: 1
+        failureThreshold: 3
+      livenessProbe:
+        httpGet:
+          path: /metrics
+          port: metrics
+          scheme: HTTP
+        initialDelaySeconds: 15
+        periodSeconds: 20
+        timeoutSeconds: 2
+        successThreshold: 1
+        failureThreshold: 3
+      volumeMounts:
+        - name: ironic-etc
+          mountPath: /etc/ironic/ironic.conf
+          subPath: ironic.conf
+          readOnly: true
+        - name: host-var-lib-ironic
+          mountPath: /var/lib/ironic
+          readOnly: true
 
 bootstrap:
   image:

--- a/base-helm-configs/opentelemetry-kube-stack/opentelemetry-kube-stack-helm-ironic-overrides.yaml.example
+++ b/base-helm-configs/opentelemetry-kube-stack/opentelemetry-kube-stack-helm-ironic-overrides.yaml.example
@@ -1,0 +1,43 @@
+---
+collectors:
+  deployment:
+    config:
+      receivers:
+        prometheus/ironic:
+          config:
+            scrape_configs:
+              - job_name: ironic-prometheus-exporter
+                scrape_interval: 30s
+                scrape_timeout: 10s
+                metrics_path: /metrics
+                kubernetes_sd_configs:
+                  - role: endpoints
+                    namespaces:
+                      names:
+                        - openstack
+                relabel_configs:
+                  - source_labels: [__meta_kubernetes_service_name]
+                    regex: ironic-prometheus-exporter
+                    action: keep
+                  - source_labels: [__meta_kubernetes_endpoint_port_name]
+                    regex: metrics
+                    action: keep
+                  - source_labels: [__meta_kubernetes_endpoint_ready]
+                    regex: "true"
+                    action: keep
+                  - source_labels: [__meta_kubernetes_namespace]
+                    target_label: namespace
+                  - source_labels: [__meta_kubernetes_service_name]
+                    target_label: service
+                  - source_labels: [__meta_kubernetes_pod_name]
+                    target_label: pod
+                  - source_labels: [__meta_kubernetes_endpoint_node_name]
+                    target_label: node
+                  - target_label: job
+                    replacement: ironic-prometheus-exporter
+
+      service:
+        pipelines:
+          metrics:
+            receivers:
+              - prometheus/ironic

--- a/base-helm-configs/opentelemetry-kube-stack/opentelemetry-kube-stack-helm-overrides.yaml
+++ b/base-helm-configs/opentelemetry-kube-stack/opentelemetry-kube-stack-helm-overrides.yaml
@@ -1199,6 +1199,8 @@ collectors:
               method: GET
             - endpoint: https://novnc.api.example.com/vnc_auto.html
               method: GET
+            - endpoint: https://ironic.api.example.com
+              method: GET
           collection_interval: 30s
 
         prometheus/infra:

--- a/base-kustomize/ironic/base/ironic-prometheus-exporter-svc.yaml
+++ b/base-kustomize/ironic/base/ironic-prometheus-exporter-svc.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ironic-prometheus-exporter
+  labels:
+    app.kubernetes.io/name: ironic-prometheus-exporter
+spec:
+  selector:
+    application: ironic
+    component: conductor
+  ports:
+    - name: metrics
+      port: 9608
+      targetPort: metrics
+      protocol: TCP

--- a/base-kustomize/ironic/base/kustomization.yaml
+++ b/base-kustomize/ironic/base/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - all.yaml
   - hpa-ironic-api.yaml
   - policies.yaml
+  - ironic-prometheus-exporter-svc.yaml

--- a/base-kustomize/opentelemetry-kube-stack/base/openstack-annotate-instrumentation.yaml
+++ b/base-kustomize/opentelemetry-kube-stack/base/openstack-annotate-instrumentation.yaml
@@ -288,6 +288,31 @@
 #      annotations:
 #        instrumentation.opentelemetry.io/inject-python: "openstack/openstack-instrumentation"
 #
+#---
+## Ironic
+#apiVersion: apps/v1
+#kind: Deployment
+#metadata:
+#  name: ironic-api
+#  namespace: openstack
+#spec:
+#  template:
+#    metadata:
+#      annotations:
+#        instrumentation.opentelemetry.io/inject-python: "openstack/openstack-instrumentation"
+#
+#---
+#apiVersion: apps/v1
+#kind: StatefulSet
+#metadata:
+#  name: ironic-conductor
+#  namespace: openstack
+#spec:
+#  template:
+#    metadata:
+#      annotations:
+#        instrumentation.opentelemetry.io/inject-python: "openstack/openstack-instrumentation"
+#
 ##---
 ### Manila
 ##apiVersion: apps/v1

--- a/bin/setup-openstack.sh
+++ b/bin/setup-openstack.sh
@@ -5,6 +5,8 @@ set -e
 declare -A pids
 declare -A pid_commands
 
+CONFIG_FILE="${CONFIG_FILE:-/etc/genestack/openstack-components.yaml}"
+
 function runTrackErator() {
     "${1}" &
     local pid=$!
@@ -67,9 +69,9 @@ prompt_component() {
     local prompt=$2
     read -p "Install ${prompt}? (y/n): " answer
     if [[ "$answer" =~ ^[Yy]$ ]]; then
-        echo "  ${component}: true" >> /etc/genestack/openstack-components.yaml
+        echo "  ${component}: true" >> "${CONFIG_FILE}"
     else
-        echo "  ${component}: false" >> /etc/genestack/openstack-components.yaml
+        echo "  ${component}: false" >> "${CONFIG_FILE}"
     fi
 }
 
@@ -79,8 +81,25 @@ is_component_enabled() {
     grep -qi "^[[:space:]]*${component}:[[:space:]]*true" "$CONFIG_FILE"
 }
 
+# Fail early when Ironic is selected without its required OpenStack services.
+validate_ironic_dependencies() {
+    is_component_enabled "ironic" || return 0
+
+    local missing_dependencies=()
+    local dependency
+    for dependency in glance placement nova neutron; do
+        if ! is_component_enabled "${dependency}"; then
+            missing_dependencies+=("${dependency}")
+        fi
+    done
+
+    if [ "${#missing_dependencies[@]}" -gt 0 ]; then
+        echo "ERROR: Ironic requires these components: ${missing_dependencies[*]}"
+        return 1
+    fi
+}
+
 # Check for YAML file and create if it doesn't exist
-CONFIG_FILE="/etc/genestack/openstack-components.yaml"
 if [ ! -f "$CONFIG_FILE" ]; then
     echo "Configuration file $CONFIG_FILE not found. Creating it..."
     cat > "$CONFIG_FILE" << EOF
@@ -97,6 +116,7 @@ EOF
     prompt_component "placement" "Placement"
     prompt_component "nova" "Nova (Compute)"
     prompt_component "neutron" "Neutron (Networking)"
+    prompt_component "ironic" "Ironic (Bare Metal)"
     prompt_component "magnum" "Magnum (Container Orchestration)"
     prompt_component "octavia" "Octavia (Load Balancer)"
     prompt_component "masakari" "Masakari (Instance High Availability)"
@@ -109,6 +129,8 @@ EOF
     prompt_component "zaqar" "Zaqar (Messaging)"
     prompt_component "qonos" "Qonos (Scheduled Actions)"
 fi
+
+validate_ironic_dependencies
 
 # Block on Keystone
 /opt/genestack/bin/install-keystone.sh
@@ -136,6 +158,9 @@ is_component_enabled "zaqar" && runTrackErator /opt/genestack/bin/install-zaqar.
 is_component_enabled "qonos" && runTrackErator /opt/genestack/bin/install-qonos.sh
 
 waitErator
+
+# Install Ironic only after Keystone, Glance, Placement, Nova, and Neutron are up.
+is_component_enabled "ironic" && /opt/genestack/bin/install-ironic.sh
 
 # Install skyline after all services are up
 is_component_enabled "skyline" && /opt/genestack/bin/install-skyline.sh

--- a/docs/openstack-ironic-lifecycle-management.md
+++ b/docs/openstack-ironic-lifecycle-management.md
@@ -1,14 +1,8 @@
 # Managing The Bare Metal Lifecycle With OpenStack Ironic
 
-Managing physical infrastructure has traditionally required significant manual effort across provisioning, maintenance, and retirement. OpenStack Ironic changes that model by treating bare metal as an API-driven infrastructure resource, allowing operators to automate the full server lifecycle in a way that is consistent, repeatable, and cloud-native.
+Managing physical infrastructure traditionally requires significant manual effort across provisioning, maintenance, and retirement. OpenStack Ironic changes this model by treating bare metal as an API-driven resource. Physical servers can be enrolled, inspected, provisioned, cleaned, and reused through consistent OpenStack services and APIs.
 
-This document explains how the bare metal lifecycle is typically managed, how Ironic improves that workflow, and how it integrates with the wider OpenStack platform.
-
-## Introduction
-
-In traditional environments, bare metal lifecycle management often depends on a combination of datacenter procedures, hardware vendor tooling, and manual operating system installation steps. These tasks are usually operationally expensive and difficult to standardize across large fleets.
-
-With Ironic, physical servers can be enrolled, provisioned, cleaned, and reused through OpenStack services and APIs. This gives operators a much more predictable and automated approach to hardware management.
+This document describes the bare metal lifecycle, how Ironic automates that lifecycle, and how it integrates with the wider OpenStack platform.
 
 ## Traditional Bare Metal Lifecycle
 
@@ -37,24 +31,30 @@ At a high level, Ironic manages a node through the following operational stages:
 ```text
 Enroll
    ->
-Manage
+Verifying
    ->
-Inspect and validate
+Manageable
    ->
-Provide
+Inspecting (optional)
    ->
-Deploy
+Manageable
    ->
-Active use
+Cleaning (through the provide action)
    ->
-Clean
+Available
+   ->
+Deploying
+   ->
+Active
+   ->
+Deleting and cleaning
    ->
 Available for reuse
 ```
 
 This lifecycle helps ensure that a node moves through a known set of transitions before it is exposed to users or returned to inventory.
 
-## Discovery And Registration
+## Node Enrollment And Registration
 
 The first step is to enroll the bare metal node in Ironic. During this stage, the operator registers the hardware and provides the required management details, such as:
 
@@ -79,13 +79,13 @@ Typical operator actions at this stage include:
 - Setting resource classes and scheduling properties
 - Running cleaning steps if metadata or disk state must be reset
 
-When the node passes validation and preparation, it can be moved to an available state. At that point, Nova can schedule workloads to it based on flavor and resource class matching.
+When the node passes validation and preparation, it can be moved to an available state. When Ironic is integrated with Nova, Nova can then schedule workloads to it based on flavor and resource class matching.
 
 ## Automated Provisioning
 
 Once a node is available, users or automation systems can request bare metal capacity through OpenStack APIs. Ironic then performs the provisioning workflow automatically.
 
-This typically includes the following actions:
+Depending on the deployment model, Nova scheduling or an Ironic allocation selects a suitable node. The provisioning workflow typically includes the following actions:
 
 - Selecting a suitable available node
 - Powering on the system
@@ -114,7 +114,7 @@ This makes it possible to include physical infrastructure in automation pipeline
 
 One of the most important parts of the bare metal lifecycle is returning a server to a known-good state after use.
 
-Ironic supports automated cleaning workflows that can:
+Ironic can perform automated cleaning before a node receives its first workload and when it is returned for reuse. Cleaning workflows can:
 
 - Erase partition metadata
 - Wipe disks
@@ -142,7 +142,6 @@ Ironic is most effective when used as part of the broader OpenStack control plan
 - **Neutron** for provisioning and tenant network connectivity
 - **Glance** for deployment image storage and retrieval
 - **Keystone** for authentication and authorization
-- **Skyline** for web-based administration and operational visibility
 - **Cinder** for optional block storage integration
 
 This integration allows bare metal infrastructure to behave like a first-class cloud resource while still preserving dedicated hardware characteristics.

--- a/docs/openstack-ironic-monitoring.md
+++ b/docs/openstack-ironic-monitoring.md
@@ -1,0 +1,341 @@
+# OpenStack Ironic Monitoring
+
+Genestack deploys `ironic-prometheus-exporter` alongside the OpenStack Ironic
+conductors. The exporter converts Ironic hardware sensor data into Prometheus
+metrics and exposes them on HTTP port `9608`. The OpenTelemetry deployment
+collector discovers every ready exporter endpoint and forwards the collected
+metrics to the monitoring backend.
+
+This guide describes how Ironic monitoring is configured, enabled, and
+validated in Genestack. For Ironic deployment and bare metal provisioning, see
+[Deploy Ironic](openstack-ironic.md) and the
+[OpenStack Ironic Operational Guide](openstack-ironic-operational-guide.md).
+
+## Architecture
+
+```text
+┌────────────────────────────────────────────────────────────────────────────┐
+│                         Bare Metal Infrastructure                          │
+│                                                                            │
+│     ┌────────────────┐   ┌────────────────┐       ┌────────────────┐       │
+│     │ Server BMC 1   │   │ Server BMC 2   │  ...  │ Server BMC N   │       │
+│     │ IPMI / Redfish │   │ IPMI / Redfish │       │ IPMI / Redfish │       │
+│     └────────┬───────┘   └────────┬───────┘       └────────┬───────┘       │
+└──────────────┼────────────────────┼────────────────────────┼───────────────┘
+               └────────────────────┼────────────────────────┘
+                                    │ Sensor collection every 120 seconds
+                                    ▼
+┌────────────────────────────────────────────────────────────────────────────┐
+│                         OpenStack Namespace                                │
+│                                                                            │
+│  ┌──────────────────────────────┐    ┌──────────────────────────────┐      │
+│  │ Ironic Conductor Pod 1       │    │ Ironic Conductor Pod N       │      │
+│  │                              │    │                              │      │
+│  │  ironic-conductor            │    │  ironic-conductor            │      │
+│  │         │                    │    │         │                    │      │
+│  │         ▼                    │    │         ▼                    │      │
+│  │  /var/lib/ironic/metrics     │    │  /var/lib/ironic/metrics     │      │
+│  │         │                    │    │         │                    │      │
+│  │         ▼                    │    │         ▼                    │      │
+│  │  exporter sidecar :9608      │    │  exporter sidecar :9608      │      │
+│  └──────────────┬───────────────┘    └──────────────┬───────────────┘      │
+│                 │                                   │                      │
+│                 └─────────────────┬─────────────────┘                      │
+│                                   ▼                                        │
+│                 ironic-prometheus-exporter Service                         │
+│                 Publishes ready endpoints on named port metrics            │
+└───────────────────────────────────┬────────────────────────────────────────┘
+                                    │ Kubernetes API discovery: role endpoints
+                                    │ Direct HTTP GET to every endpoint IP:9608
+                                    │ every 30 seconds (does not use ClusterIP)
+                                    ▼
+┌────────────────────────────────────────────────────────────────────────────┐
+│                         Monitoring Namespace                               │
+│                                                                            │
+│  ┌──────────────────────────────────────────────────────────────────────┐  │
+│  │ OpenTelemetry Deployment Collector                                   │  │
+│  │                                                                      │  │
+│  │ prometheus/ironic receiver ──► processors ──► prometheusremotewrite  │  │
+│  └───────────────────────────────────┬──────────────────────────────────┘  │
+│                                      │                                     │
+│                                      ▼                                     │
+│                              ┌──────────────┐                              │
+│                              │ Prometheus   │                              │
+│                              │ Metrics/Rules│                              │
+│                              └──────┬───────┘                              │
+│                                     │                                      │
+│                          ┌──────────┴──────────┐                           │
+│                          ▼                     ▼                           │
+│                    ┌───────────┐        ┌──────────────┐                   │
+│                    │ Grafana   │        │ Alertmanager │                   │
+│                    │ Dashboards│        │ Notifications│                   │
+│                    └───────────┘        └──────────────┘                   │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+Each conductor Pod has its own exporter sidecar. The
+`ironic-prometheus-exporter` Service selects all Ironic conductor Pods, and the
+OpenTelemetry receiver uses Kubernetes service discovery to turn every ready
+Service endpoint into a separate scrape target. It then connects directly to
+each endpoint IP on port `9608`; scrape traffic does not pass through the
+Service ClusterIP. This ensures that metrics produced by each conductor are
+collected.
+
+!!! note
+
+    The Prometheus scrape interval and the Ironic sensor collection interval
+    control different operations. The OpenTelemetry deployment collector
+    scrapes the exporter every 30 seconds, but Ironic refreshes the underlying
+    hardware sensor data every 120 seconds by default.
+
+## Prerequisites
+
+Before enabling collection, ensure that:
+
+- Ironic is deployed and its conductors are healthy.
+- The OpenTelemetry monitoring stack is installed.
+- The target BMCs are reachable from the Ironic conductors.
+- The nodes use a hardware type that can provide supported sensor data.
+- The OpenTelemetry collector can list Kubernetes Services, Endpoints, and
+  Pods in the `openstack` namespace.
+
+See [Monitoring Getting Started](monitoring-getting-started.md) for the base
+monitoring stack installation.
+
+## Ironic Sensor Configuration
+
+The base Ironic Helm overrides enable sensor collection and configure the
+Prometheus exporter notification driver:
+
+```yaml
+conf:
+  ironic:
+    sensor_data:
+      send_sensor_data: true
+      interval: 120
+      workers: 4
+      data_types: ALL
+      enable_for_conductor: true
+      enable_for_nodes: true
+      enable_for_undeployed_nodes: true
+    metrics:
+      backend: collector
+    oslo_messaging_notifications:
+      driver: prometheus_exporter
+      transport_url: fake://
+      location: /var/lib/ironic/metrics
+```
+
+The settings have the following purposes:
+
+| Setting | Purpose |
+| --- | --- |
+| `send_sensor_data` | Enables periodic collection of hardware sensor data. |
+| `interval` | Sets the sensor refresh interval in seconds. |
+| `workers` | Sets the number of workers used for sensor collection. |
+| `data_types` | Selects which available sensor data types are collected. |
+| `enable_for_conductor` | Includes conductor metrics in the collected data. |
+| `enable_for_nodes` | Includes managed bare metal node metrics. |
+| `enable_for_undeployed_nodes` | Collects sensor data from undeployed nodes. |
+| `backend` | Stores collected Ironic metrics for notification delivery. |
+| `driver` | Writes notifications in the format consumed by the exporter. |
+| `location` | Specifies the metrics directory read by the exporter. |
+
+Environment-specific changes should be placed in an override under
+`/etc/genestack/helm-configs/ironic/`. After changing the sensor configuration,
+apply it by upgrading the Ironic deployment:
+
+```shell
+/opt/genestack/bin/install-ironic.sh
+```
+
+## Exporter Deployment
+
+The Genestack Ironic Helm values add an `ironic-prometheus-exporter` sidecar to
+each conductor Pod. Each sidecar:
+
+- Reads `/etc/ironic/ironic.conf`.
+- Listens on the Pod IP at port `9608`.
+- Exposes metrics at `/metrics`.
+- Uses HTTP readiness and liveness probes against `/metrics`.
+
+The Ironic post-renderer also creates this Service:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: ironic-prometheus-exporter
+spec:
+  selector:
+    application: ironic
+    component: conductor
+  ports:
+    - name: metrics
+      port: 9608
+      targetPort: metrics
+      protocol: TCP
+```
+
+The port name must remain `metrics` because the OpenTelemetry relabel rules use
+that name to select the correct endpoint port.
+
+## Enable OpenTelemetry Collection
+
+Ironic collection is supplied as an optional OpenTelemetry values example. Copy
+it into the service override directory before installing or upgrading the
+OpenTelemetry stack:
+
+```shell
+
+cp \
+  /opt/genestack/base-helm-configs/opentelemetry-kube-stack/opentelemetry-kube-stack-helm-ironic-overrides.yaml.example \
+  /etc/genestack/helm-configs/opentelemetry-kube-stack/opentelemetry-kube-stack-helm-ironic-overrides.yaml
+
+/opt/genestack/bin/install-opentelemetry-kube-stack.sh
+```
+
+The override adds the `prometheus/ironic` receiver to the deployment
+collector's metrics pipeline. Its scrape configuration is:
+
+```yaml
+--8<-- "base-helm-configs/opentelemetry-kube-stack/opentelemetry-kube-stack-helm-ironic-overrides.yaml.example"
+```
+
+### Why Endpoint Discovery Is Used
+
+The `endpoints` role discovers the actual Pod IP and named port registered
+behind the `ironic-prometheus-exporter` Service. The relabel rules then:
+
+1. retain only the `ironic-prometheus-exporter` Service
+2. retain only the named `metrics` port
+3. retain only ready endpoints
+4. add namespace, Service, Pod, and node labels
+5. set the Prometheus job to `ironic-prometheus-exporter`
+
+Using endpoint discovery is preferable to discovering all Pods because it
+follows the Service selector and excludes endpoints that are not ready.
+
+!!! warning
+
+    Every OpenTelemetry deployment collector replica running this receiver can
+    discover and scrape every exporter endpoint. If the deployment collector is
+    scaled beyond one replica without target allocation or sharding, verify that
+    the monitoring backend is not receiving duplicate samples.
+
+## Validate Collection
+
+### Check Ironic Conductors And Exporter Sidecars
+
+List the conductor Pods and confirm that each Pod includes the exporter
+container:
+
+```shell
+kubectl --namespace openstack get pods \
+  -l application=ironic,component=conductor
+
+kubectl --namespace openstack get pods \
+  -l application=ironic,component=conductor \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[*].name}{"\n"}{end}'
+```
+
+Check the exporter logs in one conductor Pod:
+
+```shell
+CONDUCTOR_POD=$(kubectl --namespace openstack get pods \
+  -l application=ironic,component=conductor \
+  -o jsonpath='{.items[0].metadata.name}')
+
+kubectl --namespace openstack logs "${CONDUCTOR_POD}" \
+  --container ironic-prometheus-exporter
+```
+
+Check The Service And Endpoints
+
+```shell
+kubectl --namespace openstack get service ironic-prometheus-exporter
+kubectl --namespace openstack get endpoints ironic-prometheus-exporter
+```
+
+The Endpoints object should contain one ready address for each healthy
+conductor Pod and port `9608` named `metrics`.
+
+To inspect whether Ironic is creating metrics files inside a conductor Pod:
+
+```shell
+kubectl --namespace openstack exec "${CONDUCTOR_POD}" \
+  --container ironic-conductor -- \
+  find /var/lib/ironic/metrics -maxdepth 1 -type f -ls
+```
+
+### Query The Exporter Directly
+
+The Ironic conductor uses the host network, and the exporter listens on the Pod
+IP, which is the Kubernetes node IP in this configuration. Test the ClusterIP
+Service from a Pod inside the cluster:
+
+```shell
+kubectl --namespace openstack exec openstack-admin-client -- \
+  curl --fail --silent --show-error \
+  http://ironic-prometheus-exporter.openstack.svc.cluster.local:9608/metrics \
+  | head
+```
+
+An HTTP success response confirms that the Service can reach an exporter.
+Confirm that the response contains Ironic metrics and not only an empty
+response.
+
+!!! note
+
+    The manual ClusterIP request above selects one backend Pod and therefore
+    proves only that at least one exporter is reachable. OpenTelemetry does not
+    use that load-balanced path: `role: endpoints` creates one scrape target
+    for every ready endpoint published by the Service.
+
+To validate the same paths used by OpenTelemetry, query every endpoint IP from
+inside the cluster:
+
+```shell
+for ENDPOINT_IP in $(kubectl --namespace openstack get endpoints \
+  ironic-prometheus-exporter \
+  -o jsonpath='{.subsets[*].addresses[*].ip}'); do
+  echo "Checking ${ENDPOINT_IP}:9608"
+  kubectl --namespace openstack exec openstack-admin-client -- \
+    curl --fail --silent --show-error \
+    "http://${ENDPOINT_IP}:9608/metrics" >/dev/null
+done
+```
+
+Each endpoint should return successfully. If one fails, inspect the exporter
+sidecar and network path on that conductor's node.
+
+### Query Prometheus
+
+In Prometheus or Grafana Explore, start with:
+
+```promql
+up{job="ironic-prometheus-exporter"}
+```
+
+Each ready exporter endpoint should report a value of `1`. To inspect all
+metric families received for the job, use:
+
+```promql
+{job="ironic-prometheus-exporter"}
+```
+
+## Limitations
+
+- The available sensor metrics depend on the server hardware, BMC, and Ironic
+  hardware type.
+- Upstream exporter sensor parsing supports IPMI and Redfish data.
+- The exporter exposes Gauge metrics.
+- A successful exporter scrape does not prove that every BMC sensor collection
+  succeeded; conductor logs and metric freshness must also be monitored.
+
+## References
+
+For upstream details, see the
+- [Ironic Prometheus Exporter documentation](https://docs.openstack.org/ironic-prometheus-exporter/latest/)
+- [configuration reference](https://docs.openstack.org/ironic-prometheus-exporter/latest/configuration.html)
+- [limitations](https://docs.openstack.org/ironic-prometheus-exporter/latest/limitations.html)

--- a/docs/openstack-ironic-operational-guide.md
+++ b/docs/openstack-ironic-operational-guide.md
@@ -135,16 +135,16 @@ Expected result:
 Ironic Python Agent images are required for deployment and cleaning operations.
 
 ```bash
-curl -o ipa-centos9-stable-2025.2.initramfs https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos9-stable-2025.2.initramfs
-curl -o ipa-centos9-stable-2025.2.kernel https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos9-stable-2025.2.kernel
+curl -o ipa-centos9-stable-2026.1.initramfs https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos9-stable-2026.1.initramfs
+curl -o ipa-centos9-stable-2026.1.kernel https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos9-stable-2026.1.kernel
 
-openstack image create ipa-centos9-stable-2025.2-aki --public \
+openstack image create ipa-centos9-stable-2026.1-aki --public \
    --disk-format aki --container-format aki \
-   --file ipa-centos9-stable-2025.2.kernel
+   --file ipa-centos9-stable-2026.1.kernel
 
-openstack image create ipa-centos9-stable-2025.2-ari --public \
+openstack image create ipa-centos9-stable-2026.1-ari --public \
    --disk-format ari --container-format ari \
-   --file ipa-centos9-stable-2025.2.initramfs
+   --file ipa-centos9-stable-2026.1.initramfs
 ```
 
 ### Verify Core Resources
@@ -204,15 +204,15 @@ This example uses the `idrac` driver, Redfish-based management, and the `ipxe` b
 ```bash
 node=123456-compute1
 node_mac="aa:bb:cc:dd:ee:ff" # MAC address of PXE interface
-deploy_aki=ipa-centos9-stable-2025.2-aki
-deploy_ari=ipa-centos9-stable-2025.2-ari
+deploy_aki=ipa-centos9-stable-2026.1-aki
+deploy_ari=ipa-centos9-stable-2026.1-ari
 resource=GP2_XL
 phys_arch=x86_64
 phys_cpus=128
 phys_ram=720896
 phys_disk=960
 
-openstack baremetal node create --driver idrac \
+openstack baremetal node create --driver redfish \
   --boot-interface ipxe \
   --driver-info redfish_username=root \
   --driver-info redfish_password=<password> \
@@ -221,9 +221,8 @@ openstack baremetal node create --driver idrac \
   --driver-info redfish_system_id=/redfish/v1/Systems/System.Embedded.1 \
   --driver-info deploy_kernel=`openstack image show $deploy_aki -c id |awk '/id / {print $4}'` \
   --driver-info deploy_ramdisk=`openstack image show $deploy_ari -c id |awk '/id / {print $4}'` \
-  --inspect-interface idrac-redfish \
-  --management-interface idrac-redfish \
-  --power-interface idrac-redfish \
+  --management-interface redfish \
+  --power-interface redfish \
   --property cpus=$phys_cpus \
   --property memory_mb=$phys_ram \
   --property local_gb=$phys_disk \
@@ -260,8 +259,8 @@ This example uses the `redfish` driver with the `redfish-virtual-media` boot int
 ```bash
 node=123456-compute2
 node_mac="aa:bb:cc:dd:ee:ff" # MAC address of PXE interface
-deploy_aki=ipa-centos9-stable-2025.2-aki
-deploy_ari=ipa-centos9-stable-2025.2-ari
+deploy_aki=ipa-centos9-stable-2026.1-aki
+deploy_ari=ipa-centos9-stable-2026.1-ari
 deploy_bootloader=esp
 resource=GP2_XL
 phys_arch=x86_64

--- a/docs/openstack-ironic-operational-guide.md
+++ b/docs/openstack-ironic-operational-guide.md
@@ -1,25 +1,21 @@
 # OpenStack Ironic Operational Guide
 
-This guide provides an operational workflow for provisioning bare metal servers with OpenStack Ironic. It covers the major steps required to prepare the environment, enroll hardware, validate node readiness, and launch instances using either PXE/iPXE or virtual media boot.
-
-## Introduction
-
-OpenStack Ironic is the bare metal provisioning service in OpenStack. It allows operators to manage physical servers in a way that is similar to virtual machine lifecycle management, while still preserving direct access to dedicated hardware.
-
-This document is intended for operators who already have a working OpenStack environment and need a practical guide for day-to-day Ironic provisioning tasks.
+OpenStack Ironic is the bare metal provisioning service in OpenStack. This guide provides a practical operational workflow for operators who already have a working OpenStack environment. It covers preparing the environment, enrolling hardware, validating node readiness, and launching instances using either PXE/iPXE or virtual media boot.
 
 ## Scope And Assumptions
 
 This guide assumes the following:
 
-- The OpenStack control plane is already installed and operational.
-- Administrative credentials have already been sourced.
-- Required deployment, cleaning, and tenant images are already uploaded to Glance.
+- The OpenStack control plane, including Ironic and its supporting services, is installed and operational.
+- An administrative OpenStack credentials file is available to the operator.
+- The operator has permission to create networks, subnets, flavors, images, bare metal nodes, and instances.
+- A deployable tenant operating system image is already available in Glance.
 - The target node BMC is reachable from the Ironic conductor.
-- For PXE or iPXE boot, the provisioning network and network boot services are already configured.
-- For virtual media boot, the provisioning network is configured and the hardware supports a virtual media boot interface such as redfish-virtual-media.
+- Physical network connectivity between the Ironic services, bare-metal nodes, and their management controllers is available.
+- For PXE or iPXE boot, the provisioning network and network-boot services are available.
+- For virtual media boot, the provisioning network permits ramdisk connectivity and the hardware supports the `redfish-virtual-media` interface.
 
-Nova may not see a newly available node immediately after enrollment because the resource tracker updates periodically. In many environments this sync happens every 60 seconds, so a short delay is expected.
+The prerequisites in this guide source the administrative credentials, create the provisioning network and bare metal flavor, upload the Ironic Python Agent images, and verify the required OpenStack resources.
 
 ## High-Level Workflow
 
@@ -42,31 +38,18 @@ Validate node
    ->
 Manage node
    ->
+Optionally perform manual cleaning
+   ->
 Provide node
    ->
 Create server with matching flavor and required image
 ```
 
-## Purpose
-
-This guide walks through the following workflow:
-
-1. Create The Ironic Provisioning Network
-2. Create a flavor for bare metal server
-3. Set a resource class mapping so Nova can match the flavor to the correct Ironic node
-4. Enroll the physical node into Ironic with the correct driver and interfaces
-5. Set properties and driver details such as hardware specs, BMC credentials, and boot method
-6. Create ports so the node can participate in provisioning and tenant networking
-7. Validate step verifies that required fields are present and the interfaces such as power, management, deploy, boot, and others report valid/usable for the baremetal node
-8. Manage step moves the bare metal node from enroll to manageable by starting verification and confirming that Ironic can control the node using the configured interfaces and credentials.
-9. Provide the node to transition it into the available state, making it ready for scheduling.
-10. Create a server with the matching flavor and image using either PXE/iPXE or virtual media boot.
-
 Ironic supports multiple boot interfaces. PXE is the standard network boot mechanism, while virtual media typically relies on the BMC to mount boot media remotely instead of using traditional PXE infrastructure.
 
 ## Prerequisites
 
-Before enrolling a node, ensure that the OpenStack environment and all required services are properly configured and available. 
+Before enrolling a node, ensure that the OpenStack environment and all required services are properly configured and available.
 
 ### Source Administrative Credentials
 
@@ -112,11 +95,11 @@ openstack flavor set GP2.XL \
   --property resources:VCPU=0 \
   --property resources:MEMORY_MB=0 \
   --property resources:DISK_GB=0 \
-  --property capabilities:boot_option="local" \
+  --property capabilities:boot_mode="uefi" \
   --property resources:CUSTOM_GP2_XL=1
 ```
 
-The `CUSTOM_GP2_XL` property must match the `CUSTOM_<FLAVOR_NAME>` naming pattern used for the resource class. The standard flavor values still help communicate expected capacity to users, and the disk value is also used to determine root disk sizing behavior.
+The custom resource class must match the node's resource class. Nova represents an Ironic resource class by converting it to uppercase, replacing punctuation with underscores, and prefixing it with `CUSTOM_`. For example, the node resource class `GP2_XL` maps to `CUSTOM_GP2_XL`.
 
 Verify the flavor after creation:
 
@@ -145,6 +128,11 @@ openstack image create ipa-centos9-stable-2026.1-aki --public \
 openstack image create ipa-centos9-stable-2026.1-ari --public \
    --disk-format ari --container-format ari \
    --file ipa-centos9-stable-2026.1.initramfs
+
+openstack image create --container-format aki \
+ --disk-format aki \
+ --file </path/to/esp-image.img> \
+ ubuntu-noble-esp
 ```
 
 ### Verify Core Resources
@@ -191,19 +179,23 @@ Choose one of the following methods:
 1. PXE or iPXE boot
 2. Virtual media boot
 
-## Option A: Enroll A Node With PXE Or IPXE Boot
+!!! warning "Redfish TLS certificate verification"
+    The examples below set `redfish_verify_ca=False` to accommodate BMCs that use self-signed or otherwise untrusted certificates. This disables verification of the BMC's identity and can expose Redfish credentials and management operations to man-in-the-middle attacks. In production, leave this option unset or set it to `True` when the issuing CA is available in the conductor's trust store. Alternatively, set it to the path of a trusted CA certificate or certificate directory. Use `False` only as a documented exception on a controlled management network after assessing and accepting the risk.
+
+### Option A: Enroll A Node With PXE Or IPXE Boot
 
 PXE is the standard network boot path for hardware that supports network booting. In this model, the node downloads boot artifacts over the provisioning network.
 
 ![Deploy PXE](assets/images/ironic_direct_deploy_pxe.svg)
 
-### Create The Node
+#### Create The Node
 
-This example uses the `idrac` driver, Redfish-based management, and the `ipxe` boot interface.
+This example uses the `redfish` driver, Redfish-based management, and the `ipxe` boot interface.
 
 ```bash
 node=123456-compute1
 node_mac="aa:bb:cc:dd:ee:ff" # MAC address of PXE interface
+node_oob=x.x.x.x # Node ILO/IDRAC address
 deploy_aki=ipa-centos9-stable-2026.1-aki
 deploy_ari=ipa-centos9-stable-2026.1-ari
 resource=GP2_XL
@@ -215,19 +207,19 @@ phys_disk=960
 openstack baremetal node create --driver redfish \
   --boot-interface ipxe \
   --driver-info redfish_username=root \
-  --driver-info redfish_password=<password> \
-  --driver-info redfish_address=<OOB IP> \
+  --driver-info redfish_password=<REPLACE_WITH_PASSWORD> \
+  --driver-info redfish_address=https://${node_oob} \
   --driver-info redfish_verify_ca=False \
   --driver-info redfish_system_id=/redfish/v1/Systems/System.Embedded.1 \
-  --driver-info deploy_kernel=`openstack image show $deploy_aki -c id |awk '/id / {print $4}'` \
-  --driver-info deploy_ramdisk=`openstack image show $deploy_ari -c id |awk '/id / {print $4}'` \
+  --driver-info deploy_kernel=$(openstack image show "$deploy_aki" -c id -f value) \
+  --driver-info deploy_ramdisk=$(openstack image show "$deploy_ari" -c id -f value) \
   --management-interface redfish \
   --power-interface redfish \
   --property cpus=$phys_cpus \
   --property memory_mb=$phys_ram \
   --property local_gb=$phys_disk \
   --property cpu_arch=$phys_arch \
-  --property capabilities='boot_option:local,disk_label:gpt' \
+  --property capabilities='boot_mode:uefi' \
   --resource-class $resource \
   --network-interface flat \
   --name $node
@@ -244,7 +236,7 @@ openstack baremetal node clean --clean-steps '[{"interface": "deploy", "step": "
 openstack baremetal node provide $node
 ```
 
-## Option B: Enroll A Node With Virtual Media
+### Option B: Enroll A Node With Virtual Media
 
 Virtual media boot uses the server BMC to attach temporary boot media instead of depending on PXE infrastructure. This is commonly used with Redfish-capable hardware and UEFI-based booting.
 
@@ -252,16 +244,17 @@ Even when virtual media is used, the Ironic provisioning network is still requir
 
 ![Deploy Virtual Media](assets/images/ironic_direct_deploy_virtual_media.svg)
 
-### Create The Node
+#### Create The Node
 
 This example uses the `redfish` driver with the `redfish-virtual-media` boot interface.
 
 ```bash
 node=123456-compute2
-node_mac="aa:bb:cc:dd:ee:ff" # MAC address of PXE interface
+node_mac="aa:bb:cc:dd:ee:ff" # MAC address of provisioning interface
+node_oob=x.x.x.x # Node ILO/IDRAC address
 deploy_aki=ipa-centos9-stable-2026.1-aki
 deploy_ari=ipa-centos9-stable-2026.1-ari
-deploy_bootloader=esp
+deploy_bootloader=ubuntu-noble-esp
 resource=GP2_XL
 phys_arch=x86_64
 phys_cpus=128
@@ -271,7 +264,7 @@ phys_disk=960
 openstack baremetal node create --driver redfish \
   --driver-info redfish_address=https://${node_oob} \
   --driver-info redfish_username=root \
-  --driver-info redfish_password='<idrac-password>' \
+  --driver-info redfish_password=<REPLACE_WITH_PASSWORD> \
   --driver-info redfish_verify_ca=False \
   --name $node
 
@@ -280,18 +273,18 @@ openstack baremetal node set \
   $node
 
 openstack baremetal node set \
-  --driver-info bootloader=`openstack image show ${deploy_bootloader} -c id -f value` \
-  --driver-info deploy_kernel=`openstack image show ${deploy_aki} -c id -f value` \
-  --driver-info deploy_ramdisk=`openstack image show ${deploy_ari} -c id -f value` \
+  --driver-info bootloader=$(openstack image show ${deploy_bootloader} -c id -f value) \
+  --driver-info deploy_kernel=$(openstack image show "$deploy_aki" -c id -f value) \
+  --driver-info deploy_ramdisk=$(openstack image show "$deploy_ari" -c id -f value) \
   --property cpu_arch=$phys_arch \
   --property cpus=$phys_cpus \
   --property memory_mb=$phys_ram \
   --property local_gb=$phys_disk \
-  --property capabilities='boot_option:local,boot_mode:uefi' \
+  --property capabilities='boot_mode:uefi' \
   --resource-class $resource \
   $node
 
-openstack baremetal node set --property root_device='{"serial" : "CK0WW92CVXP0036P00NQ"}' \
+openstack baremetal node set --property root_device='{"serial" : "<REPLACE_WITH_DISK_SERIAL>"}' \
   $node
 
 openstack baremetal port create $node_mac \
@@ -339,22 +332,23 @@ openstack quota set --cores -1 --ram -1 --instances 100 `openstack project show 
 
 openstack server create \
   --flavor GP2.XL \
-  --image ubuntu-jammy-metal-simple \
-  --key-name <nova key name> \
-  --network baremetal-provisioning-network $node
-
---hint query='["=", "$hypervisor_hostname", "<baremetal_node_UUID>"]'
+  --image ubuntu-noble-metal-1 \
+  --use-config-drive \
+  --key-name "<key_name>" \
+  --hint query='["=", "$hypervisor_hostname", "<baremetal_node_UUID>"]' \
+  --network baremetal-provisioning-network \
+  $node
 
 openstack server list
 +--------------------------------------+-----------------------+--------+-----------------------------------------------+----------------------+-----------+
 | ID                                   | Name                  | Status | Networks                                      | Image                | Flavor    |
 +--------------------------------------+-----------------------+--------+-----------------------------------------------+----------------------+-----------+
-| c3f40ae6-b6ec-4c5d-a6e2-2e09cdfa1f7c | 123456-compute1       | ACTIVE | baremetal-provisioning-network=172.29.233.33  | ubuntu-jammy-metal-1 | GP2.XL    |
-| f55b4119-528a-41c3-8907-956047cb6854 | 123456-compute2       | ACTIVE | baremetal-provisioning-network=172.29.234.61  | ubuntu-jammy-metal-1 | GP2.XL    |
+| c3f40ae6-b6ec-4c5d-a6e2-2e09cdfa1f7c | 123456-compute1       | ACTIVE | baremetal-provisioning-network=172.29.233.33  | ubuntu-noble-metal-1 | GP2.XL    |
+| f55b4119-528a-41c3-8907-956047cb6854 | 123456-compute2       | ACTIVE | baremetal-provisioning-network=172.29.234.61  | ubuntu-noble-metal-1 | GP2.XL    |
 +--------------------------------------+-----------------------+--------+-----------------------------------------------+----------------------+-----------+
 ```
 
-If you need to target a specific bare metal host, use the scheduler hint shown in the example command.
+The scheduler hint shown in the example command is used to target a specific bare metal host.
 
 ## References
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -194,7 +194,9 @@ nav:
               - Memcached: infrastructure-memcached.md
               - Redis: infrastructure-redis.md
               - Libvirt: infrastructure-libvirt.md
-              - OVN: infrastructure-ovn-setup.md
+              - OVN:
+                  - OVN Setup: infrastructure-ovn-setup.md
+                  - OVN Ironic setup: infrastructure-ovn-ironic-setup.md
           - OpenStack:
               - openstack-overview.md
               - OpenStack Services:
@@ -214,6 +216,11 @@ nav:
                       - Placement: openstack-compute-kit-placement.md
                       - Nova: openstack-compute-kit-nova.md
                       - Neutron: openstack-compute-kit-neutron.md
+                  - Ironic:
+                      - Ironic Deployment: openstack-ironic.md
+                      - Ironic Policy: openstack-ironic-policy.md
+                      - Ironic Lifecycle Management: openstack-ironic-lifecycle-management.md
+                      - Ironic Operational Guide: openstack-ironic-operational-guide.md
                   - Dashboards:
                       - Horizon: openstack-horizon.md
                       - skyline: openstack-skyline.md
@@ -245,6 +252,7 @@ nav:
               - Grafana: monitoring-grafana.md
               - OpenStack Exporter: openstack-exporter.md
               - OpenStack Metrics Exporter: prometheus-openstack-metrics-exporter.md
+              - Ironic Prometheus Exporter: openstack-ironic-monitoring.md
               - Custom Node Metrics: prometheus-custom-node-metrics.md
               - Pushgateway: prometheus-pushgateway.md
               - Barbican Exporter: openstack-barbican-exporter.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -217,9 +217,9 @@ nav:
                       - Nova: openstack-compute-kit-nova.md
                       - Neutron: openstack-compute-kit-neutron.md
                   - Ironic:
+                      - Ironic Lifecycle Management: openstack-ironic-lifecycle-management.md
                       - Ironic Deployment: openstack-ironic.md
                       - Ironic Policy: openstack-ironic-policy.md
-                      - Ironic Lifecycle Management: openstack-ironic-lifecycle-management.md
                       - Ironic Operational Guide: openstack-ironic-operational-guide.md
                   - Dashboards:
                       - Horizon: openstack-horizon.md

--- a/openstack-components.yaml
+++ b/openstack-components.yaml
@@ -17,6 +17,7 @@ components:
   masakari: false
   neutron: true
   nova: true
+  ironic: false
   octavia: false
   placement: true
   skyline: true

--- a/releasenotes/notes/release-2026.1-ironic-38f1ac7fb88d9d53.yaml
+++ b/releasenotes/notes/release-2026.1-ironic-38f1ac7fb88d9d53.yaml
@@ -1,0 +1,230 @@
+---
+prelude: |
+  Genestack ``release-2026.1`` deploys Ironic from the OpenStack 2026.1
+  series. Ironic 35.0 is a SLURP release and supports a direct upgrade from
+  OpenStack 2025.1 (Ironic 29.0). This series adds trait-based networking,
+  automatic deploy-interface selection, improved Redfish inspection and
+  virtual-media support, and substantial API and deployment security
+  hardening.
+
+features:
+  - |
+    Genestack now enables periodic collection of Ironic conductor and bare-metal
+    hardware sensor data, including deployed and undeployed nodes. An
+    ``ironic-prometheus-exporter`` sidecar in every conductor pod exposes the
+    collected metrics on port 9608 through a dedicated Kubernetes Service. An
+    optional OpenTelemetry receiver can discover ready exporter endpoints and
+    forward their metrics to the configured monitoring backend; the standard
+    monitoring configuration also checks availability of the public Ironic API.
+  - |
+    The new ``autodetect`` deploy interface selects ``ramdisk``, ``bootc``, or
+    ``direct`` from image metadata and node configuration. Both ``autodetect``
+    and ``bootc`` are enabled by default, and ``ramdisk`` can now consume a
+    single suitably annotated Glance image.
+  - |
+    Trait-based networking can dynamically select ports and portgroups for
+    network attachment, including creating portgroups as needed. REST API
+    microversion 1.111 adds ``available_for_dynamic_portgroup`` to ports and
+    the read-only ``dynamic_portgroup`` field to portgroups.
+  - |
+    The experimental ``ironic-networking`` service provides switch
+    configuration through ``networking-generic-switch`` for standalone Ironic
+    deployments that do not use Neutron. OpenStack-integrated deployments also
+    gain VXLAN support and support for multiple physical switches.
+  - |
+    Redfish virtual-media boot now supports NFS and CIFS/SMB in addition to
+    HTTP. Ironic detects the transports advertised by the BMC, while operators
+    remain responsible for providing a share reachable by the BMC.
+  - |
+    Redfish out-of-band inspection now collects storage-controller, drive,
+    LLDP, port-speed, manufacturer, model, system UUID, and hardware-health
+    information. The ``health`` node field is exposed from API microversion
+    1.109 and is updated during periodic power synchronization for drivers that
+    implement health monitoring.
+  - |
+    Cleaning and servicing flows can skip IPA automatically when every step
+    declares ``requires_ramdisk=False``. Redfish BIOS configuration can poll
+    ``BootProgress`` and verify settings without booting IPA, and Redfish
+    firmware updates no longer require an in-band agent afterward.
+  - |
+    API microversion 1.110 permits aborting a deployment in ``DEPLOYWAIT``.
+    Deploy steps can declare whether they are abortable, matching clean and
+    service steps.
+  - |
+    Operators can load custom WSGI middleware through the
+    ``ironic.api.middleware`` entry-point namespace. Ironic 35.1 also adds
+    middleware that rejects JSON bodies exceeding configurable size or nesting
+    limits before parsing them.
+
+issues:
+  - |
+    Changing a node's ``owner`` does not update its parent or child nodes.
+    Operators must keep ownership consistent across related nodes; the upgrade
+    check warns when a node and its parent have different owners.
+  - |
+    NIC firmware inventory can be absent for newly enrolled nodes when a BMC
+    only exposes ``NetworkAdapters`` while the node is powered on. Validate
+    inventory after powering on or running the applicable cleaning or service
+    workflow.
+
+upgrade:
+  - |
+    Ironic now requires MySQL 8.0 or later, or MariaDB 10.3 or later, and
+    converts all existing tables from ``utf8mb3`` to ``utf8mb4`` during
+    ``ironic-dbsync upgrade``. Each table is locked while it is rewritten.
+    Plan control-plane downtime and test the migration against a copy of the
+    production database to estimate its duration, especially for large
+    deployments.
+  - |
+    Ironic Python Agent versions without in-band deploy-step support are no
+    longer compatible. Update old IPA kernel and ramdisk images before the
+    control-plane upgrade.
+  - |
+    Genestack sets ``[api]ramdisk_heartbeat_timeout=3600``, increasing the
+    maximum interval between Ironic Python Agent heartbeats from the upstream
+    default of 300 seconds. Account for the longer failure-detection window in
+    monitoring and automation; it accommodates long-running deployment and
+    provisioning operations that would otherwise time out.
+  - |
+    The default ``[DEFAULT]autodetect_deploy_interfaces`` value is now
+    ``ramdisk,bootc,direct``. Where ``autodetect`` is used, a Glance image with
+    ramdisk metadata can therefore select the ``ramdisk`` interface without an
+    explicit local override. Pin the option if the previous selection behavior
+    must be retained.
+  - |
+    Do not leave Redfish BIOS clean or service steps in progress during the
+    upgrade. The internal state changes to the structured
+    ``redfish_bios_state`` format. Ironic cleans up state from an operation
+    started by the old code when the next BIOS step is invoked.
+  - |
+    The deprecated ``inspector`` inspect interface has been removed. Migrate
+    nodes and configuration to the built-in ``agent`` inspection interface
+    before upgrading.
+  - |
+    Shellinabox support has been removed, including the
+    ``ipmitool-shellinabox`` console interface, the node web console that
+    depended on it, and the iLO ``console`` interface. Unset an explicitly
+    configured ``console_interface`` on affected iLO nodes and migrate console
+    workflows to a supported provider.
+  - |
+    Existing ports receive ``available_for_dynamic_portgroup=True`` and
+    existing portgroups receive ``dynamic_portgroup=False`` when the API 1.111
+    schema migration is applied. Review these defaults before enabling
+    trait-based networking on existing inventory.
+  - |
+    Generic Redfish inspection no longer stores ``sku`` in ``system_vendor``.
+    Dell service tags are reported as ``serial_number`` by the
+    ``idrac-redfish`` inspection interface. Update inspection rules or external
+    consumers that depend on the old field.
+  - |
+    The ``ilo`` console and inspector removals, database migration, deploy
+    interface defaults, and all security-related configuration changes should
+    be validated in a staging environment before conductors are upgraded.
+
+deprecations:
+  - |
+    The node ``driver_info`` value ``pxe_template`` is deprecated and is
+    expected to be removed in Ironic 2027.2. Absolute-path template overrides
+    are also disabled by default for security reasons; remove these overrides
+    instead of enabling the compatibility option.
+  - |
+    The Fujitsu ``irmc`` hardware type, all iRMC-specific interfaces, and the
+    ``[irmc]`` configuration options are deprecated. Operators should plan a
+    migration to a supported hardware type.
+  - |
+    Using ``ironic.api.wsgi:initialize_wsgi_app`` to select a custom
+    configuration file is deprecated. Use ``IRONIC_CONFIG_DIR`` and
+    ``IRONIC_CONFIG_FILE`` instead.
+  - |
+    The unused ``[drac]config_job_max_retries`` and
+    ``[drac]bios_factory_reset_timeout`` options are deprecated following the
+    earlier removal of the iDRAC WSMAN interfaces.
+
+critical:
+  - |
+    The mandatory ``utf8mb4`` database conversion rewrites and locks every
+    Ironic table. Do not treat this as an online migration: schedule downtime,
+    verify the database server version and row-format support, take a tested
+    backup, and measure the migration against production-like data first.
+
+security:
+  - |
+    Genestack now requires TLS for communication with Ironic Python Agent by
+    setting ``[agent]require_tls=True`` and ``[agent]verify_ca=True``. Callback
+    URLs without ``https://`` are rejected. Auto-generated certificates used
+    to validate ramdisk connections are stored in
+    ``[agent]certificates_path=/var/lib/ironic/certificates``. Ensure custom IPA
+    images and site overrides support TLS and preserve access to this directory
+    before upgrading.
+  - |
+    Ironic 35.1 includes fixes for ISO9660 path traversal (CVE-2026-48681),
+    unvalidated ``file://`` image sources that could exhaust conductor workers
+    (CVE-2026-44919), PXE template path overrides (CVE-2026-44917), and boot
+    script injection through ``kernel_append_params`` (CVE-2026-46447). Strict
+    kernel-parameter parsing is enabled by default and should not be disabled.
+  - |
+    The ``ipmitool`` vendor-passthru ``send_raw`` method is disabled by default.
+    Ironic recommends Redfish where possible; do not re-enable raw IPMI access
+    without a documented operational need and compensating access controls.
+  - |
+    IPA BIOS bootloader installation can be disabled with
+    ``enable_bios_bootloader_install=False`` to reduce exposure addressed by
+    CVE-2026-43003. The option remains ``True`` by default on this stable
+    branch for compatibility, so security-sensitive deployments must opt out.
+  - |
+    API authorization now prevents cross-project parent-node relationships and
+    reassignment of ports, portgroups, volume targets, and volume connectors
+    across node owners. Portgroup shard queries also apply owner and lessee
+    filtering.
+  - |
+    JSON body size and depth limits protect API workers from memory exhaustion
+    and recursion crashes. Review ``[api]max_json_body_size``,
+    ``[api]max_json_body_size_provision``,
+    ``[api]max_json_body_size_inspection``, and
+    ``[api]max_json_body_depth`` if clients submit unusually large payloads.
+  - |
+    The noVNC security proxy now bounds server-supplied failure reasons to
+    prevent a malicious BMC-side VNC server from exhausting proxy memory.
+    Volume-target responses also mask password-like iSCSI properties
+    independently of RBAC policy enforcement.
+
+fixes:
+  - |
+    Redfish firmware and BIOS updates receive more reliable task-state
+    handling, stabilization checks, timeout controls, reboot behavior, and Dell
+    iDRAC lifecycle-job detection. Power synchronization no longer interrupts
+    an in-progress firmware update.
+  - |
+    Redfish boot and power handling is more tolerant of BMC differences,
+    including full boot-parameter requests, transient power-on conflicts,
+    changes attempted during POST, missing Storage APIs or Volumes links, and
+    virtual-media slots without ``InsertMedia`` support.
+  - |
+    Inspection fixes cover MAC-address normalization, inspection-rule variable
+    interpolation, ``network.tags`` evaluation, missing inventory fields,
+    cleanup of inspection VIFs on failure, fast-track heartbeats, and graceful
+    shutdown before virtual-media ejection.
+  - |
+    Image handling now validates URLs before checksum calculation, streams
+    checksums while downloading large images, uses practical download chunk
+    sizes, supports secure Glance hashes, and correctly copies cached images
+    across filesystems or reuses an existing hard link.
+  - |
+    Networking fixes prevent orphaned Neutron ports for iPXE interfaces,
+    preserve physical-network consistency between ports and portgroups, use
+    service credentials for Neutron operations, and correctly unplug VIFs when
+    Nova reschedules a bare-metal instance.
+  - |
+    API fixes cover field-level RBAC decisions when callers request a limited
+    field set, masked volume-target update responses, portgroup shard filtering,
+    read-only virtual-media queries under concurrent operations, and node
+    deletion races that previously returned a misleading HTTP 409.
+
+other:
+  - |
+    Review the complete upstream Ironic 2026.1 series
+    [release notes](https://docs.openstack.org/releasenotes/ironic/2026.1.html)
+    before upgrading. The upstream page includes hardware- and driver-specific
+    changes that may apply to site-specific BMCs, out-of-tree drivers,
+    inspection rules, and firmware workflows beyond the Genestack highlights
+    above.

--- a/scripts/tests/lib/openstack.sh
+++ b/scripts/tests/lib/openstack.sh
@@ -392,3 +392,13 @@ detach_volume_from_server() {
 
     os_cmd server remove volume "${server}" "${volume}" 2>/dev/null || true
 }
+
+# List Ironic drivers
+list_baremetal_drivers() {
+    os_cmd baremetal driver list --fields name -f value
+}
+
+# List Ironic conductors and their health state
+list_baremetal_conductors() {
+    os_cmd baremetal conductor list -f value -c Hostname -c Alive
+}

--- a/testing/requirements.txt
+++ b/testing/requirements.txt
@@ -1,3 +1,4 @@
 python-openstackclient
 python-heatclient
+python-ironicclient
 ansible


### PR DESCRIPTION
- enable TLS for Ironic Python Agent communication and configure the certificate directory used to verify agent connections
- increase the ramdisk heartbeat timeout to accommodate longer-running deployment and provisioning operations
- configure Neutron as the DHCP provider and use the bare-metal provisioning network for both cleaning and provisioning workflows
- enable periodic collection of conductor and bare-metal hardware sensor data, including metrics from deployed and undeployed nodes
- configure the Prometheus exporter notification driver to write collected metrics to a shared directory
- run ironic-prometheus-exporter as a sidecar in every conductor pod, including health probes and access to Ironic configuration and metrics
- expose all healthy exporter sidecars through a dedicated Kubernetes Service on port 9608
- provide an optional OpenTelemetry receiver configuration that discovers ready exporter endpoints and forwards their metrics to the monitoring backend
- add an HTTP availability check for the public Ironic API and provide example OpenTelemetry instrumentation annotations for Ironic workloads
- document the monitoring architecture, configuration, deployment, validation, and troubleshooting procedures
- expand the documentation navigation to include Ironic operational, monitoring, lifecycle, policy, deployment, and OVN integration guides