### PR TITLE
feat(barbican): OSPC-2338: Adding PKCS#11 HSM support in hyperconverged lab

### DIFF
--- a/bin/install-barbican.sh
+++ b/bin/install-barbican.sh
@@ -138,6 +138,21 @@ set_args=(
     --set "conf.barbican.keystone_authtoken.memcache_secret_key=$(kubectl --namespace openstack get secret os-memcached -o jsonpath='{.data.memcache_secret_key}' | base64 -d)"
 )
 
+# Detects if missing PKCS#11 HSM p11_crypto_plugin and regenerates the file automatically.
+if [[ "${BARBICAN_HSM_ENABLED:-false}" == "true" ]] || [[ "${HYPERCONVERGED_BARBICAN_HSM:-false}" == "true" ]]; then
+
+    override_file="${SERVICE_CUSTOM_OVERRIDES}/barbican-helm-overrides.yaml"
+
+    # If override file is missing OR does not contain p11_crypto_plugin, regenerate it
+    if [[ ! -f "${override_file}" ]] || ! grep -q "p11_crypto_plugin" "${override_file}" 2>/dev/null; then
+        echo "HSM enabled but p11_crypto_plugin missing in ${override_file}. Regenerating..."
+        rm -f "${override_file}"
+        SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        source "${SCRIPT_DIR}/../scripts/lib/hyperconverged-common.sh"
+        writeServiceHelmOverrides "${GENESTACK_OVERRIDES_DIR}/helm-configs"
+    fi
+fi
+
 # PKCS#11 HSM PIN Injection
 # Reads PIN from barbican-hsm-credentials K8s Secret (created by create-secrets.sh).
 # No-op when secret doesn't exist or PIN is empty.
@@ -174,3 +189,22 @@ echo
 
 # Execute the command directly from the array
 "${helm_command[@]}"
+
+# Post-Install HSM Key Initialization
+# Runs ONLY in Hyperconverged lab when:
+#   1. BARBICAN_HSM_ENABLED=true (exported during automated hyperconverged lab run)
+#   2. HYPERCONVERGED_BARBICAN_HSM=true (set manually when running script directly)
+if [[ "${BARBICAN_HSM_ENABLED:-false}" == "true" ]] || [[ "${HYPERCONVERGED_BARBICAN_HSM:-false}" == "true" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+    if ! declare -f initBarbicanHSMKeys >/dev/null 2>&1; then
+        common_sh="${SCRIPT_DIR}/../scripts/lib/hyperconverged-common.sh"
+        if [[ -f "${common_sh}" ]]; then
+            source "${common_sh}" >/dev/null 2>&1 || true
+        fi
+    fi
+
+    if declare -f initBarbicanHSMKeys >/dev/null 2>&1; then
+        initBarbicanHSMKeys
+    fi
+fi

--- a/scripts/lib/hyperconverged-common.sh
+++ b/scripts/lib/hyperconverged-common.sh
@@ -168,6 +168,21 @@ function parseCommonArgs() {
         echo "manila-share enabled: manila control plane + share enablement (secrets, service image build, share type)"
     fi
 
+    # Resolve barbican-hsm pseudo service. It can be enabled with '-i barbican-hsm'
+    # or the legacy HYPERCONVERGED_BARBICAN_HSM=true environment variable, and disabled
+    # with '-e barbican-hsm' (which wins over both).
+    BARBICAN_HSM_ENABLED="${HYPERCONVERGED_BARBICAN_HSM:-false}"
+    if isIncluded barbican-hsm; then
+        BARBICAN_HSM_ENABLED=true
+    fi
+    if isExcluded barbican-hsm; then
+        BARBICAN_HSM_ENABLED=false
+    fi
+    export BARBICAN_HSM_ENABLED
+    if [ "${BARBICAN_HSM_ENABLED}" = "true" ]; then
+        echo "barbican-hsm enabled"
+    fi
+
     export RUN_EXTRAS
     export INCLUDE_LIST
     export EXCLUDE_LIST
@@ -798,7 +813,56 @@ EOF
     fi
 
     if [ ! -f "${config_base}/barbican/barbican-helm-overrides.yaml" ]; then
-        if [ "${CINDER_VOLUME_ENABLED:-false}" = "true" ]; then
+        if [[ "${BARBICAN_HSM_ENABLED:-false}" = "true" ]] || [[ "${HYPERCONVERGED_BARBICAN_HSM:-false}" = "true" ]]; then
+            cat > "${config_base}/barbican/barbican-helm-overrides.yaml" <<EOF
+---
+pod:
+  resources:
+    enabled: false
+
+  mounts:
+    barbican_api:
+      barbican_api:
+        volumeMounts:
+          - name: softhsm-tokens
+            mountPath: /var/lib/softhsm/tokens
+        volumes:
+          - name: softhsm-tokens
+            persistentVolumeClaim:
+              claimName: barbican-softhsm-tokens
+
+conf:
+  barbican_api_uwsgi:
+    uwsgi:
+      processes: 4
+  barbican:
+    oslo_messaging_notifications:
+      driver: noop
+    p11_crypto_plugin:
+      library_path: "/usr/lib/softhsm/libsofthsm2.so"
+      token_labels:
+        - "barbican_token"
+      slot_id: 1
+    crypto:
+      enabled_crypto_plugins:
+        - p11_crypto
+        - simple_crypto
+EOF
+            # Create PVC for SoftHSM2 token persistence
+            kubectl apply --namespace openstack -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: barbican-softhsm-tokens
+  namespace: openstack
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+EOF
+        elif [ "${CINDER_VOLUME_ENABLED:-false}" = "true" ]; then
             cat > "${config_base}/barbican/barbican-helm-overrides.yaml" <<EOF
 ---
 pod:
@@ -1521,6 +1585,101 @@ endpoints:
       public: https
 EOF
     fi
+}
+
+function initBarbicanHSMKeys() {
+    # Initializes SoftHSM2 token + generates MKEK/HMAC keys inside barbican pod.
+    # Idempotent — skips if token/keys already exist.
+    # Called only when BARBICAN_HSM_ENABLED=true or HYPERCONVERGED_BARBICAN_HSM = true (hyperconverged lab).
+
+    if [[ "${BARBICAN_HSM_ENABLED:-false}" != "true" ]] && [[ "${HYPERCONVERGED_BARBICAN_HSM:-false}" != "true" ]]; then
+        return 0
+    fi
+
+    echo "=== Barbican HSM Key Initialization ==="
+
+    local hsm_pin token_label library_path slot_id mkek_label hmac_label pod
+
+    hsm_pin="$(kubectl --namespace openstack get secret barbican-hsm-credentials \
+        -o jsonpath='{.data.pin}' 2>/dev/null | base64 -d)" || true
+    if [[ -z "${hsm_pin}" ]]; then
+        echo "ERROR: barbican-hsm-credentials not found. Run create-secrets.sh first."
+        return 1
+    fi
+
+    library_path="/usr/lib/softhsm/libsofthsm2.so"
+    token_label="barbican_token"
+    slot_id="1"
+    mkek_label="barbican_mkek"
+    hmac_label="barbican_hmac"
+
+    echo "Waiting for barbican-api pod..."
+    kubectl --namespace openstack wait --for=condition=ready pod \
+        -l application=barbican,component=api --timeout=300s
+
+    pod="$(kubectl --namespace openstack get pod \
+        -l application=barbican,component=api \
+        -o jsonpath='{.items[0].metadata.name}')"
+    echo "Using pod: ${pod}"
+
+    # Initialize SoftHSM2 token
+    echo "Checking SoftHSM2 token (${token_label})..."
+    if ! kubectl --namespace openstack exec "${pod}" -- \
+        softhsm2-util --show-slots 2>/dev/null | grep -q "${token_label}"; then
+        echo "Initializing token..."
+        kubectl --namespace openstack exec "${pod}" -- \
+            softhsm2-util --init-token --free \
+                --label "${token_label}" \
+                --pin "${hsm_pin}" \
+                --so-pin "${hsm_pin}"
+    else
+        echo "Token exists — OK"
+    fi
+
+    # Generate MKEK
+    echo "Checking MKEK (${mkek_label})..."
+    if kubectl --namespace openstack exec "${pod}" -- \
+        barbican-manage hsm check_mkek \
+            --library-path "${library_path}" \
+            --passphrase "${hsm_pin}" \
+            --slot-id "${slot_id}" \
+            --label "${mkek_label}" 2>/dev/null; then
+        echo "MKEK exists — OK"
+    else
+        echo "Generating MKEK..."
+        kubectl --namespace openstack exec "${pod}" -- \
+            barbican-manage hsm gen_mkek \
+                --library-path "${library_path}" \
+                --passphrase "${hsm_pin}" \
+                --slot-id "${slot_id}" \
+                --label "${mkek_label}" \
+                --length 32
+    fi
+
+    # Generate HMAC key
+    echo "Checking HMAC key (${hmac_label})..."
+    if kubectl --namespace openstack exec "${pod}" -- \
+        barbican-manage hsm check_hmac \
+            --library-path "${library_path}" \
+            --passphrase "${hsm_pin}" \
+            --slot-id "${slot_id}" \
+            --label "${hmac_label}" \
+            --key-type CKK_AES 2>/dev/null; then
+        echo "HMAC key exists — OK"
+    else
+        echo "Generating HMAC key..."
+        kubectl --namespace openstack exec "${pod}" -- \
+            barbican-manage hsm gen_hmac \
+                --library-path "${library_path}" \
+                --passphrase "${hsm_pin}" \
+                --slot-id "${slot_id}" \
+                --label "${hmac_label}" \
+                --key-type CKK_AES \
+                --length 32 \
+                --mechanism CKM_AES_KEY_GEN
+    fi
+
+    echo "=== HSM initialization complete ==="
 }
 
 function createPostSetupResources() {


### PR DESCRIPTION
Automating the `SoftHSM2` deployment and key initialization for adding `PKCS#11` HSM support in hyperconverged lab.
- Update `parseCommonArgs` in `hyperconverged-common.sh` to parse the `barbican-hsm` pseudo service via `-i barbican-hsm`, `-e barbican-hsm`, or `HYPERCONVERGED_BARBICAN_HSM` and update the `BARBICAN_HSM_ENABLED` flag.
- Add `SoftHSM2` Helm overrides in `writeServiceHelmOverrides`:
  - Enables `p11_crypto` and `simple_crypto` plugins.
  - Mounts `softhsm-tokens` PVC at `/var/lib/softhsm/tokens` inside `barbican-api` pod.
  - Automatically provisions the `barbican-softhsm-tokens` K8s PVC.
- Implement idempotent `initBarbicanHSMKeys` function in `hyperconverged-common.sh`:
  - Waits for `barbican-api` pod readiness.
  - Initializes `SoftHSM2` token (`barbican_token`) using PIN from `barbican-hsm-credentials`.
  - Generates `MKEK` ('`barbican_mkek`') and `HMAC` (`barbican_hmac`) keys inside the pod.
- Update `bin/install-barbican.sh`:
  - Auto-regenerates `barbican-helm-overrides.yaml` if `p11_crypto_plugin` configuration is missing.
  - Executes post-install key initialization when HSM mode is enabled.

_*Note: End-to-end testing is still pending in the hyperconverged lab until the Barbican image is backed with the SoftHSM2 package/library._

Refs: [OSPC-1979](https://rackspace.atlassian.net/browse/OSPC-1979)