### PR TITLE
feat(barbican): OSPC-2370: Added SoftHSM2 ConfigMap mount and fix PKCS#11 p11_crypto_plugin configuration

### DIFF
--- a/base-helm-configs/barbican/barbican-helm-overrides.yaml
+++ b/base-helm-configs/barbican/barbican-helm-overrides.yaml
@@ -103,7 +103,6 @@ conf:
       hmac_key_type: CKK_AES
       hmac_keygen_mechanism: CKM_AES_KEY_GEN
       key_wrap_mechanism: CKM_AES_CBC_PAD
-      slot_id: 1
       plugin_name: "PKCS11 HSM"
 
     crypto:

--- a/base-kustomize/barbican/base/barbican-softhsm-config.yaml
+++ b/base-kustomize/barbican/base/barbican-softhsm-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: barbican-softhsm-config
+  namespace: openstack
+data:
+  softhsm2.conf: |
+    # SoftHSM v2 configuration file
+    directories.tokendir = /var/lib/softhsm/tokens
+    objectstore.backend = file
+    log.level = INFO

--- a/base-kustomize/barbican/base/barbican-softhsm-tokens-pvc.yaml
+++ b/base-kustomize/barbican/base/barbican-softhsm-tokens-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: barbican-softhsm-tokens
+  namespace: openstack
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Mi

--- a/base-kustomize/barbican/base/kustomization.yaml
+++ b/base-kustomize/barbican/base/kustomization.yaml
@@ -4,6 +4,8 @@ sortOptions:
 resources:
   - barbican-mariadb-database.yaml
   - barbican-rabbitmq-queue.yaml
+  - barbican-softhsm-config.yaml
+  - barbican-softhsm-tokens-pvc.yaml
   - all.yaml
   - hpa-barbican-api.yaml
   - policies.yaml

--- a/bin/create-secrets.sh
+++ b/bin/create-secrets.sh
@@ -94,10 +94,8 @@ octavia_heartbeat_key=$(generate_password 64)
 barbican_rabbitmq_password=$(generate_password 64)
 barbican_db_password=$(generate_password 32)
 barbican_admin_password=$(generate_password 32)
-# PKCS#11 HSM PIN
-# Hyperconverged lab: auto-generated when BARBICAN_HSM_PIN is not set.
-# Production/Staging: export BARBICAN_HSM_PIN="<pin-from-hsm-admin>" before running.
-barbican_hsm_pin="${BARBICAN_HSM_PIN:-$(generate_password 32)}"
+# PKCS#11 SoftHSM2 PIN auto-generated.
+barbican_hsm_pin=$(generate_password 32)
 magnum_rabbitmq_password=$(generate_password 64)
 magnum_db_password=$(generate_password 32)
 magnum_admin_password=$(generate_password 32)

--- a/bin/install-barbican.sh
+++ b/bin/install-barbican.sh
@@ -138,14 +138,14 @@ set_args=(
     --set "conf.barbican.keystone_authtoken.memcache_secret_key=$(kubectl --namespace openstack get secret os-memcached -o jsonpath='{.data.memcache_secret_key}' | base64 -d)"
 )
 
-# Detects if missing PKCS#11 HSM p11_crypto_plugin and regenerates the file automatically.
+# Detects if missing PKCS#11 SoftHSM2 configuration and regenerates the file automatically.
 if [[ "${BARBICAN_HSM_ENABLED:-false}" == "true" ]] || [[ "${HYPERCONVERGED_BARBICAN_HSM:-false}" == "true" ]]; then
 
     override_file="${SERVICE_CUSTOM_OVERRIDES}/barbican-helm-overrides.yaml"
 
-    # If override file is missing OR does not contain p11_crypto_plugin, regenerate it
-    if [[ ! -f "${override_file}" ]] || ! grep -q "p11_crypto_plugin" "${override_file}" 2>/dev/null; then
-        echo "HSM enabled but p11_crypto_plugin missing in ${override_file}. Regenerating..."
+    # If override file is missing OR does not contain p11_crypto_plugin/softhsm-config, regenerate it
+    if [[ ! -f "${override_file}" ]] || ! grep -q "p11_crypto_plugin" "${override_file}" 2>/dev/null || ! grep -q "softhsm-config" "${override_file}" 2>/dev/null; then
+        echo "HSM enabled but p11_crypto_plugin/softhsm-config missing in ${override_file}. Regenerating..."
         rm -f "${override_file}"
         SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
         source "${SCRIPT_DIR}/../scripts/lib/hyperconverged-common.sh"
@@ -153,7 +153,7 @@ if [[ "${BARBICAN_HSM_ENABLED:-false}" == "true" ]] || [[ "${HYPERCONVERGED_BARB
     fi
 fi
 
-# PKCS#11 HSM PIN Injection
+# PKCS#11 SoftHSM2 PIN Injection
 # Reads PIN from barbican-hsm-credentials K8s Secret (created by create-secrets.sh).
 # No-op when secret doesn't exist or PIN is empty.
 hsm_pin="$(kubectl --namespace openstack get secret barbican-hsm-credentials \
@@ -190,10 +190,10 @@ echo
 # Execute the command directly from the array
 "${helm_command[@]}"
 
-# Post-Install HSM Key Initialization
-# Runs ONLY in Hyperconverged lab when:
-#   1. BARBICAN_HSM_ENABLED=true (exported during automated hyperconverged lab run)
-#   2. HYPERCONVERGED_BARBICAN_HSM=true (set manually when running script directly)
+# Post-Install SoftHSM2 Key Initialization
+# Runs ONLY when:
+#   1. BARBICAN_HSM_ENABLED=true (exported during automated hyperconverged lab run with "-i barbican-hsm")
+#   2. HYPERCONVERGED_BARBICAN_HSM=true (set manually when running install-barbican.sh script directly)
 if [[ "${BARBICAN_HSM_ENABLED:-false}" == "true" ]] || [[ "${HYPERCONVERGED_BARBICAN_HSM:-false}" == "true" ]]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/scripts/lib/hyperconverged-common.sh
+++ b/scripts/lib/hyperconverged-common.sh
@@ -817,6 +817,11 @@ EOF
             cat > "${config_base}/barbican/barbican-helm-overrides.yaml" <<EOF
 ---
 pod:
+  security_context:
+    barbican_api:
+      pod:
+        runAsUser: 42424
+        fsGroup: 42424
   resources:
     enabled: false
 
@@ -826,10 +831,16 @@ pod:
         volumeMounts:
           - name: softhsm-tokens
             mountPath: /var/lib/softhsm/tokens
+          - name: softhsm-config
+            mountPath: /etc/softhsm/softhsm2.conf
+            subPath: softhsm2.conf
         volumes:
           - name: softhsm-tokens
             persistentVolumeClaim:
               claimName: barbican-softhsm-tokens
+          - name: softhsm-config
+            configMap:
+              name: barbican-softhsm-config
 
 conf:
   barbican_api_uwsgi:
@@ -838,15 +849,35 @@ conf:
   barbican:
     oslo_messaging_notifications:
       driver: noop
-    p11_crypto_plugin:
-      library_path: "/usr/lib/softhsm/libsofthsm2.so"
-      token_labels:
-        - "barbican_token"
-      slot_id: 1
+    secretstore:
+      enabled_secretstore_plugins:
+        - store_crypto
     crypto:
       enabled_crypto_plugins:
         - p11_crypto
         - simple_crypto
+    p11_crypto_plugin:
+      library_path: "/usr/lib/softhsm/libsofthsm2.so"
+      token_labels:
+        - "barbican_token"
+      mkek_label: "barbican_mkek"
+      mkek_length: 32
+      hmac_label: "barbican_hmac"
+      rw_session: true
+EOF
+            # Create ConfigMap for softhsm2.conf
+            kubectl apply --namespace openstack -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: barbican-softhsm-config
+  namespace: openstack
+data:
+  softhsm2.conf: |
+    # SoftHSM v2 configuration file
+    directories.tokendir = /var/lib/softhsm/tokens
+    objectstore.backend = file
+    log.level = INFO
 EOF
             # Create PVC for SoftHSM2 token persistence
             kubectl apply --namespace openstack -f - <<EOF
@@ -857,7 +888,7 @@ metadata:
   namespace: openstack
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: 100Mi
@@ -1590,15 +1621,15 @@ EOF
 function initBarbicanHSMKeys() {
     # Initializes SoftHSM2 token + generates MKEK/HMAC keys inside barbican pod.
     # Idempotent — skips if token/keys already exist.
-    # Called only when BARBICAN_HSM_ENABLED=true or HYPERCONVERGED_BARBICAN_HSM = true (hyperconverged lab).
+    # Called only when BARBICAN_HSM_ENABLED=true or HYPERCONVERGED_BARBICAN_HSM=true.
 
     if [[ "${BARBICAN_HSM_ENABLED:-false}" != "true" ]] && [[ "${HYPERCONVERGED_BARBICAN_HSM:-false}" != "true" ]]; then
         return 0
     fi
 
-    echo "=== Barbican HSM Key Initialization ==="
+    echo "=== Barbican SoftHSM2 Key Initialization ==="
 
-    local hsm_pin token_label library_path slot_id mkek_label hmac_label pod
+    local hsm_pin token_label library_path mkek_label hmac_label pod
 
     hsm_pin="$(kubectl --namespace openstack get secret barbican-hsm-credentials \
         -o jsonpath='{.data.pin}' 2>/dev/null | base64 -d)" || true
@@ -1609,7 +1640,6 @@ function initBarbicanHSMKeys() {
 
     library_path="/usr/lib/softhsm/libsofthsm2.so"
     token_label="barbican_token"
-    slot_id="1"
     mkek_label="barbican_mkek"
     hmac_label="barbican_hmac"
 
@@ -1642,7 +1672,6 @@ function initBarbicanHSMKeys() {
         barbican-manage hsm check_mkek \
             --library-path "${library_path}" \
             --passphrase "${hsm_pin}" \
-            --slot-id "${slot_id}" \
             --label "${mkek_label}" 2>/dev/null; then
         echo "MKEK exists — OK"
     else
@@ -1651,7 +1680,6 @@ function initBarbicanHSMKeys() {
             barbican-manage hsm gen_mkek \
                 --library-path "${library_path}" \
                 --passphrase "${hsm_pin}" \
-                --slot-id "${slot_id}" \
                 --label "${mkek_label}" \
                 --length 32
     fi
@@ -1662,7 +1690,6 @@ function initBarbicanHSMKeys() {
         barbican-manage hsm check_hmac \
             --library-path "${library_path}" \
             --passphrase "${hsm_pin}" \
-            --slot-id "${slot_id}" \
             --label "${hmac_label}" \
             --key-type CKK_AES 2>/dev/null; then
         echo "HMAC key exists — OK"
@@ -1672,14 +1699,13 @@ function initBarbicanHSMKeys() {
             barbican-manage hsm gen_hmac \
                 --library-path "${library_path}" \
                 --passphrase "${hsm_pin}" \
-                --slot-id "${slot_id}" \
                 --label "${hmac_label}" \
                 --key-type CKK_AES \
                 --length 32 \
                 --mechanism CKM_AES_KEY_GEN
     fi
 
-    echo "=== HSM initialization complete ==="
+    echo "=== SoftHSM2 initialization complete ==="
 }
 
 function createPostSetupResources() {


### PR DESCRIPTION
Mount `softhsm2.conf` ConfigMap into `barbican-api` pods, add `fsGroup` security context for token store access, fix PVC `accessMode` to `ReadWriteMany` for multi-replica support, and remove hardcoded `slot_id` in favour of dynamic token-label resolution across all HSM-enabled code paths.

- `base-kustomize/barbican/base/barbican-softhsm-config.yaml`
  This creates a Kubernetes ConfigMap named `barbican-softhsm-config` in the openstack namespace containing the SoftHSM2 configuration file (`softhsm2.conf`).
  This ConfigMap is then mounted as a file inside the barbican-api pod at `/etc/softhsm/softhsm2.conf` (via subPath: `softhsm2.conf`), so SoftHSM2 running inside the pod reads its configuration from it.

- `base-kustomize/barbican/base/barbican-softhsm-tokens-pvc.yaml`
  This creates a Kubernetes PersistentVolumeClaim (PVC) named `barbican-softhsm-tokens` in the openstack namespace.
  It provides persistent storage for the SoftHSM2 token directory (`/var/lib/softhsm/tokens`) mounted inside barbican-api pods.

- `base-kustomize/barbican/base/kustomization.yaml`
  Add `barbican-softhsm-config.yaml` and `barbican-softhsm-tokens-pvc.yaml` to the kustomize base resource list so ConfigMap and PVC are applied on every Barbican deployment.

- `base-helm-configs/barbican/barbican-helm-overrides.yaml`
  Remove hardcoded `slot_id: 1` from `p11_crypto_plugin`; SoftHSM2 resolves the PKCS#11 slot dynamically from token_labels.

- `bin/create-secrets.sh`
  Simplify SoftHSM2 PIN generation to always auto-generate; remove the `BARBICAN_HSM_PIN` env-var override path (not applicable for SoftHSM2).

- `bin/install-barbican.sh`
  Extend override file detection to check for softhsm-config presence alongside p11_crypto_plugin, triggering auto-regeneration when either is missing. Update comments to reference SoftHSM2 correctly.

- `scripts/lib/hyperconverged-common.sh`
  - Add pod security context (`runAsUser: 42424`, `fsGroup: 42424`) to generated `barbican-helm-overrides.yaml` for SoftHSM2 token store file access by the barbican process.
  - Add `softhsm-config` ConfigMap `volumeMount` at `/etc/softhsm/softhsm2.conf` (subPath: `softhsm2.conf`) alongside existing `softhsm-tokens` PVC mount.
  - Inline kubectl apply of `barbican-softhsm-config` ConfigMap during `writeServiceHelmOverrides` so ConfigMap exists before Helm deploys.
  - Fix PVC accessMode from `ReadWriteOnce` to `ReadWriteMany` for multi-replica `barbican-api` deployments.
  - Add `store_crypto` to `enabled_secretstore_plugins`; restructure conf block to correct OpenStack-Helm schema ordering.
  - Replace `slot_id` with `mkek_label`, `hmac_label`, and `rw_session` in `p11_crypto_plugin` config.
  - Remove `--slot-id` from all `barbican-manage hsm` subcommands (`check_mkek`, `gen_mkek`, `check_hmac`, `gen_hmac`); SoftHSM2 resolves slot dynamically from token label.
  - Update log messages to reference SoftHSM2 explicitly.
  
 Refs: [OSPC-1979](https://rackspace.atlassian.net/browse/OSPC-1979)