### PR TITLE
fix: Updating octavia to utilize redis sentinels

### DIFF
--- a/base-helm-configs/octavia/octavia-helm-overrides.yaml
+++ b/base-helm-configs/octavia/octavia-helm-overrides.yaml
@@ -158,6 +158,11 @@ conf:
       insecure: true
     task_flow:
       jobboard_enabled: false
+      jobboard_backend_driver: redis_taskflow_driver
+      jobboard_redis_sentinel: myMaster
+      jobboard_redis_backend_db: 0
+      jobboard_redis_backend_ssl_options: "ssl:False"
+      jobboard_redis_sentinel_ssl_options: "ssl:False"
   octavia_api_uwsgi:
     uwsgi:
       processes: 2
@@ -231,15 +236,15 @@ endpoints:
   valkey:
     name: valkey
     hosts:
-      default: redis-replication-master.redis-systems.svc.cluster.local
+      default: redis-sentinel-sentinel.redis-systems.svc.cluster.local
     # NOTE(rlin): we should only provide password when not using CA cert.
     password: null
     host_fqdn_override:
-      default: redis-replication-master.redis-systems.svc.cluster.local
+      default: redis-sentinel-sentinel.redis-systems.svc.cluster.local
     port:
       server:
-        default: 6379
-        sentinel: 6379
+        default: 26379
+        sentinel: 26379
 
 # NOTE: (brew) requests cpu/mem values based on a three node
 # hyperconverged lab (/scripts/hyperconverged-lab.sh).

--- a/base-helm-configs/octavia/octavia-helm-overrides.yaml
+++ b/base-helm-configs/octavia/octavia-helm-overrides.yaml
@@ -163,6 +163,12 @@ conf:
       jobboard_redis_backend_db: 0
       jobboard_redis_backend_ssl_options: "ssl:False"
       jobboard_redis_sentinel_ssl_options: "ssl:False"
+      jobboard_backend_port: 26379
+      jobboard_backend_hosts:
+        - redis-sentinel-sentinel-0.redis-sentinel-sentinel-headless.redis-systems.svc.cluster.local
+        - redis-sentinel-sentinel-1.redis-sentinel-sentinel-headless.redis-systems.svc.cluster.local
+        - redis-sentinel-sentinel-2.redis-sentinel-sentinel-headless.redis-systems.svc.cluster.local
+
   octavia_api_uwsgi:
     uwsgi:
       processes: 2

--- a/releasenotes/notes/octavia-redis-sentinel-c3eaab3d38846e4b.yaml
+++ b/releasenotes/notes/octavia-redis-sentinel-c3eaab3d38846e4b.yaml
@@ -1,0 +1,9 @@
+---
+prelude: >
+    Octavia now uses Redis Sentinel endpoints.
+other:
+  - |
+    Octavia has been configured to use individual Redis Sentinel endpoints
+    rather than the master replication service endpoint. This allows the
+    redis client to better handle Redis communications while avoiding
+    potential service endpoint outages.


### PR DESCRIPTION
This change updates Octavia to utilize the individual Redis Sentinel endpoints rather than the replication master service in order to better take advantage of redis client behavior and expectations. 