### PR TITLE
OSPC-2243 Changes needed to enable database log list

### DIFF
--- a/ansible/roles/trove_enablement_techpreview/tasks/trove_helm_config.yml
+++ b/ansible/roles/trove_enablement_techpreview/tasks/trove_helm_config.yml
@@ -3,6 +3,24 @@
 # into the existing trove-helm-overrides.yaml.
 
 # =========================================================================
+# PART 0: SWIFT ROLE ASSIGNMENT FOR GUEST LOG PUBLISHING
+# =========================================================================
+# The trove service user needs the swiftoperator role on the service
+# project so the guest agent can publish database logs to Swift.
+
+- name: Ensure trove user has swiftoperator role for guest log publishing
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      source {{ genestack_venv }}/bin/activate
+      openstack --os-cloud {{ os_cloud }} role add \
+        --user trove --project service swiftoperator 2>/dev/null || true
+    executable: /bin/bash
+  environment:
+    HOME: "{{ ubuntu_home }}"
+  changed_when: false
+
+# =========================================================================
 # PART 1: GATHER REQUIRED IDS
 # =========================================================================
 

--- a/ansible/roles/trove_enablement_techpreview/templates/trove-guestagent.conf.j2
+++ b/ansible/roles/trove_enablement_techpreview/templates/trove-guestagent.conf.j2
@@ -16,7 +16,7 @@ notification_service_id = mysql:2f3ff068-2bfb-4f70-9a9d-a6bb65bc084b
 os_region_name = {{ trove_region_name }}
 swift_endpoint_type = internalURL
 swift_service_type = object-store
-swift_url = http://{{ trove_services_anchor_ip }}:8080/v1/AUTH_%(tenant_id)s
+swift_url = http://{{ trove_services_anchor_ip }}:8080/v1/AUTH_
 taskmanager_manager = trove.taskmanager.manager.Manager
 #transport_url = rabbit://trove:{{ trove_rabbitmq_password }}@rabbitmq.openstack.svc.cluster.local:5672/trove
 trove_auth_url = http://keystone-api.openstack.svc.cluster.local:5000/v3
@@ -62,6 +62,9 @@ usage_timeout = 400
 volume_support = true
 ignore_users = os_admin
 ignore_dbs = mysql, information_schema, performance_schema, sys
+guest_log_exposed_logs = general,slow_query
+database_service_uid = 1001
+database_service_gid = 1001
 
 [oslo_concurrency]
 lock_path = /var/lib/trove/tmp

--- a/ansible/roles/trove_enablement_techpreview/templates/trove-mysql-cloudinit.j2
+++ b/ansible/roles/trove_enablement_techpreview/templates/trove-mysql-cloudinit.j2
@@ -85,6 +85,14 @@ if [ -f /var/lib/trove-images/datastore-backup.tar ]; then
   docker push localhost:5000/mysql-backup:8.4
 fi
 
+# Disable trove-image-loader.service - we pre-load images via cloud-init
+# above, so the upstream loader is unnecessary and fails on Debian.
+# echo "Disabling trove-image-loader service"
+# systemctl disable trove-image-loader.service 2>/dev/null || true
+# systemctl mask trove-image-loader.service 2>/dev/null || true
+# But TODO: Re-enable this once datastore images are shipped via the
+# genestack-images repo and cloud-init image loading is removed.
+
 # guest-agent.service may have started already (it depends on
 # network.target, not cloud-init.target), so it likely loaded its config
 # before transport.conf was written. Force a restart so it picks up the

--- a/ansible/roles/trove_enablement_techpreview/templates/trove_default_helm_config.yaml
+++ b/ansible/roles/trove_enablement_techpreview/templates/trove_default_helm_config.yaml
@@ -129,6 +129,9 @@ conf:
       # Re-enable when upstream trove ships SQLAlchemy 2.x compat
       # for DBInstance.find_by (or we ship a patched trove image).
       enable_secure_rpc_messaging: false
+    mysql:
+      volume_support: true
+      guest_log_exposed_logs: general,slow_query
     network:
       enable_access_check: false
       network_isolation: true

--- a/base-helm-configs/trove/trove-helm-overrides.yaml
+++ b/base-helm-configs/trove/trove-helm-overrides.yaml
@@ -117,6 +117,7 @@ conf:
       # heat_url: null
     mysql:
       volume_support: true
+      guest_log_exposed_logs: general,slow_query
     cache:
       enabled: true
       backend: oslo_cache.memcache_pool

--- a/scripts/tests/test-trove.sh
+++ b/scripts/tests/test-trove.sh
@@ -643,8 +643,8 @@ main() {
     run_test "instance_restart"             test_instance_restart
 #    run_test "resize_instance"              test_resize_instance
     run_test "resize_volume"                test_resize_volume
-#    run_test "log_list"                     test_log_list
-#    run_test "log_enable_disable"           test_log_enable_disable
+   run_test "log_list"                     test_log_list
+   run_test "log_enable_disable"           test_log_enable_disable
 
     # ── backup & restore
     run_test "backup_create"                test_backup_create


### PR DESCRIPTION
This will **enable** below types of **logs** we can access on a **database instance**
**_general_**       : Almost every MySQL client connection/query/event           -- “What SQL is happening?”
**_slow_query_** : Queries that take longer than configured threshold            -- “Which queries are slow?”
**_guest_**           : Trove guest-agent + container + OS/MySQL startup logs  -- “Why did my database instance fail?”

**How to enable above?**
openstack database log list <instance_id> (guest logs are enabled by default)
openstack database log set <instance_id> general --enable
openstack database log set <instance_id> slow_query --enable

**After enabling you can see details of each type of logs like container, metafile, name, status etc…**
openstack database log show <instance_id> guest -f yaml
openstack database log show <instance_id> general -f yaml
openstack database log show <instance_id> slow_query -f yaml

**You can publish and tail the logs to and from swift conainer with below** 
openstack database log set <instance_id> guest --publish
openstack database log set <instance_id> slow_query --publish
openstack database log set <instance_id> general --publish
openstack database log tail <instance_id> guest
openstack database log tail <instance_id> slow_query
openstack database log tail <instance_id> general

**Validate logs in swift**
openstack container list
openstack object list database_logs
openstack object show database_logs <instance_id>/mysql-guest_metafile

**And finally to download the log to present working directly, use the save command**
openstack database log save  <instance_id> slow_query