### PR TITLE
chore(fix): correct fernet sync token resources requests and limits

### DIFF
--- a/base-kustomize/keystone/base/fix-fernet-credential-permissions.yaml
+++ b/base-kustomize/keystone/base/fix-fernet-credential-permissions.yaml
@@ -59,11 +59,11 @@ spec:
             readOnlyRootFilesystem: false
           resources:
             limits:
-              cpu: 100m
-              memory: 64Mi
+              cpu: 1000m
+              memory: 1Gi
             requests:
-              cpu: 50m
-              memory: 16Mi
+              cpu: 500m
+              memory: 256Mi
       containers:
         - name: keystone-api
           volumeMounts:


### PR DESCRIPTION
To clear poundcake monitoring alerts, correctly set the resource request/limist for the fernet syncing sidecar in keystone.  