### PR TITLE
fix: drop OpenStack config options deprecated as of Gazpacho

### DIFF
--- a/base-helm-configs/barbican/barbican-helm-overrides.yaml
+++ b/base-helm-configs/barbican/barbican-helm-overrides.yaml
@@ -52,7 +52,6 @@ conf:
       connection_debug: 0
       connection_recycle_time: 600
       connection_trace: true
-      idle_timeout: 3600
       mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60

--- a/base-helm-configs/blazar/blazar-helm-overrides.yaml
+++ b/base-helm-configs/blazar/blazar-helm-overrides.yaml
@@ -64,7 +64,6 @@ conf:
       connection_debug: 0
       connection_recycle_time: 600
       connection_trace: true
-      idle_timeout: 3600
       mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60

--- a/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
+++ b/base-helm-configs/ceilometer/ceilometer-helm-overrides.yaml
@@ -67,7 +67,6 @@ conf:
       connection_debug: 0
       connection_recycle_time: 600
       connection_trace: true
-      idle_timeout: 3600
       mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60

--- a/base-helm-configs/cinder/cinder-helm-overrides.yaml
+++ b/base-helm-configs/cinder/cinder-helm-overrides.yaml
@@ -157,7 +157,6 @@ conf:
       connection_debug: 0
       connection_recycle_time: 600
       connection_trace: true
-      idle_timeout: 3600
       mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60

--- a/base-helm-configs/designate/designate-helm-overrides.yaml
+++ b/base-helm-configs/designate/designate-helm-overrides.yaml
@@ -167,7 +167,6 @@ conf:
       connection_debug: 0
       connection_recycle_time: 600
       connection_trace: true
-      idle_timeout: 3600
       mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60

--- a/base-helm-configs/freezer/freezer-helm-overrides.yaml
+++ b/base-helm-configs/freezer/freezer-helm-overrides.yaml
@@ -55,7 +55,6 @@ conf:
       connection_debug: 0
       connection_recycle_time: 600
       connection_trace: true
-      idle_timeout: 3600
       mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60

--- a/base-helm-configs/glance/glance-helm-overrides.yaml
+++ b/base-helm-configs/glance/glance-helm-overrides.yaml
@@ -55,7 +55,6 @@ network_policy:
 conf:
   glance:
     DEFAULT:
-      workers: 2
       # NOTE(cloudnull): This option is required when using the new glance multi-backend feature.
       #                  The example below is for the rxt_swift backend, but could easily be used
       #                  for other backends.
@@ -77,10 +76,6 @@ conf:
       #                  option should be set to the name of the default backend section.
       # default_backend: rxt_swift
       filesystem_store_datadir: /var/lib/glance/images
-      swift_auth_address: https://swift.cluster.local
-      swift_auth_version: 3
-      swift_user: glance:glance-store
-      swift_password: override_from_your_secrets_files
     rxt_swift:
       swift_store_auth_address: http://keystone-api.openstack.svc.cluster.local:5000/v3
       swift_store_create_container_on_put: true
@@ -91,7 +86,6 @@ conf:
       connection_debug: 0
       connection_recycle_time: 600
       connection_trace: true
-      idle_timeout: 3600
       mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60
@@ -146,10 +140,12 @@ conf:
     user = {{ .Values.endpoints.ceph_object_store.auth.glance.username }}:swift
     key = {{ .Values.endpoints.ceph_object_store.auth.glance.password }}
     {{- else if eq .Values.storage "swift" }}
-    auth_version = {{ .Values.conf.glance.glance_store.swift_auth_version }}
-    auth_address = {{ .Values.conf.glance.glance_store.swift_auth_address }}
-    user = {{ .Values.conf.glance.glance_store.swift_user }}
-    key = {{ .Values.conf.glance.glance_store.swift_password }}
+    auth_version = 3
+    auth_address = {{ tuple "identity" "internal" "api" . | include "helm-toolkit.endpoints.keystone_endpoint_uri_lookup" }}
+    user = {{ .Values.endpoints.identity.auth.glance.project_name }}:{{ .Values.endpoints.identity.auth.glance.username }}
+    key = {{ .Values.endpoints.identity.auth.glance.password }}
+    user_domain_name = {{ .Values.endpoints.identity.auth.glance.user_domain_name }}
+    project_domain_name = {{ .Values.endpoints.identity.auth.glance.project_domain_name }}
     {{- else }}
     user = {{ .Values.endpoints.identity.auth.glance.project_name }}:{{ .Values.endpoints.identity.auth.glance.username }}
     key = {{ .Values.endpoints.identity.auth.glance.password }}

--- a/base-helm-configs/heat/heat-helm-overrides.yaml
+++ b/base-helm-configs/heat/heat-helm-overrides.yaml
@@ -74,7 +74,6 @@ conf:
       connection_debug: 0
       connection_recycle_time: 600
       connection_trace: true
-      idle_timeout: 3600
       mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60

--- a/base-helm-configs/ironic/ironic-helm-overrides.yaml
+++ b/base-helm-configs/ironic/ironic-helm-overrides.yaml
@@ -30,20 +30,20 @@ conf:
       default_deploy_interface: "direct"
       default_inspect_interface: "agent"
       default_network_interface: "flat"
-      enabled_hardware_types: "ilo,ipmi,redfish,idrac"
-      enabled_bios_interfaces: "ilo,no-bios,idrac-redfish,redfish"
-      enabled_boot_interfaces: "pxe,ipxe,redfish-virtual-media,redfish-https,ilo-virtual-media,ilo-pxe"
+      enabled_hardware_types: "ipmi,redfish,idrac"
+      enabled_bios_interfaces: "no-bios,idrac-redfish,redfish"
+      enabled_boot_interfaces: "pxe,ipxe,redfish-virtual-media,redfish-https"
       enabled_console_interfaces: "no-console"
       enabled_deploy_interfaces: "direct,ramdisk"
       enabled_firmware_interfaces: "redfish,no-firmware"
-      enabled_inspect_interfaces: "ilo,agent,no-inspect,inspector,idrac-redfish,redfish"
-      enabled_management_interfaces: "ilo,ipmitool,idrac-redfish,redfish"
+      enabled_inspect_interfaces: "agent,no-inspect,idrac-redfish,redfish"
+      enabled_management_interfaces: "ipmitool,idrac-redfish,redfish"
       enabled_network_interfaces: "flat,neutron,noop"
-      enabled_power_interfaces: "ilo,ipmitool,idrac-redfish,redfish"
+      enabled_power_interfaces: "ipmitool,idrac-redfish,redfish"
       enabled_raid_interfaces: "agent,idrac-redfish,redfish,no-raid"
       enabled_rescue_interfaces: "no-rescue,agent"
       enabled_storage_interfaces: "noop"
-      enabled_vendor_interfaces: "ipmitool,ilo,idrac-redfish,redfish,no-vendor"
+      enabled_vendor_interfaces: "ipmitool,idrac-redfish,redfish,no-vendor"
     conductor:
       sync_power_state_interval: "60"
       automated_clean: "False"
@@ -82,9 +82,6 @@ conf:
       uefi_pxe_bootfile_name: "ipxe.efi"
       ipxe_enabled: true
       # image_cache_size: "21474836480"
-    ilo:
-      use_web_server_for_images: "True"
-      kernel_append_params: "nofb nomodeset vga=normal ipa-debug=1"
     redfish:
       use_swift: false
       kernel_append_params: "nofb nomodeset vga=normal ipa-debug=1"
@@ -92,7 +89,6 @@ conf:
       connection_debug: 0
       connection_recycle_time: 600
       connection_trace: true
-      idle_timeout: 3600
       mysql_sql_mode: ""
       use_db_reconnect: true
       pool_timeout: 60

--- a/base-helm-configs/keystone/keystone-helm-overrides.yaml
+++ b/base-helm-configs/keystone/keystone-helm-overrides.yaml
@@ -72,7 +72,6 @@ conf:
       connection_debug: 0
       connection_recycle_time: 600
       connection_trace: true
-      idle_timeout: 3600
       mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60

--- a/base-helm-configs/magnum/magnum-helm-overrides.yaml
+++ b/base-helm-configs/magnum/magnum-helm-overrides.yaml
@@ -70,7 +70,6 @@ conf:
       connection_debug: 0
       connection_recycle_time: 600
       connection_trace: true
-      idle_timeout: 3600
       mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60

--- a/base-helm-configs/masakari/masakari-helm-overrides.yaml
+++ b/base-helm-configs/masakari/masakari-helm-overrides.yaml
@@ -162,7 +162,6 @@ conf:
       connection_debug: 0
       connection_recycle_time: 600
       connection_trace: true
-      idle_timeout: 3600
       mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60

--- a/base-helm-configs/neutron/neutron-helm-overrides.yaml
+++ b/base-helm-configs/neutron/neutron-helm-overrides.yaml
@@ -214,7 +214,6 @@ conf:
       connection_debug: 0
       connection_recycle_time: 600
       connection_trace: true
-      idle_timeout: 3600
       mysql_sql_mode: {}
       use_db_reconnect: true
       max_pool_size: 30
@@ -241,7 +240,6 @@ conf:
       dns_servers: "8.8.8.8,1.1.1.1"
       enable_distributed_floating_ip: true
       neutron_sync_mode: "off"
-      ovn_l3_mode: "true"
       ovn_l3_scheduler: leastloaded
       ovn_nb_connection: "tcp:127.0.0.1:6641"
       ovn_sb_connection: "tcp:127.0.0.1:6642"
@@ -294,14 +292,13 @@ conf:
       ml2:
         extension_drivers: "port_security,qos,fwaas_v2"
         mechanism_drivers: ovn
-        tenant_network_types: geneve
+        project_network_types: geneve
         type_drivers: "flat,vlan,geneve"
       ml2_type_vlan:
         network_vlan_ranges: physnet1
       ovn:
         dns_servers: "8.8.8.8,1.1.1.1"
         neutron_sync_mode: "off"
-        ovn_l3_mode: "true"
         ovn_l3_scheduler: leastloaded
         ovn_metadata_enabled: true
         ovn_nb_connection: "tcp:127.0.0.1:6641"

--- a/base-helm-configs/nova/nova-helm-overrides.yaml
+++ b/base-helm-configs/nova/nova-helm-overrides.yaml
@@ -112,8 +112,9 @@ conf:
       use_rootwrap_daemon: true
       vif_plugging_is_fatal: true
       vif_plugging_timeout: 300
-      cross_az_attach: true
       network_allocate_retries: 3
+    cinder:
+      cross_az_attach: true
     cache:
       enabled: true
       backend: oslo_cache.memcache_pool
@@ -125,7 +126,6 @@ conf:
       connection_debug: 0
       connection_recycle_time: 600
       connection_trace: true
-      idle_timeout: 3600
       mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60
@@ -134,7 +134,6 @@ conf:
       connection_debug: 0
       connection_recycle_time: 600
       connection_trace: true
-      idle_timeout: 3600
       mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60
@@ -147,7 +146,6 @@ conf:
       connection_debug: 0
       connection_recycle_time: 600
       connection_trace: true
-      idle_timeout: 3600
       mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60

--- a/base-helm-configs/octavia/octavia-helm-overrides.yaml
+++ b/base-helm-configs/octavia/octavia-helm-overrides.yaml
@@ -99,7 +99,6 @@ conf:
       connection_debug: 0
       connection_recycle_time: 600
       connection_trace: true
-      idle_timeout: 3600
       mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60

--- a/base-helm-configs/placement/placement-helm-overrides.yaml
+++ b/base-helm-configs/placement/placement-helm-overrides.yaml
@@ -60,7 +60,6 @@ conf:
       connection_debug: 0
       connection_recycle_time: 600
       connection_trace: true
-      idle_timeout: 3600
       mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60

--- a/base-helm-configs/trove/trove-helm-overrides.yaml
+++ b/base-helm-configs/trove/trove-helm-overrides.yaml
@@ -125,7 +125,6 @@ conf:
       connection_debug: 0
       connection_recycle_time: 600
       connection_trace: true
-      idle_timeout: 3600
       mysql_sql_mode: {}
       use_db_reconnect: true
       pool_timeout: 60


### PR DESCRIPTION
Remove helm overrides that are unused or deprecated in 2026.1: Glance eventlet workers and legacy glance_store swift_auth_* keys, Ironic iLO/inspector interfaces, Neutron ovn_l3_mode, rename tenant_network_types to project_network_types, move Nova cross_az_attach under [cinder], and drop oslo.db idle_timeout in favor of connection_recycle_time.