### PR TITLE
OSPC-2276 Database instance going into ERROR state overnight

### DIFF
--- a/ansible/roles/trove_enablement_techpreview/files/elements/debian-guest/install.d/11-user
+++ b/ansible/roles/trove_enablement_techpreview/files/elements/debian-guest/install.d/11-user
@@ -17,3 +17,11 @@ ${GUEST_USERNAME}
 ${GUEST_USERNAME}
 _EOF_
 fi
+
+# Ensure group membership is applied even when the base image already
+# created ${GUEST_USERNAME} (in which case the useradd block above is
+# skipped and its -G sudo never takes effect). usermod -aG is idempotent.
+#   sudo            -> privilege escalation
+#   adm, systemd-journal -> read the journal (e.g. journalctl -u
+#                      trove-mgmt-dhclient) without needing sudo
+usermod -aG sudo,adm,systemd-journal ${GUEST_USERNAME}

--- a/ansible/roles/trove_enablement_techpreview/files/elements/debian-guest/post-install.d/14-classless-routes-hook
+++ b/ansible/roles/trove_enablement_techpreview/files/elements/debian-guest/post-install.d/14-classless-routes-hook
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Fix the isc-dhcp-client rfc3442 classless-static-routes exit hook so it
+# reinstalls DHCP option 121 routes on ALL dhclient lease events, not just
+# BOUND/REBOOT.
+#
+# Background
+# ----------
+# The Trove management network delivers the guest's routes to the anchor
+# gateway via DHCP option 121 -- specifically 0.0.0.0/1 and 128.0.0.0/1 via
+# the mgmt gateway (see trove_mgmt_network.yml: the --host-route pair).
+# Those routes are the guest's only path to in-cluster RabbitMQ, Keystone,
+# and Swift (reached through the trove-mgmt-bridge anchor).
+#
+# On Debian, isc-dhcp-client processes option 121 only through the
+# /etc/dhcp/dhclient-exit-hooks.d/rfc3442-classless-routes hook. The stock
+# hook (a) ships non-executable and (b) only installs routes on BOUND/REBOOT.
+# Handling RENEW/REBIND fixed forced-renewal route loss, but instances still
+# lose their RabbitMQ connection at ~12h, which correlates with the DHCP
+# lease timeout. This version is the "handle everything" experiment: it acts
+# on all reasons that can touch routes, and falls back to the previous
+# lease's route data (old_*) when the current lease data (new_*) is empty --
+# which is what happens on EXPIRE. It also logs the reason + interface
+# address to /var/log/trove-dhcp-reason.log so we can tell, after the next
+# ~12h failure, whether the address itself survived (hook can help) or was
+# torn down (hook cannot help and we pivot to a lease-independent fix).
+#
+# NOTE (experiment caveat): on EXPIRE the lease is gone and dhclient-script
+# also removes the interface address; re-adding routes may not stick if the
+# address is torn down. The logger is what makes this experiment conclusive.
+set -e
+set -o xtrace
+
+HOOK=/etc/dhcp/dhclient-exit-hooks.d/rfc3442-classless-routes
+
+cat > "${HOOK}" <<'EOF'
+# Set classless static routes (DHCP option 121, RFC 3442) on every lease
+# event. Genestack experiment: handle all reasons, fall back to old_* route
+# data when new_* is empty (EXPIRE), use idempotent "ip route replace".
+
+# Diagnostic: record what fired and whether the interface still has an addr.
+echo "$(date -u +%FT%TZ) reason=${reason} new=[${new_rfc3442_classless_static_routes:+set}] old=[${old_rfc3442_classless_static_routes:+set}] addr=[$(ip -br addr show ${interface:-ens4} 2>/dev/null | awk '{print $3}')]" >> /var/log/trove-dhcp-reason.log 2>/dev/null
+
+RUN="yes"
+
+if [ "$RUN" = "yes" ]; then
+	# Act on any reason that can add/remove routes. On teardown reasons the
+	# current-lease var is empty, so fall back to the previous lease's routes.
+	case "$reason" in
+		BOUND|RENEW|REBIND|REBOOT|EXPIRE|STOP|RELEASE|FAIL|TIMEOUT) ;;
+		*) return 0 ;;
+	esac
+
+	routes="${new_rfc3442_classless_static_routes:-$old_rfc3442_classless_static_routes}"
+
+	if [ -n "$routes" ]; then
+		set -- $routes
+
+		while [ $# -gt 0 ]; do
+			net_length=$1
+			via_arg=''
+
+			case $net_length in
+				32|31|30|29|28|27|26|25)
+					if [ $# -lt 9 ]; then
+						return 1
+					fi
+					net_address="${2}.${3}.${4}.${5}"
+					gateway="${6}.${7}.${8}.${9}"
+					shift 9
+					;;
+				24|23|22|21|20|19|18|17)
+					if [ $# -lt 8 ]; then
+						return 1
+					fi
+					net_address="${2}.${3}.${4}.0"
+					gateway="${5}.${6}.${7}.${8}"
+					shift 8
+					;;
+				16|15|14|13|12|11|10|9)
+					if [ $# -lt 7 ]; then
+						return 1
+					fi
+					net_address="${2}.${3}.0.0"
+					gateway="${4}.${5}.${6}.${7}"
+					shift 7
+					;;
+				8|7|6|5|4|3|2|1)
+					if [ $# -lt 6 ]; then
+						return 1
+					fi
+					net_address="${2}.0.0.0"
+					gateway="${3}.${4}.${5}.${6}"
+					shift 6
+					;;
+				0)	# default route
+					if [ $# -lt 5 ]; then
+						return 1
+					fi
+					net_address="0.0.0.0"
+					gateway="${2}.${3}.${4}.${5}"
+					shift 5
+					;;
+				*)	# error
+					return 1
+					;;
+			esac
+
+			# take care of link-local routes
+			if [ "${gateway}" != '0.0.0.0' ]; then
+				via_arg="via ${gateway}"
+			fi
+
+			# replace route (idempotent: add if missing, update if present;
+			# ip detects host routes automatically)
+			ip -4 route replace "${net_address}/${net_length}" \
+				${via_arg} dev "${interface}" >/dev/null 2>&1
+		done
+	fi
+fi
+EOF
+
+chmod +x "${HOOK}"

--- a/ansible/roles/trove_enablement_techpreview/files/elements/debian-guest/post-install.d/15-remove-stale-eth-stanzas
+++ b/ansible/roles/trove_enablement_techpreview/files/elements/debian-guest/post-install.d/15-remove-stale-eth-stanzas
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Remove stale eth0/eth1 ifupdown stanzas shipped by the base DIB elements.
+#
+# The base/vm/debian-minimal elements populate /etc/network/interfaces.d/
+# with generic "auto eth0 / iface eth0 inet dhcp" (and eth1) stanzas. On
+# these guests the real NICs are ens3 (tenant) and ens4 (Trove mgmt), so
+# eth0/eth1 do not exist. "ifup -a" (networking.service) then tries to
+# bring up eth0/eth1, fails, and exits non-zero -- which leaves ifupdown's
+# state machine inconsistent and, critically, means isc-dhcp-client is not
+# left running as a persistent renewing daemon for ens4.
+#
+# With no resident dhclient, the ens4 DHCP lease is acquired once at boot
+# and never renewed at T1/T2; it lapses at expiry (~12h), dhclient removes
+# the ens4 address, all mgmt routes (0.0.0.0/1 + 128.0.0.0/1 via the anchor)
+# disappear, and the guest-agent loses RabbitMQ with "[Errno 101]
+# ENETUNREACH" until a reboot. Removing these bogus stanzas lets "ifup -a"
+# succeed so networking is managed cleanly. (See also 16-mgmt-dhcp-renew for
+# a persistent-renewal safeguard.)
+set -e
+set -o xtrace
+
+for stanza in /etc/network/interfaces.d/eth0 /etc/network/interfaces.d/eth1; do
+    if [ -f "${stanza}" ]; then
+        rm -f "${stanza}"
+    fi
+done

--- a/ansible/roles/trove_enablement_techpreview/files/elements/debian-guest/post-install.d/16-mgmt-dhcp-renew
+++ b/ansible/roles/trove_enablement_techpreview/files/elements/debian-guest/post-install.d/16-mgmt-dhcp-renew
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Guarantee a persistent, renewing DHCP client on the Trove mgmt NIC (ens4).
+#
+# Root cause this addresses:
+# On the Debian guest (ifupdown + isc-dhcp-client, no systemd-networkd), the
+# ens4 DHCP lease is acquired once at boot but no dhclient daemon is left
+# resident to renew it. The lease is never renewed at T1/T2 and lapses at
+# expiry (~12h); dhclient then removes the ens4 IPv4 address, every route
+# through it (the mgmt routes 0.0.0.0/1 + 128.0.0.0/1 via the anchor gateway)
+# is dropped, and the guest-agent loses its RabbitMQ/Keystone/Swift path with
+# "[Errno 101] ENETUNREACH" until reboot. Ubuntu guests use systemd-networkd,
+# which renews the lease in-daemon -- which is why this was Debian-only.
+#
+# This installs a systemd service that runs dhclient in the foreground (-d)
+# for ens4 only, so a renewing client is always resident. dhclient handles
+# T1/T2 renewal itself; systemd restarts it if it ever exits. The rfc3442
+# exit hook (see 14-classless-routes-hook) reinstalls the option-121 routes
+# on each renewal event.
+set -e
+set -o xtrace
+
+UNIT=/etc/systemd/system/trove-mgmt-dhclient.service
+
+cat > "${UNIT}" <<'EOF'
+[Unit]
+Description=Persistent renewing DHCP client for Trove mgmt NIC (ens4)
+Documentation=man:dhclient(8)
+# Wait for the interface to exist before starting.
+After=network.target
+Wants=network.target
+
+[Service]
+Type=simple
+# -d: run in foreground so systemd supervises it and it stays resident to
+# renew the lease at T1/T2. -4: IPv4 only. Single interface: ens4.
+ExecStart=/sbin/dhclient -d -4 ens4
+Restart=always
+RestartSec=5
+# Only start once ens4 is present; if not, keep retrying.
+ExecStartPre=/bin/sh -c 'until ip link show ens4 >/dev/null 2>&1; do sleep 2; done'
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl enable trove-mgmt-dhclient.service

--- a/ansible/roles/trove_enablement_techpreview/files/elements/debian-guest/post-install.d/17-reap-ens3-dhclient
+++ b/ansible/roles/trove_enablement_techpreview/files/elements/debian-guest/post-install.d/17-reap-ens3-dhclient
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Reap the orphaned ens3 dhclient after Trove's prepare step tears down ens3.
+#
+# Trove's guest prepare, by design, removes the tenant NIC (ens3) and
+# repurposes it into a veth/bridge for the datastore docker container. The
+# dhclient that ifupdown started for ens3 at boot is NOT stopped when the
+# interface goes away, so it keeps sending DHCPDISCOVERs against a
+# non-existent interface forever:
+#   dhclient[423]: DHCPDISCOVER on ens3 ...
+#   dhclient[423]: dhclient.c:2600: Failed to send ... over ens3 interface.
+# These are harmless (the mgmt path is ens4, which is healthy) but they spam
+# the logs every few seconds, bury real ens4 events, and waste cycles.
+#
+# IMPORTANT (why this is Type=simple and ordered After=cloud-final):
+# This service waits for ens3 to disappear, which does not happen until
+# Trove's guest-agent prepare runs -- i.e. AFTER cloud-init has finished.
+# It must therefore never sit in the boot-critical path. An earlier version
+# used Type=oneshot + WantedBy=multi-user.target with a blocking "while"
+# loop; because multi-user.target waits for oneshot units to complete, that
+# blocked multi-user.target forever, which in turn blocked cloud-final.service
+# (ordered After=multi-user.target) -- so cloud-init's final stage (and the
+# mysql cloud-init shellscript) never ran. Using Type=simple means systemd
+# considers the unit "started" as soon as it forks, so it never blocks the
+# boot transaction, and ordering it After=cloud-final guarantees it can't
+# precede cloud-init's final stage.
+set -e
+set -o xtrace
+
+UNIT=/etc/systemd/system/trove-reap-ens3-dhclient.service
+
+cat > "${UNIT}" <<'EOF'
+[Unit]
+Description=Reap orphaned ens3 dhclient after Trove prepare tears down ens3
+# Run only after cloud-init has fully finished so we never block its stages.
+After=cloud-final.service network.target
+Wants=cloud-final.service
+
+[Service]
+# Type=simple: considered started as soon as the process forks, so nothing
+# (multi-user.target, cloud-final) ever waits on this to "complete". The
+# blocking wait below therefore cannot stall the boot transaction.
+Type=simple
+ExecStart=/bin/sh -c '\
+  while ip link show ens3 >/dev/null 2>&1; do sleep 10; done; \
+  if [ -f /run/dhclient.ens3.pid ]; then \
+    /sbin/dhclient -x -pf /run/dhclient.ens3.pid >/dev/null 2>&1 || true; \
+  fi; \
+  pkill -f "dhclient.*ens3" 2>/dev/null || true; \
+  echo "ens3 gone; dhclient reaped"'
+# Do not restart: once ens3 is reaped the job is done. If ens3 never goes
+# away (non-Trove use), the process simply waits harmlessly.
+Restart=no
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl enable trove-reap-ens3-dhclient.service

--- a/ansible/roles/trove_enablement_techpreview/templates/trove-mgmt-bridge-daemonset.yaml.j2
+++ b/ansible/roles/trove_enablement_techpreview/templates/trove-mgmt-bridge-daemonset.yaml.j2
@@ -35,6 +35,21 @@ spec:
       # Init container moves t-mgmt0 from root netns into the pod netns
       # using the host PID of the init process, so we need hostPID=true.
       hostPID: true
+      # Tune TCP keepalive for the haproxy sockets. The config enables
+      # keepalive via option clitcpka/srvtcpka, but the kernel defaults
+      # (tcp_keepalive_time=7200s) are far too long to catch a silently
+      # half-open guest-agent<->RabbitMQ connection. These namespaced
+      # sysctls make the kernel start probing an idle socket after 5min
+      # and tear down a dead peer within ~2min of probing, forcing a
+      # prompt guest reconnect instead of blackholing the next publish.
+      securityContext:
+        sysctls:
+          - name: net.ipv4.tcp_keepalive_time
+            value: "300"
+          - name: net.ipv4.tcp_keepalive_intvl
+            value: "30"
+          - name: net.ipv4.tcp_keepalive_probes
+            value: "4"
       tolerations:
         - operator: Exists
       volumes:

--- a/ansible/roles/trove_enablement_techpreview/templates/trove-mgmt-bridge-haproxy.cfg.j2
+++ b/ansible/roles/trove_enablement_techpreview/templates/trove-mgmt-bridge-haproxy.cfg.j2
@@ -6,9 +6,22 @@ defaults
   mode tcp
   log global
   option tcplog
+  # Kernel TCP keepalive on both legs. The guest-agent<->RabbitMQ AMQP
+  # connection is long-lived and mostly idle (only ~20s heartbeat frames).
+  # oslo.messaging heartbeats are application frames written into the send
+  # buffer; they do NOT detect a silently half-open socket. With keepalive
+  # on, the kernel probes idle sockets (see keepalive sysctls on the pod)
+  # and tears down a dead peer in minutes, forcing the guest to reconnect
+  # through a healthy path instead of blackholing the next publish.
+  option clitcpka
+  option srvtcpka
   timeout connect 5s
   timeout client 1h
   timeout server 1h
+  # Bound the established tunnel phase explicitly. Unset, HAProxy uses the
+  # client/server inactivity timeouts for the tunnel; setting it makes a
+  # stale AMQP tunnel get recycled rather than lingering indefinitely.
+  timeout tunnel 1h
 
 # RabbitMQ — trove-guestagent oslo.messaging backplane.
 frontend rabbitmq_in


### PR DESCRIPTION
## Summary

Trove database guests built on **Debian** lost connectivity to RabbitMQ after ~12 hours (`[Errno 101] ENETUNREACH`), after which the guest agent looped on reconnect and only a reboot restored service — until it recurred. Ubuntu-based guests were unaffected.

**Root cause:** The Trove management NIC (`ens4`) receives its routes to the in-cluster RabbitMQ/Keystone/Swift anchor via DHCP option 121 (classless static routes). On the Debian guest image the mgmt DHCP lease (~12h) was **never renewed** — no persistent DHCP client was maintaining it — so at lease expiry the interface address and all its routes were torn down, breaking the guest agent's messaging path. This is Debian-specific: Ubuntu images use systemd-networkd (renews leases in-daemon), while the `debian-minimal` image uses ifupdown + isc-dhcp-client, which was not keeping a renewing client alive.

While tracing this, several related defects in the Debian guest image's network handling were also found and fixed.

## Changes

All changes are in the `debian-guest` diskimage-builder element.

| File | Fix |
|------|-----|
| `post-install.d/16-mgmt-dhcp-renew` | **Core fix.** Installs a systemd unit running a persistent `dhclient -d -4 ens4`, so the mgmt lease is renewed at T1 and never lapses. |
| `post-install.d/14-classless-routes-hook` | The stock `rfc3442-classless-routes` hook shipped non-executable (so option 121 was ignored) and, even when executable, only installed routes on `BOUND`/`REBOOT` — not `RENEW`/`REBIND`. Rewritten to handle all lease events (with `old_*` fallback for `EXPIRE`) using idempotent `ip route replace`, so routes survive renewals. |
| `post-install.d/15-remove-stale-eth-stanzas` | Base image shipped `eth0`/`eth1` ifupdown stanzas for NICs that don't exist on these guests (`ens3`/`ens4`), causing `ifup -a` / `networking.service` to fail. Removed. |
| `post-install.d/17-reap-ens3-dhclient` | Trove's prepare step tears down `ens3` (repurposed for the datastore container bridge), but its boot-time dhclient kept sending DHCPDISCOVERs to the missing interface indefinitely, spamming logs. Adds a unit that waits for `ens3` to disappear, then gracefully reaps its dhclient. |
| `install.d/11-user` | Group membership (`usermod -G sudo`) only applied when the user was newly created, but the base image pre-creates `debian`, so it was skipped. Made membership unconditional (`usermod -aG sudo,adm,systemd-journal debian`; `adm`/`systemd-journal` allow reading journald without sudo). |

### Also included (general hardening)

Added while investigating a suspected transport-layer cause. Not the root-cause fix, but harmless defense-in-depth:

- `trove-mgmt-bridge` HAProxy config: `option clitcpka`, `option srvtcpka`, `timeout tunnel 1h`.
- `trove-mgmt-bridge` DaemonSet: TCP keepalive sysctls (`tcp_keepalive_time=300`, `tcp_keepalive_intvl=30`, `tcp_keepalive_probes=4`).

## Testing

Validated on an instance built from the updated image:

- `ens4` logged continuous `RENEW` events over 23+ hours with the address and both mgmt routes (`0.0.0.0/1`, `128.0.0.0/1`) remaining present — well past the previous ~12h failure point.
- DHCP client logs show `bound to <addr> -- renewal in <N> seconds` followed by successful `DHCPREQUEST`/`DHCPACK` renewals (the renewal that previously never occurred).
- Instance remained `ACTIVE` / `HEALTHY` throughout.
- Confirmed the `ens3` reaper eliminates the orphaned-dhclient log spam after Trove prepare.

## Notes

The DHCP route-hook fix (`14`) addresses a real latent bug but was not the ~12h trigger on its own; the persistent renewing client (`16`) is what resolves the reported symptom. Both are needed for correct behavior across lease renewals.