### PR TITLE
fix(barbican): OSPC-2375: Added simple_crypto KEK resolution for greenfield deployments

### DIFF
--- a/bin/create-secrets.sh
+++ b/bin/create-secrets.sh
@@ -96,6 +96,8 @@ barbican_db_password=$(generate_password 32)
 barbican_admin_password=$(generate_password 32)
 # PKCS#11 SoftHSM2 PIN auto-generated.
 barbican_hsm_pin=$(generate_password 32)
+# simple_crypto Fernet Master KEK (32-byte urlsafe base64 / 44 chars).
+barbican_simple_crypto_kek="$(python3 -c 'import secrets, base64; print(base64.urlsafe_b64encode(secrets.token_bytes(32)).decode())' 2>/dev/null || openssl rand -base64 32)"
 magnum_rabbitmq_password=$(generate_password 64)
 magnum_db_password=$(generate_password 32)
 magnum_admin_password=$(generate_password 32)
@@ -643,6 +645,15 @@ metadata:
 type: Opaque
 data:
   pin: $(echo -n $barbican_hsm_pin | base64 -w0)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: barbican-simple-crypto-kek
+  namespace: openstack
+type: Opaque
+data:
+  kek: $(echo -n $barbican_simple_crypto_kek | base64 -w0)
 ---
 apiVersion: v1
 kind: Secret

--- a/bin/install-barbican.sh
+++ b/bin/install-barbican.sh
@@ -167,7 +167,7 @@ fi
 unset hsm_pin
 
 # Programmatically Extract LEGACY_MASTER_KEK for simple_crypto Decryption
-# Only injects simple_crypto KEK if legacy encrypted secrets exist in MariaDB
+# Covers brownfield upgrades (Tier 1 & 2) and greenfield fresh install (Tier 3)
 LEGACY_MASTER_KEK=""
 
 # 1. Discover active primary MariaDB pod via Kubernetes labels
@@ -193,22 +193,19 @@ fi
 
 echo "Found ${SIMPLE_CRYPTO_SECRET_COUNT:-0} simple_crypto KEK record(s) in database."
 
-if [[ "${SIMPLE_CRYPTO_SECRET_COUNT:-0}" -gt 0 ]]; then
-    echo "Legacy simple_crypto secrets detected. Extracting Master KEK..."
+# TIER 1: Read kek from active barbican.conf in 'barbican-etc' Kubernetes Secret
+if [[ -z "${LEGACY_MASTER_KEK}" ]]; then
+    LEGACY_MASTER_KEK="$(kubectl --namespace "$SERVICE_NAMESPACE" get secret barbican-etc \
+        -o jsonpath='{.data.barbican\.conf}' 2>/dev/null | base64 -d | \
+        grep -E "^\s*kek\s*=" | head -n1 | cut -d'=' -f2 | tr -d ' ' || true)"
+    [[ -n "${LEGACY_MASTER_KEK}" ]] && echo "KEK found in barbican-etc secret."
+fi
 
-    # Tier 1: Read kek from active barbican.conf in 'barbican-etc' Kubernetes Secret
-    if [[ -z "${LEGACY_MASTER_KEK}" ]]; then
-        LEGACY_MASTER_KEK="$(kubectl --namespace "$SERVICE_NAMESPACE" get secret barbican-etc \
-            -o jsonpath='{.data.barbican\.conf}' 2>/dev/null | base64 -d | \
-            grep -E "^\s*kek\s*=" | head -n1 | cut -d'=' -f2 | tr -d ' ' || true)"
-        [[ -n "${LEGACY_MASTER_KEK}" ]] && echo "KEK found in barbican-etc secret."
-    fi
-
-    # Tier 2: Read simple_crypto_plugin.kek or simple_crypto_kek_rewrap.old_kek
-    #         from the deployed Helm release values
-    if [[ -z "${LEGACY_MASTER_KEK}" ]]; then
-        LEGACY_MASTER_KEK="$(helm get values "$SERVICE_NAME_DEFAULT" --namespace "$SERVICE_NAMESPACE" --all 2>/dev/null | \
-            python3 -c "
+# Tier 2: Read simple_crypto_plugin.kek or simple_crypto_kek_rewrap.old_kek
+#         from the deployed Helm release values
+if [[ -z "${LEGACY_MASTER_KEK}" ]]; then
+    LEGACY_MASTER_KEK="$(helm get values "$SERVICE_NAME_DEFAULT" --namespace "$SERVICE_NAMESPACE" --all 2>/dev/null | \
+        python3 -c "
 import sys, yaml
 try:
     d = yaml.safe_load(sys.stdin) or {}
@@ -225,22 +222,26 @@ try:
 except Exception:
     pass
 " 2>/dev/null || true)"
-        [[ -n "${LEGACY_MASTER_KEK}" ]] && echo "KEK found in deployed Helm release values."
-    fi
+    [[ -n "${LEGACY_MASTER_KEK}" ]] && echo "KEK found in deployed Helm release values."
+fi
 
-    # Inject the extracted KEK or fail fast
-    if [[ -n "${LEGACY_MASTER_KEK}" ]]; then
-        echo "Injecting Legacy Master KEK into Barbican configuration..."
-        set_args+=(
-            --set "conf.barbican.simple_crypto_plugin.kek=${LEGACY_MASTER_KEK}"
-        )
-    else
-        echo "ERROR: Legacy simple_crypto secrets exist in DB but no KEK could be extracted!"
-        echo "       Manual intervention required before upgrading Barbican."
-        exit 1
-    fi
-else
-    echo "No legacy simple_crypto secrets found. Skipping KEK injection (p11_crypto-only cluster)."
+# TIER 3: Greenfield / Fresh Lab - Read from barbican-simple-crypto-kek Secret
+if [[ -z "${LEGACY_MASTER_KEK}" ]]; then
+    LEGACY_MASTER_KEK="$(kubectl --namespace "$SERVICE_NAMESPACE" get secret barbican-simple-crypto-kek \
+        -o jsonpath='{.data.kek}' 2>/dev/null | base64 -d || true)"
+    [[ -n "${LEGACY_MASTER_KEK}" ]] && echo "KEK found in barbican-simple-crypto-kek secret (fresh install)."
+fi
+
+# Inject the resolved KEK or fail fast if brownfield has secrets in DB but no KEK found
+if [[ -n "${LEGACY_MASTER_KEK}" ]]; then
+    echo "Injecting simple_crypto Master KEK into Barbican configuration..."
+    set_args+=(
+        --set "conf.barbican.simple_crypto_plugin.kek=${LEGACY_MASTER_KEK}"
+    )
+elif [[ "${SIMPLE_CRYPTO_SECRET_COUNT:-0}" -gt 0 ]]; then
+    echo "ERROR: Legacy simple_crypto secrets exist in DB but no KEK could be extracted!"
+    echo "       Manual intervention required before upgrading Barbican."
+    exit 1
 fi
 
 helm_command=(


### PR DESCRIPTION
The solution now correctly support both brownfield upgrades and greenfield/fresh deployments in Barbican Gazpacho by ensuring a valid `simple_crypto` Master KEK is always resolvable, persisted, and injected without manual operator intervention.

- `bin/create-secrets.sh`:
  Generate a 32-byte urlsafe base64 (44-character) Fernet Master KEK and persist it in the `barbican-simple-crypto-kek` Kubernetes Secret at cluster bootstrap.

- `bin/install-barbican.sh`:
  Implement a 3-tier KEK resolution fallback:
  * Tier 1 (Brownfield): Extract active KEK from barbican.conf in the `barbican-etc` secret.
  * Tier 2 (Brownfield): Extract KEK from deployed Helm release values (handling override-based configurations not yet rendered into `barbican-etc`).
  * Tier 3 (Greenfield): Extract KEK from the `barbican-simple-crypto-kek` secret created by `create-secrets.sh`.

- Injection & Fail-Fast Protection:
  * Inject the resolved KEK via `--set conf.barbican.simple_crypto_plugin.kek`.
  * Maintain fail-fast protection (exit 1) if MariaDB contains legacy `simple_crypto` records but no KEK can be resolved from any tier.
  * Prevent Gazpacho pod crashloops (`ValueError: SimpleCrypto KEK is undefined`) and encrypted volume/database creation failures across both fresh installs and upgrades.